### PR TITLE
fix: Do not delete ConnMetadata store with SELECT or EXAMINE

### DIFF
--- a/internal/backend/mailbox.go
+++ b/internal/backend/mailbox.go
@@ -280,5 +280,9 @@ func (m *Mailbox) Flush(ctx context.Context, permitExpunge bool) ([]response.Res
 }
 
 func (m *Mailbox) Close(ctx context.Context) error {
+	if err := m.state.deleteConnMetadata(); err != nil {
+		return err
+	}
+
 	return m.state.close(ctx, m.tx)
 }

--- a/internal/backend/state.go
+++ b/internal/backend/state.go
@@ -466,15 +466,19 @@ func (state *State) updateMessageID(oldID, newID string) error {
 	return nil
 }
 
+func (state *State) deleteConnMetadata() error {
+	if err := state.remote.DeleteConnMetadataStore(state.metadataID); err != nil {
+		return fmt.Errorf("failed to delete conn metadata store: %w", err)
+	}
+
+	return nil
+}
+
 func (state *State) close(ctx context.Context, tx *ent.Tx) error {
 	if state.snap != nil && state.pool.hasSnap(state.snap) {
 		if err := state.pool.expungeSnap(ctx, tx, state.snap); err != nil {
 			return err
 		}
-	}
-
-	if err := state.remote.DeleteConnMetadataStore(state.metadataID); err != nil {
-		return fmt.Errorf("failed to delete conn metadata store: %w", err)
 	}
 
 	state.snap = nil

--- a/internal/backend/user_state.go
+++ b/internal/backend/user_state.go
@@ -31,6 +31,10 @@ func (user *user) closeState(ctx context.Context, state *State) error {
 		user.statesLock.Lock()
 		defer user.statesLock.Unlock()
 
+		if err := state.deleteConnMetadata(); err != nil {
+			return err
+		}
+
 		if err := state.close(ctx, tx); err != nil {
 			return fmt.Errorf("failed to close state: %w", err)
 		}
@@ -47,6 +51,10 @@ func (user *user) closeStates(ctx context.Context) error {
 		defer user.statesLock.Unlock()
 
 		for stateID, state := range user.states {
+			if err := state.deleteConnMetadata(); err != nil {
+				return err
+			}
+
 			if err := state.close(ctx, tx); err != nil {
 				return fmt.Errorf("failed to close state: %w", err)
 			}


### PR DESCRIPTION
This patch adds `State.cleanupConnMetadata()` to cleanup the metadata
rather than relying on `State.close()`. If present in the letter the
state is also cleaned up when the SELECT or EXAMINE commands are
executed, which is not what we want.