### PR TITLE
fix(GODT-1597): Handle permanently deleted messages

### DIFF
--- a/connector/dummy_simulate.go
+++ b/connector/dummy_simulate.go
@@ -134,6 +134,12 @@ func (conn *Dummy) MessageFlagged(messageID string, flagged bool) error {
 	return nil
 }
 
+func (conn *Dummy) MessageDeleted(messageID string) error {
+	conn.pushUpdate(imap.NewMessagesDeleted(messageID))
+
+	return nil
+}
+
 func (conn *Dummy) Flush() {
 	conn.ticker.Poll()
 }

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -18,16 +18,18 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	server, err := gluon.New(temp())
+
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create server")
 	}
 
-	if err := addUser(server, []string{"user1@example.com", "alias1@example.com"}, "password1"); err != nil {
+	if err := addUser(ctx, server, []string{"user1@example.com", "alias1@example.com"}, "password1"); err != nil {
 		logrus.WithError(err).Fatal("Failed to add user")
 	}
 
-	if err := addUser(server, []string{"user2@example.com", "alias2@example.com"}, "password2"); err != nil {
+	if err := addUser(ctx, server, []string{"user2@example.com", "alias2@example.com"}, "password2"); err != nil {
 		logrus.WithError(err).Fatal("Failed to add user")
 	}
 
@@ -38,12 +40,12 @@ func main() {
 
 	logrus.Infof("Server is listening on %v", listener.Addr())
 
-	for err := range server.Serve(context.Background(), listener) {
+	for err := range server.Serve(ctx, listener) {
 		logrus.WithError(err).Error("Error while serving")
 	}
 }
 
-func addUser(server *gluon.Server, addresses []string, password string) error {
+func addUser(ctx context.Context, server *gluon.Server, addresses []string, password string) error {
 	connector := connector.NewDummy(
 		addresses,
 		password,
@@ -59,6 +61,7 @@ func addUser(server *gluon.Server, addresses []string, password string) error {
 	}
 
 	userID, err := server.AddUser(
+		ctx,
 		connector,
 		store,
 		dialect.SQLite,

--- a/imap/update_message_deleted.go
+++ b/imap/update_message_deleted.go
@@ -1,0 +1,26 @@
+package imap
+
+import (
+	"fmt"
+
+	"github.com/ProtonMail/gluon/internal/utils"
+)
+
+type MessageDeleted struct {
+	*updateWaiter
+
+	MessageID string
+}
+
+func NewMessagesDeleted(messageID string) *MessageDeleted {
+	return &MessageDeleted{
+		updateWaiter: newUpdateWaiter(),
+		MessageID:    messageID,
+	}
+}
+
+func (u *MessageDeleted) String() string {
+	return fmt.Sprintf("MessageDeleted ID=%v", utils.ShortID(u.MessageID))
+}
+
+func (u *MessageDeleted) _isUpdate() {}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -42,7 +42,7 @@ func (b *Backend) SetDelimiter(delim string) {
 	b.delim = delim
 }
 
-func (b *Backend) AddUser(conn connector.Connector, store store.Store, client *ent.Client) (string, error) {
+func (b *Backend) AddUser(ctx context.Context, conn connector.Connector, store store.Store, client *ent.Client) (string, error) {
 	b.usersLock.Lock()
 	defer b.usersLock.Unlock()
 
@@ -53,7 +53,7 @@ func (b *Backend) AddUser(conn connector.Connector, store store.Store, client *e
 		return "", err
 	}
 
-	user, err := newUser(userID, client, remote, store, b.delim)
+	user, err := newUser(ctx, userID, client, remote, store, b.delim)
 	if err != nil {
 		return "", err
 	}

--- a/internal/backend/ent/message.go
+++ b/internal/backend/ent/message.go
@@ -30,6 +30,8 @@ type Message struct {
 	BodyStructure string `json:"BodyStructure,omitempty"`
 	// Envelope holds the value of the "Envelope" field.
 	Envelope string `json:"Envelope,omitempty"`
+	// Deleted holds the value of the "Deleted" field.
+	Deleted bool `json:"Deleted,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the MessageQuery when eager-loading is set.
 	Edges MessageEdges `json:"edges"`
@@ -69,6 +71,8 @@ func (*Message) scanValues(columns []string) ([]interface{}, error) {
 	values := make([]interface{}, len(columns))
 	for i := range columns {
 		switch columns[i] {
+		case message.FieldDeleted:
+			values[i] = new(sql.NullBool)
 		case message.FieldID, message.FieldSize:
 			values[i] = new(sql.NullInt64)
 		case message.FieldMessageID, message.FieldInternalID, message.FieldBody, message.FieldBodyStructure, message.FieldEnvelope:
@@ -138,6 +142,12 @@ func (m *Message) assignValues(columns []string, values []interface{}) error {
 			} else if value.Valid {
 				m.Envelope = value.String
 			}
+		case message.FieldDeleted:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field Deleted", values[i])
+			} else if value.Valid {
+				m.Deleted = value.Bool
+			}
 		}
 	}
 	return nil
@@ -190,6 +200,8 @@ func (m *Message) String() string {
 	builder.WriteString(m.BodyStructure)
 	builder.WriteString(", Envelope=")
 	builder.WriteString(m.Envelope)
+	builder.WriteString(", Deleted=")
+	builder.WriteString(fmt.Sprintf("%v", m.Deleted))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/backend/ent/message/message.go
+++ b/internal/backend/ent/message/message.go
@@ -21,6 +21,8 @@ const (
 	FieldBodyStructure = "body_structure"
 	// FieldEnvelope holds the string denoting the envelope field in the database.
 	FieldEnvelope = "envelope"
+	// FieldDeleted holds the string denoting the deleted field in the database.
+	FieldDeleted = "deleted"
 	// EdgeFlags holds the string denoting the flags edge name in mutations.
 	EdgeFlags = "flags"
 	// EdgeUIDs holds the string denoting the uids edge name in mutations.
@@ -53,6 +55,7 @@ var Columns = []string{
 	FieldBody,
 	FieldBodyStructure,
 	FieldEnvelope,
+	FieldDeleted,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -64,3 +67,8 @@ func ValidColumn(column string) bool {
 	}
 	return false
 }
+
+var (
+	// DefaultDeleted holds the default value on creation for the "Deleted" field.
+	DefaultDeleted bool
+)

--- a/internal/backend/ent/message/where.go
+++ b/internal/backend/ent/message/where.go
@@ -142,6 +142,13 @@ func Envelope(v string) predicate.Message {
 	})
 }
 
+// Deleted applies equality check predicate on the "Deleted" field. It's identical to DeletedEQ.
+func Deleted(v bool) predicate.Message {
+	return predicate.Message(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldDeleted), v))
+	})
+}
+
 // MessageIDEQ applies the EQ predicate on the "MessageID" field.
 func MessageIDEQ(v string) predicate.Message {
 	return predicate.Message(func(s *sql.Selector) {
@@ -846,6 +853,20 @@ func EnvelopeEqualFold(v string) predicate.Message {
 func EnvelopeContainsFold(v string) predicate.Message {
 	return predicate.Message(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldEnvelope), v))
+	})
+}
+
+// DeletedEQ applies the EQ predicate on the "Deleted" field.
+func DeletedEQ(v bool) predicate.Message {
+	return predicate.Message(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldDeleted), v))
+	})
+}
+
+// DeletedNEQ applies the NEQ predicate on the "Deleted" field.
+func DeletedNEQ(v bool) predicate.Message {
+	return predicate.Message(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldDeleted), v))
 	})
 }
 

--- a/internal/backend/ent/message_create.go
+++ b/internal/backend/ent/message_create.go
@@ -64,6 +64,20 @@ func (mc *MessageCreate) SetEnvelope(s string) *MessageCreate {
 	return mc
 }
 
+// SetDeleted sets the "Deleted" field.
+func (mc *MessageCreate) SetDeleted(b bool) *MessageCreate {
+	mc.mutation.SetDeleted(b)
+	return mc
+}
+
+// SetNillableDeleted sets the "Deleted" field if the given value is not nil.
+func (mc *MessageCreate) SetNillableDeleted(b *bool) *MessageCreate {
+	if b != nil {
+		mc.SetDeleted(*b)
+	}
+	return mc
+}
+
 // AddFlagIDs adds the "flags" edge to the MessageFlag entity by IDs.
 func (mc *MessageCreate) AddFlagIDs(ids ...int) *MessageCreate {
 	mc.mutation.AddFlagIDs(ids...)
@@ -105,6 +119,7 @@ func (mc *MessageCreate) Save(ctx context.Context) (*Message, error) {
 		err  error
 		node *Message
 	)
+	mc.defaults()
 	if len(mc.hooks) == 0 {
 		if err = mc.check(); err != nil {
 			return nil, err
@@ -162,6 +177,14 @@ func (mc *MessageCreate) ExecX(ctx context.Context) {
 	}
 }
 
+// defaults sets the default values of the builder before save.
+func (mc *MessageCreate) defaults() {
+	if _, ok := mc.mutation.Deleted(); !ok {
+		v := message.DefaultDeleted
+		mc.mutation.SetDeleted(v)
+	}
+}
+
 // check runs all checks and user-defined validators on the builder.
 func (mc *MessageCreate) check() error {
 	if _, ok := mc.mutation.MessageID(); !ok {
@@ -184,6 +207,9 @@ func (mc *MessageCreate) check() error {
 	}
 	if _, ok := mc.mutation.Envelope(); !ok {
 		return &ValidationError{Name: "Envelope", err: errors.New(`ent: missing required field "Message.Envelope"`)}
+	}
+	if _, ok := mc.mutation.Deleted(); !ok {
+		return &ValidationError{Name: "Deleted", err: errors.New(`ent: missing required field "Message.Deleted"`)}
 	}
 	return nil
 }
@@ -268,6 +294,14 @@ func (mc *MessageCreate) createSpec() (*Message, *sqlgraph.CreateSpec) {
 		})
 		_node.Envelope = value
 	}
+	if value, ok := mc.mutation.Deleted(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: message.FieldDeleted,
+		})
+		_node.Deleted = value
+	}
 	if nodes := mc.mutation.FlagsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -323,6 +357,7 @@ func (mcb *MessageCreateBulk) Save(ctx context.Context) ([]*Message, error) {
 	for i := range mcb.builders {
 		func(i int, root context.Context) {
 			builder := mcb.builders[i]
+			builder.defaults()
 			var mut Mutator = MutateFunc(func(ctx context.Context, m Mutation) (Value, error) {
 				mutation, ok := m.(*MessageMutation)
 				if !ok {

--- a/internal/backend/ent/message_update.go
+++ b/internal/backend/ent/message_update.go
@@ -79,6 +79,20 @@ func (mu *MessageUpdate) SetEnvelope(s string) *MessageUpdate {
 	return mu
 }
 
+// SetDeleted sets the "Deleted" field.
+func (mu *MessageUpdate) SetDeleted(b bool) *MessageUpdate {
+	mu.mutation.SetDeleted(b)
+	return mu
+}
+
+// SetNillableDeleted sets the "Deleted" field if the given value is not nil.
+func (mu *MessageUpdate) SetNillableDeleted(b *bool) *MessageUpdate {
+	if b != nil {
+		mu.SetDeleted(*b)
+	}
+	return mu
+}
+
 // AddFlagIDs adds the "flags" edge to the MessageFlag entity by IDs.
 func (mu *MessageUpdate) AddFlagIDs(ids ...int) *MessageUpdate {
 	mu.mutation.AddFlagIDs(ids...)
@@ -284,6 +298,13 @@ func (mu *MessageUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: message.FieldEnvelope,
 		})
 	}
+	if value, ok := mu.mutation.Deleted(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: message.FieldDeleted,
+		})
+	}
 	if mu.mutation.FlagsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -457,6 +478,20 @@ func (muo *MessageUpdateOne) SetBodyStructure(s string) *MessageUpdateOne {
 // SetEnvelope sets the "Envelope" field.
 func (muo *MessageUpdateOne) SetEnvelope(s string) *MessageUpdateOne {
 	muo.mutation.SetEnvelope(s)
+	return muo
+}
+
+// SetDeleted sets the "Deleted" field.
+func (muo *MessageUpdateOne) SetDeleted(b bool) *MessageUpdateOne {
+	muo.mutation.SetDeleted(b)
+	return muo
+}
+
+// SetNillableDeleted sets the "Deleted" field if the given value is not nil.
+func (muo *MessageUpdateOne) SetNillableDeleted(b *bool) *MessageUpdateOne {
+	if b != nil {
+		muo.SetDeleted(*b)
+	}
 	return muo
 }
 
@@ -687,6 +722,13 @@ func (muo *MessageUpdateOne) sqlSave(ctx context.Context) (_node *Message, err e
 			Type:   field.TypeString,
 			Value:  value,
 			Column: message.FieldEnvelope,
+		})
+	}
+	if value, ok := muo.mutation.Deleted(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: message.FieldDeleted,
 		})
 	}
 	if muo.mutation.FlagsCleared() {

--- a/internal/backend/ent/migrate/schema.go
+++ b/internal/backend/ent/migrate/schema.go
@@ -93,6 +93,7 @@ var (
 		{Name: "body", Type: field.TypeString},
 		{Name: "body_structure", Type: field.TypeString},
 		{Name: "envelope", Type: field.TypeString},
+		{Name: "deleted", Type: field.TypeBool, Default: false},
 	}
 	// MessagesTable holds the schema information for the "messages" table.
 	MessagesTable = &schema.Table{

--- a/internal/backend/ent/mutation.go
+++ b/internal/backend/ent/mutation.go
@@ -1924,6 +1924,7 @@ type MessageMutation struct {
 	_Body          *string
 	_BodyStructure *string
 	_Envelope      *string
+	_Deleted       *bool
 	clearedFields  map[string]struct{}
 	flags          map[int]struct{}
 	removedflags   map[int]struct{}
@@ -2306,6 +2307,42 @@ func (m *MessageMutation) ResetEnvelope() {
 	m._Envelope = nil
 }
 
+// SetDeleted sets the "Deleted" field.
+func (m *MessageMutation) SetDeleted(b bool) {
+	m._Deleted = &b
+}
+
+// Deleted returns the value of the "Deleted" field in the mutation.
+func (m *MessageMutation) Deleted() (r bool, exists bool) {
+	v := m._Deleted
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeleted returns the old "Deleted" field's value of the Message entity.
+// If the Message object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *MessageMutation) OldDeleted(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeleted is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeleted requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeleted: %w", err)
+	}
+	return oldValue.Deleted, nil
+}
+
+// ResetDeleted resets all changes to the "Deleted" field.
+func (m *MessageMutation) ResetDeleted() {
+	m._Deleted = nil
+}
+
 // AddFlagIDs adds the "flags" edge to the MessageFlag entity by ids.
 func (m *MessageMutation) AddFlagIDs(ids ...int) {
 	if m.flags == nil {
@@ -2433,7 +2470,7 @@ func (m *MessageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MessageMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 8)
 	if m._MessageID != nil {
 		fields = append(fields, message.FieldMessageID)
 	}
@@ -2454,6 +2491,9 @@ func (m *MessageMutation) Fields() []string {
 	}
 	if m._Envelope != nil {
 		fields = append(fields, message.FieldEnvelope)
+	}
+	if m._Deleted != nil {
+		fields = append(fields, message.FieldDeleted)
 	}
 	return fields
 }
@@ -2477,6 +2517,8 @@ func (m *MessageMutation) Field(name string) (ent.Value, bool) {
 		return m.BodyStructure()
 	case message.FieldEnvelope:
 		return m.Envelope()
+	case message.FieldDeleted:
+		return m.Deleted()
 	}
 	return nil, false
 }
@@ -2500,6 +2542,8 @@ func (m *MessageMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldBodyStructure(ctx)
 	case message.FieldEnvelope:
 		return m.OldEnvelope(ctx)
+	case message.FieldDeleted:
+		return m.OldDeleted(ctx)
 	}
 	return nil, fmt.Errorf("unknown Message field %s", name)
 }
@@ -2557,6 +2601,13 @@ func (m *MessageMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetEnvelope(v)
+		return nil
+	case message.FieldDeleted:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeleted(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Message field %s", name)
@@ -2642,6 +2693,9 @@ func (m *MessageMutation) ResetField(name string) error {
 		return nil
 	case message.FieldEnvelope:
 		m.ResetEnvelope()
+		return nil
+	case message.FieldDeleted:
+		m.ResetDeleted()
 		return nil
 	}
 	return fmt.Errorf("unknown Message field %s", name)

--- a/internal/backend/ent/runtime.go
+++ b/internal/backend/ent/runtime.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"github.com/ProtonMail/gluon/internal/backend/ent/mailbox"
+	"github.com/ProtonMail/gluon/internal/backend/ent/message"
 	"github.com/ProtonMail/gluon/internal/backend/ent/schema"
 	"github.com/ProtonMail/gluon/internal/backend/ent/uid"
 )
@@ -26,6 +27,12 @@ func init() {
 	mailboxDescSubscribed := mailboxFields[4].Descriptor()
 	// mailbox.DefaultSubscribed holds the default value on creation for the Subscribed field.
 	mailbox.DefaultSubscribed = mailboxDescSubscribed.Default.(bool)
+	messageFields := schema.Message{}.Fields()
+	_ = messageFields
+	// messageDescDeleted is the schema descriptor for Deleted field.
+	messageDescDeleted := messageFields[7].Descriptor()
+	// message.DefaultDeleted holds the default value on creation for the Deleted field.
+	message.DefaultDeleted = messageDescDeleted.Default.(bool)
 	uidFields := schema.UID{}.Fields()
 	_ = uidFields
 	// uidDescDeleted is the schema descriptor for Deleted field.

--- a/internal/backend/ent/schema/message.go
+++ b/internal/backend/ent/schema/message.go
@@ -22,6 +22,7 @@ func (Message) Fields() []ent.Field {
 		field.String("Body"),
 		field.String("BodyStructure"),
 		field.String("Envelope"),
+		field.Bool("Deleted").Default(false),
 	}
 }
 

--- a/internal/backend/message_tx.go
+++ b/internal/backend/message_tx.go
@@ -359,3 +359,30 @@ func txUpdateMessageID(ctx context.Context, tx *ent.Tx, oldID, newID string) err
 
 	return nil
 }
+
+func txMarkMessageAsDeleted(ctx context.Context, tx *ent.Tx, messageID string) error {
+	if _, err := tx.Message.Update().Where(message.MessageID(messageID)).SetDeleted(true).Save(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txDeleteMessages(ctx context.Context, tx *ent.Tx, messageIDs ...string) error {
+	if _, err := tx.Message.Delete().Where(message.MessageIDIn(messageIDs...)).Exec(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func txGetMessageIDsMarkedDeleted(ctx context.Context, tx *ent.Tx) ([]string, error) {
+	messages, err := tx.Message.Query().Where(message.Deleted(true)).All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return xslices.Map(messages, func(t *ent.Message) string {
+		return t.MessageID
+	}), nil
+}

--- a/internal/backend/state.go
+++ b/internal/backend/state.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/backend/ent"
 	"github.com/ProtonMail/gluon/internal/backend/ent/mailbox"
@@ -487,6 +489,10 @@ func (state *State) deleteConnMetadata() error {
 }
 
 func (state *State) close(ctx context.Context, tx *ent.Tx) error {
+	if err := state.deleteUnusedMessagesMarkedDeleted(ctx, tx, state); err != nil {
+		logrus.WithError(err).Errorf("Failed to delete unused messages marked for delete")
+	}
+
 	state.snap = nil
 
 	state.res = nil

--- a/store/disk.go
+++ b/store/disk.go
@@ -109,3 +109,18 @@ func (c *onDiskStore) Update(oldID, newID string) error {
 		filepath.Join(c.path, hashString(newID)),
 	)
 }
+
+func (c *onDiskStore) Delete(ids ...string) error {
+	if c.sem != nil {
+		c.sem.Lock()
+		defer c.sem.Unlock()
+	}
+
+	for _, id := range ids {
+		if err := os.RemoveAll(filepath.Join(c.path, hashString(id))); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/store/memory.go
+++ b/store/memory.go
@@ -52,3 +52,14 @@ func (c *inMemoryStore) Update(oldID, newID string) error {
 
 	return nil
 }
+
+func (c *inMemoryStore) Delete(ids ...string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for _, id := range ids {
+		delete(c.data, id)
+	}
+
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -4,4 +4,5 @@ type Store interface {
 	Get(messageID string) ([]byte, error)
 	Set(messageID string, literal []byte) error
 	Update(oldID, newID string) error
+	Delete(messageID ...string) error
 }

--- a/tests/db_utils.go
+++ b/tests/db_utils.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+	"context"
+
+	"github.com/ProtonMail/gluon/internal/backend/ent"
+	"github.com/stretchr/testify/require"
+)
+
+func dbCheckUserMessageCount(s *testSession, user string, expectedCount int) {
+	err := s.withUserDB(user, func(ent *ent.Client, ctx context.Context) {
+		val, err := ent.Message.Query().Count(ctx)
+		require.NoError(s.tb, err)
+		require.Equal(s.tb, expectedCount, val)
+	})
+	require.NoError(s.tb, err)
+}

--- a/tests/event_waiter.go
+++ b/tests/event_waiter.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"sync"
+
+	"github.com/ProtonMail/gluon"
+	"github.com/ProtonMail/gluon/events"
+)
+
+type eventWaiter struct {
+	wg     sync.WaitGroup
+	ch     chan events.Event
+	server *gluon.Server
+}
+
+func newEventWaiter(server *gluon.Server) *eventWaiter {
+	return &eventWaiter{
+		wg:     sync.WaitGroup{},
+		ch:     server.AddWatcher(),
+		server: server,
+	}
+}
+
+func (e *eventWaiter) waitEndOfSession() {
+	e.wg.Add(1)
+
+	go func() {
+		for message := range e.ch {
+			switch message.(type) {
+			case events.EventSessionRemoved:
+				e.wg.Done()
+				return
+			}
+		}
+	}()
+
+	e.wg.Wait()
+}
+
+func (e *eventWaiter) close() {
+	e.server.RemoveWatcher(e.ch)
+}


### PR DESCRIPTION
This patch ensures that messages that have been marked as deleted by the
connector are evicted from the store and the user database. To do this,
the messages table has new field named `Deleted` which tracks whether
the connector has deleted this message.

On user creation we erase all messages from the database and the store
that are marked as such. On client logout we attempt to delete all
marked messages that are not in use by other sessions which share the
same user.

Finally this patch extends the store interface with `Delete()` and the
respective implementations for the on disk and memory storage.