### PR TITLE
fix(GODT-1621): Fix race condition with temporary IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/mattn/go-sqlite3 v1.14.10
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942
 	golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf
@@ -33,6 +32,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/zclconf/go-cty v1.8.0 // indirect

--- a/internal/backend/user_updates.go
+++ b/internal/backend/user_updates.go
@@ -110,6 +110,10 @@ func (user *user) applyMailboxIDChanged(ctx context.Context, tx *ent.Tx, update 
 		return err
 	}
 
+	if err := user.remote.FinishMailboxIDUpdate(update.OldID); err != nil {
+		logrus.WithError(err).Errorf("Call to FinishMailboxIDUpdate() failed")
+	}
+
 	return txUpdateMailboxID(ctx, tx, update.OldID, update.NewID)
 }
 
@@ -206,6 +210,10 @@ func (user *user) applyMessageIDChanged(ctx context.Context, tx *ent.Tx, update 
 		return state.updateMessageID(update.OldID, update.NewID)
 	}); err != nil {
 		return err
+	}
+
+	if err := user.remote.FinishMessageIDUpdate(update.OldID); err != nil {
+		logrus.WithError(err).Error("Call to FinishMessageIDUpdate() failed")
 	}
 
 	if err := user.store.Update(update.OldID, update.NewID); err != nil {

--- a/internal/remote/operation.go
+++ b/internal/remote/operation.go
@@ -21,14 +21,6 @@ func (c *OperationBase) getConnMetadataID() ConnMetadataID {
 	return c.MetadataID
 }
 
-type mailboxOperation interface {
-	setMailboxID(tempID, mailboxID string)
-}
-
-type messageOperation interface {
-	setMessageID(tempID, messageID string)
-}
-
 // saveOps serializes the operation queue to a binary format to be serialized to disk.
 func saveOps(ops []operation) ([]byte, error) {
 	buf := new(bytes.Buffer)

--- a/internal/remote/operation_mailbox_delete.go
+++ b/internal/remote/operation_mailbox_delete.go
@@ -15,10 +15,4 @@ func (op *OpMailboxDelete) merge(other operation) (operation, bool) {
 	return nil, false
 }
 
-func (op *OpMailboxDelete) setMailboxID(tempID, mailboxID string) {
-	if op.MBoxID == tempID {
-		op.MBoxID = mailboxID
-	}
-}
-
 func (OpMailboxDelete) _isOperation() {}

--- a/internal/remote/operation_mailbox_update.go
+++ b/internal/remote/operation_mailbox_update.go
@@ -16,10 +16,4 @@ func (op *OpMailboxUpdate) merge(other operation) (operation, bool) {
 	return nil, false
 }
 
-func (op *OpMailboxUpdate) setMailboxID(tempID, mailboxID string) {
-	if op.MBoxID == tempID {
-		op.MBoxID = mailboxID
-	}
-}
-
 func (OpMailboxUpdate) _isOperation() {}

--- a/internal/remote/operation_message_add.go
+++ b/internal/remote/operation_message_add.go
@@ -28,18 +28,4 @@ func (op *OpMessageAdd) merge(other operation) (operation, bool) {
 	}
 }
 
-func (op *OpMessageAdd) setMailboxID(tempID, mboxID string) {
-	if op.MBoxID == tempID {
-		op.MBoxID = mboxID
-	}
-}
-
-func (op *OpMessageAdd) setMessageID(tempID, messageID string) {
-	for idx := range op.MessageIDs {
-		if op.MessageIDs[idx] == tempID {
-			op.MessageIDs[idx] = messageID
-		}
-	}
-}
-
 func (OpMessageAdd) _isOperation() {}

--- a/internal/remote/operation_message_create.go
+++ b/internal/remote/operation_message_create.go
@@ -24,10 +24,4 @@ func (op *OpMessageCreate) merge(other operation) (operation, bool) {
 	return nil, false
 }
 
-func (op *OpMessageCreate) setMailboxID(tempID, mailboxID string) {
-	if op.MBoxID == tempID {
-		op.MBoxID = mailboxID
-	}
-}
-
 func (OpMessageCreate) _isOperation() {}

--- a/internal/remote/operation_message_flagged.go
+++ b/internal/remote/operation_message_flagged.go
@@ -28,12 +28,4 @@ func (op *OpMessageFlagged) merge(other operation) (operation, bool) {
 	}
 }
 
-func (op *OpMessageFlagged) setMessageID(tempID, messageID string) {
-	for idx := range op.MessageIDs {
-		if op.MessageIDs[idx] == tempID {
-			op.MessageIDs[idx] = messageID
-		}
-	}
-}
-
 func (OpMessageFlagged) _isOperation() {}

--- a/internal/remote/operation_message_remove.go
+++ b/internal/remote/operation_message_remove.go
@@ -28,20 +28,6 @@ func (op *OpMessageRemove) merge(other operation) (operation, bool) {
 	}
 }
 
-func (op *OpMessageRemove) setMailboxID(tempID, mboxID string) {
-	if op.MBoxID == tempID {
-		op.MBoxID = mboxID
-	}
-}
-
-func (op *OpMessageRemove) setMessageID(tempID, messageID string) {
-	for idx := range op.MessageIDs {
-		if op.MessageIDs[idx] == tempID {
-			op.MessageIDs[idx] = messageID
-		}
-	}
-}
-
 func (op *OpMessageRemove) getConnMetadataID() ConnMetadataID {
 	return op.MetadataID
 }

--- a/internal/remote/operation_message_seen.go
+++ b/internal/remote/operation_message_seen.go
@@ -28,12 +28,4 @@ func (op *OpMessageSeen) merge(other operation) (operation, bool) {
 	}
 }
 
-func (op *OpMessageSeen) setMessageID(tempID, messageID string) {
-	for idx := range op.MessageIDs {
-		if op.MessageIDs[idx] == tempID {
-			op.MessageIDs[idx] = messageID
-		}
-	}
-}
-
 func (OpMessageSeen) _isOperation() {}

--- a/internal/remote/operation_temp_id.go
+++ b/internal/remote/operation_temp_id.go
@@ -1,0 +1,48 @@
+package remote
+
+import "encoding/gob"
+
+type OpRemMailboxTempID struct {
+	OperationBase
+	tempID string
+}
+
+type OpRemMessageTempID struct {
+	OperationBase
+	tempID string
+}
+
+func (op *OpRemMailboxTempID) merge(other operation) (operation, bool) {
+	switch other := other.(type) {
+	case *OpRemMailboxTempID:
+		if op.tempID != other.tempID || op.MetadataID != other.MetadataID {
+			return nil, false
+		}
+
+		return op, true
+	default:
+		return nil, false
+	}
+}
+
+func (OpRemMailboxTempID) _isOperation() {}
+
+func (op *OpRemMessageTempID) merge(other operation) (operation, bool) {
+	switch other := other.(type) {
+	case *OpRemMessageTempID:
+		if op.tempID != other.tempID || op.MetadataID != other.MetadataID {
+			return nil, false
+		}
+
+		return op, true
+	default:
+		return nil, false
+	}
+}
+
+func (OpRemMessageTempID) _isOperation() {}
+
+func init() {
+	gob.Register(&OpRemMailboxTempID{})
+	gob.Register(&OpRemMessageTempID{})
+}

--- a/internal/remote/user.go
+++ b/internal/remote/user.go
@@ -78,6 +78,18 @@ func (user *User) CloseAndFlushOperationQueue() {
 	user.processWG.Wait()
 }
 
+func (user *User) FinishMailboxIDUpdate(tempID string) error {
+	return user.pushOp(&OpRemMailboxTempID{
+		tempID: tempID,
+	})
+}
+
+func (user *User) FinishMessageIDUpdate(tempID string) error {
+	return user.pushOp(&OpRemMessageTempID{
+		tempID: tempID,
+	})
+}
+
 // CloseAndSerializeOperationQueue closes the remote user.
 func (user *User) CloseAndSerializeOperationQueue() error {
 	ops, err := user.opQueue.closeQueueAndRetrieveRemaining()


### PR DESCRIPTION
Currently it is possible to have temporary IDs for mailboxes and
messages to become stale. It is possible, due to concurrency, that a
session pushes an operation which still uses a temporary ID that is no
longer valid.

Rather than locking the entire queue and updating all the remaining
entries, we now maintain two separate translation tables which are
evicted via separate operations.

This reduces the amount of time the queue spends in a locking state and
also guarantees that by the time the removal of the temporary ID is
processed by the operation queue no other operations exist that still
refer to this temporary ID.