### PR TITLE
test(GODT-1596): Add unit test which simulate Draft updates

### DIFF
--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -1,0 +1,38 @@
+package tests
+
+import "testing"
+
+func TestDraftScenario(t *testing.T) {
+	// Simulate a draft update issued from the connector, which involves deleting the original message in drafts
+	// and replacing it with a new one.
+	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+
+		mailboxID := s.mailboxCreated("user", []string{"Drafts"})
+
+		c.C("A002 SELECT Drafts").OK("A002")
+
+		messageID := s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"))
+
+		c.C("A002 NOOP")
+		c.S("* 1 EXISTS")
+		c.S("* 1 RECENT")
+		c.S("A002 OK (^_^)")
+
+		c.C("A003 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm)")
+		c.OK("A003")
+
+		s.messageDeleted("user", messageID)
+		s.messageCreated("user", mailboxID, []byte("To: 4@4.pm"))
+
+		c.C("A002 NOOP")
+		c.S("* 1 EXPUNGE")
+		c.S("* 1 EXISTS")
+		c.S("* 1 RECENT")
+		c.S("A002 OK (^_^)")
+
+		c.C("A003 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm)")
+		c.OK("A003")
+	})
+}


### PR DESCRIPTION
The code contains all the pieces required for the connector to update
draft messages. This unit tests checks for this sequence of events and
makes sure we get the required responses.