### PR TITLE
chore: Add pprof annotations to important goroutines

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -48,7 +48,7 @@ func (b *Backend) AddUser(ctx context.Context, conn connector.Connector, store s
 
 	userID := uuid.NewString()
 
-	remote, err := b.remote.AddUser(userID, conn)
+	remote, err := b.remote.AddUser(ctx, userID, conn)
 	if err != nil {
 		return "", err
 	}

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -37,7 +37,7 @@ func New(dir string) (*Manager, error) {
 
 // AddUser adds the remote user with the given (IMAP) credentials to the remote manager.
 // The user interacts with the remote via the given connector.
-func (m *Manager) AddUser(userID string, conn connector.Connector) (*User, error) {
+func (m *Manager) AddUser(ctx context.Context, userID string, conn connector.Connector) (*User, error) {
 	m.usersLock.Lock()
 	defer m.usersLock.Unlock()
 
@@ -46,7 +46,7 @@ func (m *Manager) AddUser(userID string, conn connector.Connector) (*User, error
 		return nil, err
 	}
 
-	user, err := newUser(userID, path, conn)
+	user, err := newUser(ctx, userID, path, conn)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/session/command.go
+++ b/internal/session/command.go
@@ -1,8 +1,11 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"io"
+	"runtime/pprof"
+	"strconv"
 
 	"github.com/ProtonMail/gluon/internal/parser/proto"
 	"github.com/ProtonMail/gluon/internal/response"
@@ -13,38 +16,40 @@ type command struct {
 	cmd *proto.Command
 }
 
-func (s *Session) getCommandCh() <-chan command {
+func (s *Session) getCommandCh(ctx context.Context) <-chan command {
 	cmdCh := make(chan command)
 
 	go func() {
-		defer close(cmdCh)
-
-		for {
-			tag, cmd, err := s.readCommand()
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					return
-				} else if err := response.Bad(tag).WithError(err).Send(s); err != nil {
-					return
-				}
-
-				continue
-			}
-
-			switch {
-			case cmd.GetStartTLS() != nil:
-				if err := s.handleStartTLS(tag, cmd.GetStartTLS()); err != nil {
-					if err := response.Bad(tag).WithError(err).Send(s); err != nil {
+		labels := pprof.Labels("go", "CommandReader", "SessionID", strconv.Itoa(s.sessionID))
+		pprof.Do(ctx, labels, func(_ context.Context) {
+			defer close(cmdCh)
+			for {
+				tag, cmd, err := s.readCommand()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						return
+					} else if err := response.Bad(tag).WithError(err).Send(s); err != nil {
 						return
 					}
 
 					continue
 				}
 
-			default:
-				cmdCh <- command{tag: tag, cmd: cmd}
+				switch {
+				case cmd.GetStartTLS() != nil:
+					if err := s.handleStartTLS(tag, cmd.GetStartTLS()); err != nil {
+						if err := response.Bad(tag).WithError(err).Send(s); err != nil {
+							return
+						}
+
+						continue
+					}
+
+				default:
+					cmdCh <- command{tag: tag, cmd: cmd}
+				}
 			}
-		}
+		})
 	}()
 
 	return cmdCh

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -113,7 +113,7 @@ func (s *Session) Serve(ctx context.Context) error {
 		return err
 	}
 
-	return s.serve(ctx, s.getCommandCh())
+	return s.serve(ctx, s.getCommandCh(ctx))
 }
 
 func (s *Session) serve(ctx context.Context, cmdCh <-chan command) error {


### PR DESCRIPTION
Annotate certain important goroutines so they can easily be located
in the debugger for problem analysis.