### PR TITLE
test(GODT-1648): Add support for restarting server with previous data

### DIFF
--- a/tests/append_test.go
+++ b/tests/append_test.go
@@ -16,7 +16,7 @@ func TestAppend(t *testing.T) {
 		messagePath = "testdata/afternoon-meeting.eml"
 	)
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create(mailboxName))
 		{
 			// first check, empty mailbox
@@ -45,7 +45,7 @@ func TestAppendWithUidPlus(t *testing.T) {
 		messagePath = "testdata/afternoon-meeting.eml"
 	)
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const (
 			validityUid = uint32(1)
 		)
@@ -94,12 +94,12 @@ func TestAppendNoSuchMailbox(t *testing.T) {
 		messagePath = "testdata/afternoon-meeting.eml"
 	)
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		err := doAppendWithClientFromFile(t, client, mailboxName, messagePath, time.Now(), goimap.SeenFlag)
 		require.Error(t, err)
 	})
 	// Run the old test as well as there is no way to check for the `[TRYCREATE]` flag of the response
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.doAppendFromFile(`saved-messages`, `testdata/afternoon-meeting.eml`, `\Seen`).expect(`NO \[TRYCREATE\]`)
 	})
 }
@@ -110,7 +110,7 @@ func TestAppendWhileSelected(t *testing.T) {
 		messagePath = "testdata/afternoon-meeting.eml"
 	)
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create(mailboxName))
 		// Mailbox should have read-write modifier
 		mailboxStatus, err := client.Select(mailboxName, false)

--- a/tests/benchmark_fetch_test.go
+++ b/tests/benchmark_fetch_test.go
@@ -10,7 +10,7 @@ func BenchmarkFetchDatabase(b *testing.B) {
 		mboxSize := 1 << n
 
 		b.Run(strconv.Itoa(mboxSize), func(b *testing.B) {
-			runOneToOneTestWithAuth(b, "user", "pass", "/", func(c *testConnection, s *testSession) {
+			runOneToOneTestWithAuth(b, defaultServerOptions(b), func(c *testConnection, s *testSession) {
 				benchID := s.mailboxCreated("user", []string{"BENCH"})
 
 				for i := 0; i < mboxSize; i++ {
@@ -50,7 +50,7 @@ func BenchmarkFetchSingleCache(b *testing.B) {
 		mboxSize := 1 << n
 
 		b.Run(strconv.Itoa(mboxSize), func(b *testing.B) {
-			runOneToOneTestWithAuth(b, "user", "pass", "/", func(c *testConnection, s *testSession) {
+			runOneToOneTestWithAuth(b, defaultServerOptions(b), func(c *testConnection, s *testSession) {
 				benchID := s.mailboxCreated("user", []string{"BENCH"})
 
 				for i := 0; i < mboxSize; i++ {

--- a/tests/capability_test.go
+++ b/tests/capability_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCapability(t *testing.T) {
-	runOneToOneTestClient(t, "user", "pass", "/", func(client *client.Client, s *testSession) {
+	runOneToOneTestClient(t, defaultServerOptions(t), func(client *client.Client, s *testSession) {
 		capabilities, err := client.Capability()
 		require.NoError(t, err)
 		require.ElementsMatch(t, maps.Keys(capabilities), []string{

--- a/tests/case_test.go
+++ b/tests/case_test.go
@@ -6,7 +6,7 @@ import (
 
 // GOMSRV-39: We should be able to match INBOX in other cases!
 func _TestMailboxCase(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// Create a non-inbox mailbox.
 		c.C(`A001 CREATE Archive`).OK(`A001`)
 

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		mailboxStatus, err := client.Select("INBOX", false)
 		require.NoError(t, err)
 		require.Equal(t, false, mailboxStatus.ReadOnly)

--- a/tests/close_test.go
+++ b/tests/close_test.go
@@ -14,7 +14,7 @@ func TestClose(t *testing.T) {
 	// This test is still useful as we have no way of checking the fetch responses after the store command.
 	// Additionally, we also need to ensure that there are no unilateral EXPUNGE messages returned from the server after close.
 	// There is currently no way to check for this with the go imap client.
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
 		c.S("b001 OK (^_^)")
 
@@ -52,7 +52,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestCloseWithClient(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const (
 			messageBoxName = "saved-messages"
 		)

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCopy(t *testing.T) {
-	runOneToOneTestClientWithData(t, "user", "pass", "/", func(client *client.Client, s *testSession, mbox, mboxID string) {
+	runOneToOneTestClientWithData(t, defaultServerOptions(t), func(client *client.Client, s *testSession, mbox, mboxID string) {
 		{
 			// There are 100 messages in the origin and no messages in the destination.
 			mailboxStatus, err := client.Status(mbox, []goimap.StatusItem{goimap.StatusMessages})
@@ -62,7 +62,7 @@ func TestCopy(t *testing.T) {
 
 func TestCopyTryCreate(t *testing.T) {
 	// Test can't be remove since there is no way to check the TRYCREATE response from the server
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// There are 100 messages in the origin.
 		c.Cf(`A001 status %v (messages)`, mbox).Sxe(`MESSAGES 100`).OK(`A001`)
 
@@ -77,7 +77,7 @@ func TestCopyTryCreate(t *testing.T) {
 }
 
 func TestCopyNonExistingClient(t *testing.T) {
-	runOneToOneTestClientWithData(t, "user", "pass", "/", func(client *client.Client, s *testSession, mbox, mboxID string) {
+	runOneToOneTestClientWithData(t, defaultServerOptions(t), func(client *client.Client, s *testSession, mbox, mboxID string) {
 		{
 			// Move message intervals to inbox
 			sequenceSet, seqErr := goimap.ParseSeqSet("1:25,76:100")
@@ -115,7 +115,7 @@ func TestCopyNonExistingClient(t *testing.T) {
 }
 
 func TestCopyNonExisting(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// MOVE some of the messages out of the mailbox.
 		c.C(`A001 move 1:24,76:100 inbox`).OK(`A001`)
 

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX"})
 		require.NoError(t, client.Create("owatagusiam"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "owatagusiam"})
@@ -18,7 +18,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateEndingInSeparator(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX"})
 		require.NoError(t, client.Create("owatagusiam/"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "owatagusiam"})
@@ -26,13 +26,13 @@ func TestCreateEndingInSeparator(t *testing.T) {
 }
 
 func TestCreateCannotCreateInbox(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.Error(t, client.Create("INBOX"))
 	})
 }
 
 func TestCreateCannotCreateExistingMailbox(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("Folder"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "Folder"})
 		require.Error(t, client.Create("Folder"))
@@ -40,7 +40,7 @@ func TestCreateCannotCreateExistingMailbox(t *testing.T) {
 }
 
 func TestCreateWithDifferentHierarchySeparator(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX"})
 		require.NoError(t, client.Create("Folder"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "Folder"})
@@ -50,7 +50,7 @@ func TestCreateWithDifferentHierarchySeparator(t *testing.T) {
 }
 
 func TestCreatePreviousLevelHierarchyIfNonExisting(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("Folder/Bar/ZZ"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "Folder", "Folder/Bar", "Folder/Bar/ZZ"})
 	})
@@ -58,7 +58,7 @@ func TestCreatePreviousLevelHierarchyIfNonExisting(t *testing.T) {
 
 // TODO: GOMSRV-51.
 func _TestEnsureNewMailboxWithDeletedNameHasGreaterId(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const (
 			inboxName = "Folder"
 		)

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDelete(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", ".", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("blurdybloop"))
 		require.NoError(t, client.Create("foo"))
 		require.NoError(t, client.Create("foo.bar"))
@@ -51,13 +51,13 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteCannotDeleteInbox(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.Error(t, client.Delete("INBOX"))
 	})
 }
 
 func TestDeleteCannotDeleteMissingMailbox(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.Error(t, client.Delete("this doesn't exist"))
 	})
 }

--- a/tests/deleted_test.go
+++ b/tests/deleted_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestDeleted(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// Create two mailboxes.
 		c.C("b001 CREATE mbox1")
 		c.S("b001 OK (^_^)")
@@ -73,7 +73,7 @@ func TestDeleted(t *testing.T) {
 }
 
 func TestUIDDeleted(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// Create two mailboxes
 		c.C("b001 CREATE mbox1")
 		c.S("b001 OK (^_^)")

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestDraftScenario(t *testing.T) {
 	// Simulate a draft update issued from the connector, which involves deleting the original message in drafts
 	// and replacing it with a new one.
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 
 		mailboxID := s.mailboxCreated("user", []string{"Drafts"})
 

--- a/tests/examine_test.go
+++ b/tests/examine_test.go
@@ -13,7 +13,7 @@ import (
 func TestExamineWithLiteral(t *testing.T) {
 	// This test remains here since it is not possible to send literal commands with the
 	// IMAP client. The rest of the functionality is still tested in the IMAP client test.
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE Archive")
 		c.S("A002 OK (^_^)")
 
@@ -33,7 +33,7 @@ func TestExamineWithLiteral(t *testing.T) {
 }
 
 func TestExamineClient(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("Archive"))
 		require.NoError(t, client.Append("INBOX", []string{goimap.SeenFlag}, time.Now(), strings.NewReader("To: 1@pm.me")))
 		require.NoError(t, client.Append("INBOX", []string{}, time.Now(), strings.NewReader("To: 2@pm.me")))

--- a/tests/expunge_test.go
+++ b/tests/expunge_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestExpungeUnmarked(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("mbox"))
 		_, err := client.Select("mbox", false)
 		require.NoError(t, err)
@@ -22,7 +22,7 @@ func TestExpungeUnmarked(t *testing.T) {
 }
 
 func TestExpungeSingle(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("mbox"))
 		_, err := client.Select("mbox", false)
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestExpungeSingle(t *testing.T) {
 }
 
 func TestRemoveSameMessageTwice(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, s *testSession) {
 		// There are three messages in the inbox.
 		c[1].doAppend(`inbox`, `To: 1@pm.me`).expect("OK")
 		c[1].doAppend(`inbox`, `To: 2@pm.me`).expect("OK")
@@ -69,7 +69,7 @@ func TestRemoveSameMessageTwice(t *testing.T) {
 }
 
 func TestExpungeInterval(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("mbox"))
 		_, err := client.Select("mbox", false)
 		require.NoError(t, err)
@@ -120,7 +120,7 @@ func beforeOrAfterExpungeCheck(t *testing.T, client *client.Client, mailboxName 
 func TestExpungeWithAppendBeforeMailboxSelect(t *testing.T) {
 	// This test exists to catch an issue where in the past messages that might be added before/after selected would
 	// not be removed.
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const mailboxName = "saved-messages"
 		require.NoError(t, client.Create(mailboxName))
 
@@ -140,7 +140,7 @@ func TestExpungeWithAppendBeforeMailboxSelect(t *testing.T) {
 func TestExpungeWithAppendAfterMailBoxSelect(t *testing.T) {
 	// This test exists to catch an issue where in the past messages that might be added before/after selected would
 	// not be removed.
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const mailboxName = "saved-messages"
 
 		require.NoError(t, client.Create(mailboxName))
@@ -158,7 +158,7 @@ func TestExpungeWithAppendAfterMailBoxSelect(t *testing.T) {
 }
 
 func TestExpungeUID(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const mailboxName = "mbox"
 
 		require.NoError(t, client.Create(mailboxName))
@@ -221,7 +221,7 @@ func TestExpungeUID(t *testing.T) {
 func TestExpungeResponseSequence(t *testing.T) {
 	// Test the response sequence produce by the expunge command, should match the example output of
 	// rfc3501#section-6.4.3
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		const mailboxName = "mbox"
 		require.NoError(t, client.Create(mailboxName))
 		_, err := client.Select(mailboxName, false)

--- a/tests/fetch_body_test.go
+++ b/tests/fetch_body_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFetchBodySetsSeenFlag(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.doAppendFromFile(`INBOX`, `testdata/multipart-mixed.eml`).expect("OK")
 
 		c.C(`A004 SELECT INBOX`)
@@ -42,7 +42,7 @@ func TestFetchBodySetsSeenFlag(t *testing.T) {
 }
 
 func TestFetchBodyPeekDoesNotSetSeenFlag(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.doAppendFromFile(`INBOX`, `testdata/multipart-mixed.eml`).expect("OK")
 
 		c.C(`A004 SELECT INBOX`)
@@ -70,7 +70,7 @@ func TestFetchBodyPeekDoesNotSetSeenFlag(t *testing.T) {
 }
 
 func TestFetchStructure(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.doAppendFromFile(`INBOX`, `testdata/multipart-mixed.eml`, `\Seen`).expect("OK")
 
 		c.C(`A004 SELECT INBOX`)
@@ -89,7 +89,7 @@ func TestFetchStructure(t *testing.T) {
 }
 
 func TestFetchStructureMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchBodyStructure).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -147,7 +147,7 @@ func TestFetchStructureMultiPart(t *testing.T) {
 }
 
 func TestFetchEnvelopeMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchEnvelope).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -176,7 +176,7 @@ func TestFetchEnvelopeMultiPart(t *testing.T) {
 }
 
 func TestFetchStructureEmbedded(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectEmbeddedMessage(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchBodyStructure).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -229,7 +229,7 @@ func TestFetchStructureEmbedded(t *testing.T) {
 }
 
 func TestFetchBodyMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		// Get full body
@@ -309,7 +309,7 @@ func TestFetchBodyMultiPart(t *testing.T) {
 }
 
 func TestFetchBodyEmbedded(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectEmbeddedMessage(t, client)
 
 		// Get full body
@@ -368,7 +368,7 @@ func TestFetchBodyEmbedded(t *testing.T) {
 }
 
 func TestFetchBodyPlain(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectPlainMessage(t, client)
 
 		// Get full body
@@ -393,7 +393,7 @@ func TestFetchBodyPlain(t *testing.T) {
 }
 
 func TestFetchStructurePlain(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectPlainMessage(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchBodyStructure).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -412,7 +412,7 @@ func TestFetchStructurePlain(t *testing.T) {
 }
 
 func TestFetchBodyPartialMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems("BODY[1.TEXT]<20.10>").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -432,7 +432,7 @@ func TestFetchBodyPartialMultiPart(t *testing.T) {
 }
 
 func TestFetchBodyPartialReturnsEmptyWhenStartingOctetIsGreaterThanContentSize(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems("BODY[1.TEXT]<20000.10>").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -443,7 +443,7 @@ func TestFetchBodyPartialReturnsEmptyWhenStartingOctetIsGreaterThanContentSize(t
 }
 
 func TestFetchHeaderMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems("BODY[HEADER]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -518,7 +518,7 @@ func TestFetchHeaderMultiPart(t *testing.T) {
 }
 
 func TestFetchHeaderFieldsMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems("BODY[HEADER.FIELDS (To From Date)]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -556,7 +556,7 @@ func TestFetchHeaderFieldsMultiPart(t *testing.T) {
 }
 
 func TestFetchHeaderFieldsEmbedded(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectEmbeddedMessage(t, client)
 
 		newFetchCommand(t, client).withItems("BODY[2.HEADER.FIELDS (To)]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -581,7 +581,7 @@ func TestFetchHeaderFieldsEmbedded(t *testing.T) {
 }
 
 func TestFetchMIMEMultiPart(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMultiPartMessage(t, client)
 
 		newFetchCommand(t, client).withItems("BODY[MIME]").fetchFailure("1")

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestFetchAllMacro(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchAll).fetch("1").forSeqNum(1, func(validator *validatorBuilder) {
@@ -29,7 +29,7 @@ func TestFetchAllMacro(t *testing.T) {
 }
 
 func TestFetchFastMacro(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchFast).fetch("1").forSeqNum(1, func(validator *validatorBuilder) {
@@ -42,7 +42,7 @@ func TestFetchFastMacro(t *testing.T) {
 }
 
 func TestFetchFullMacro(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchFull).fetch("1").forSeqNum(1, func(validator *validatorBuilder) {
@@ -58,7 +58,7 @@ func TestFetchFullMacro(t *testing.T) {
 
 func TestFetchRFC822(t *testing.T) {
 	// This test does all checks for RFC822 at the same time so we can compare the retrieved data
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Load message
@@ -78,7 +78,7 @@ func TestFetchRFC822(t *testing.T) {
 
 func TestFetchRFC822Header(t *testing.T) {
 	// This test does all checks for RFC822 at the same time so we can compare the retrieved data
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Load message
@@ -98,7 +98,7 @@ func TestFetchRFC822Header(t *testing.T) {
 
 func TestFetchRFC822Size(t *testing.T) {
 	// This test does all checks for RFC822 at the same time so we can compare the retrieved data
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 		newFetchCommand(t, client).withItems(goimap.FetchRFC822Size).fetch("1").forSeqNum(1, func(validator *validatorBuilder) {
 			validator.ignoreFlags()
@@ -109,7 +109,7 @@ func TestFetchRFC822Size(t *testing.T) {
 
 func TestFetchRFC822Text(t *testing.T) {
 	// This test does all checks for RFC822 at the same time so we can compare the retrieved data
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Load message
@@ -128,7 +128,7 @@ func TestFetchRFC822Text(t *testing.T) {
 }
 
 func TestFetchEnvelopeOnly(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 		newFetchCommand(t, client).withItems(goimap.FetchEnvelope).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
 			builder.wantEnvelope(newAfternoonMeetingMessageEnvelopeValidator)
@@ -137,7 +137,7 @@ func TestFetchEnvelopeOnly(t *testing.T) {
 }
 
 func TestFetchFlagsOnly(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchFlags).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -147,7 +147,7 @@ func TestFetchFlagsOnly(t *testing.T) {
 }
 
 func TestFetchInternalDateOnly(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchInternalDate).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -158,7 +158,7 @@ func TestFetchInternalDateOnly(t *testing.T) {
 }
 
 func TestFetchUIDOnly(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		newFetchCommand(t, client).withItems(goimap.FetchUid).fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
@@ -168,7 +168,7 @@ func TestFetchUIDOnly(t *testing.T) {
 }
 
 func TestFetchRFC822AddsSeenFlag(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Fetch the message flags and check the seen flag is not set
@@ -187,7 +187,7 @@ func TestFetchRFC822AddsSeenFlag(t *testing.T) {
 }
 
 func TestFetchRFC822TextAddsSeenFlag(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Fetch the message flags and check the seen flag is not set
@@ -206,7 +206,7 @@ func TestFetchRFC822TextAddsSeenFlag(t *testing.T) {
 }
 
 func TestFetchRFC822HeaderDoesNotAddSeenFlag(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Fetch the message flags and check the seen flag is not set
@@ -225,7 +225,7 @@ func TestFetchRFC822HeaderDoesNotAddSeenFlag(t *testing.T) {
 }
 
 func TestFetchBodyPeekDoesNotAddSeenFlag(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectAfternoonMeetingMailbox(t, client)
 
 		// Fetch the message flags and check the seen flag is not set
@@ -244,7 +244,7 @@ func TestFetchBodyPeekDoesNotAddSeenFlag(t *testing.T) {
 }
 
 func TestFetchSequence(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMailboxWithMultipleEntries(t, client)
 
 		// delete message number 4
@@ -279,7 +279,7 @@ func TestFetchSequence(t *testing.T) {
 }
 
 func TestFetchUID(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		fillAndSelectMailboxWithMultipleEntries(t, client)
 
 		// delete message number 4
@@ -318,7 +318,7 @@ func TestFetchUID(t *testing.T) {
 }
 
 func TestFetchFromDataSequences(t *testing.T) {
-	runOneToOneTestClientWithData(t, "user", "pass", "/", func(client *client.Client, _ *testSession, _ string, _ string) {
+	runOneToOneTestClientWithData(t, defaultServerOptions(t), func(client *client.Client, _ *testSession, _ string, _ string) {
 		const sectionStr = "BODY[HEADER.FIELDS (To Subject)]"
 		fetchResult := newFetchCommand(t, client).withItems(sectionStr).fetch("1:4,30:31,81")
 		fetchResult.forSeqNum(1, func(builder *validatorBuilder) {
@@ -389,7 +389,7 @@ func TestFetchFromDataSequences(t *testing.T) {
 }
 
 func TestFetchFromDataUids(t *testing.T) {
-	runOneToOneTestClientWithData(t, "user", "pass", "/", func(client *client.Client, _ *testSession, _ string, _ string) {
+	runOneToOneTestClientWithData(t, defaultServerOptions(t), func(client *client.Client, _ *testSession, _ string, _ string) {
 		// Remove a couple of messages
 		require.NoError(t, client.Store(createSeqSet("20:29,50:60,90"), goimap.AddFlags, []interface{}{goimap.DeletedFlag}, nil))
 		require.NoError(t, client.Expunge(nil))

--- a/tests/full_state_test.go
+++ b/tests/full_state_test.go
@@ -29,7 +29,7 @@ func TestSimpleMailCopy(t *testing.T) {
 		messagePath = "testdata/afternoon-meeting.eml"
 	)
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("Archive"))
 		// list mailbox
 		{
@@ -84,7 +84,7 @@ func TestReceptionOnIdle(t *testing.T) {
 		messagePath = "testdata/afternoon-meeting.eml"
 	)
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(c *client.Client, sess *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(c *client.Client, sess *testSession) {
 		// list mailbox
 		{
 			expectedMailboxNames := []string{
@@ -178,7 +178,7 @@ func TestReceptionOnIdle(t *testing.T) {
  * Either delete it, Archive it or put it as unseen.
  */
 func TestMorningFiltering(t *testing.T) {
-	runOneToOneTestClientWithData(t, "user", "pass", "/", func(client *client.Client, s *testSession, mbox, mboxID string) {
+	runOneToOneTestClientWithData(t, defaultServerOptions(t), func(client *client.Client, s *testSession, mbox, mboxID string) {
 		require.NoError(t, client.Create("ReadLater"))
 		require.NoError(t, client.Create("Archive"))
 

--- a/tests/id_test.go
+++ b/tests/id_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIdNilNoData(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		idResponse := response.ID(imap.NewIMAPIDFromVersionInfo(&TestServerVersionInfo))
 		c.C(`A001 ID NIL`)
 		c.S(idResponse.String())
@@ -19,7 +19,7 @@ func TestIdNilNoData(t *testing.T) {
 }
 
 func TestIdContextLookup(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		idResponse := response.ID(imap.NewIMAPIDFromVersionInfo(&TestServerVersionInfo))
 		// Store new ID
 		c.C(`A001 ID ("foo" "bar")`)

--- a/tests/idle_test.go
+++ b/tests/idle_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestIDLEExistsUpdates(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// First client selects in INBOX to receive EXISTS update.
 		c[1].C("A006 select INBOX")
 		c[1].Se("A006 OK [READ-WRITE] (^_^)")
@@ -32,7 +32,7 @@ func TestIDLEExistsUpdates(t *testing.T) {
 }
 
 func TestIDLEPendingUpdates(t *testing.T) {
-	runManyToOneTestWithData(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession, _, _ string) {
+	runManyToOneTestWithData(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession, _, _ string) {
 		c[1].C("A001 select INBOX").OK("A001")
 
 		// Generate some pending updates.

--- a/tests/invalid_test.go
+++ b/tests/invalid_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestInvalidIMAPCommandBadTag(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		c.C("A006 RANDOMGIBBERISHTHATDOESNOTMAKEAVALIDIMAPCOMMAND").BAD("A006")
 	})
 }

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestList(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE #news/comp/mail/mime")
 		c.S("A002 OK (^_^)")
 
@@ -45,7 +45,7 @@ func TestList(t *testing.T) {
 }
 
 func TestListFlagsAndAttributes(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		mailboxID := s.mailboxCreatedCustom(
 			"user",
 			[]string{"custom-attributes"},

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -5,19 +5,19 @@ import (
 )
 
 func TestLoginSuccess(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A001 login user pass").OK("A001")
 	})
 }
 
 func TestLoginQuoted(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C(`A001 login "user" "pass"`).OK("A001")
 	})
 }
 
 func TestLoginLiteral(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C(`A001 login {4}`)
 		c.S(`+ (*_*)`)
 		c.C(`user {4}`)
@@ -28,10 +28,10 @@ func TestLoginLiteral(t *testing.T) {
 }
 
 func TestLoginMultiple(t *testing.T) {
-	runTest(t, []credentials{
+	runTest(t, defaultServerOptions(t, withCredentials([]credentials{
 		{usernames: []string{"user1"}, password: "pass1"},
 		{usernames: []string{"user2"}, password: "pass2"},
-	}, "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	})), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// Login as the first user.
 		c[1].C("A001 login user1 pass1").OK("A001")
 
@@ -47,10 +47,10 @@ func TestLoginMultiple(t *testing.T) {
 }
 
 func TestLoginAlias(t *testing.T) {
-	runTest(t, []credentials{{
+	runTest(t, defaultServerOptions(t, withCredentials([]credentials{{
 		usernames: []string{"alias1", "alias2"},
 		password:  "pass",
-	}}, "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	}})), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// Login as each alias.
 		c[1].C("tag1 login alias1 pass").OK("tag1")
 		c[2].C("tag2 login alias2 pass").OK("tag2")
@@ -66,13 +66,13 @@ func TestLoginAlias(t *testing.T) {
 }
 
 func TestLoginFailure(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A001 login baduser badpass").NO("A001")
 	})
 }
 
 func TestLoginLiteralFailure(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C(`A001 login {7}`)
 		c.S(`+ (*_*)`)
 		c.C(`baduser {7}`)
@@ -83,7 +83,7 @@ func TestLoginLiteralFailure(t *testing.T) {
 }
 
 func TestLoginCapabilities(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A001 login user pass")
 		c.S(`A001 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT] (^_^)`)
 	})

--- a/tests/logout_test.go
+++ b/tests/logout_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestLogout(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("a001 logout")
 		c.S("* BYE (^_^)/~")
 		c.S("a001 OK (^_^)")

--- a/tests/lsub_test.go
+++ b/tests/lsub_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestLsub(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", ".", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("B002 CREATE #news.comp.mail.mime")
 		c.S("B002 OK (^_^)")
 

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMove(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// There are 100 messages in the origin and no messages in the destination.
 		c.Cf(`A001 status %v (messages)`, mbox).Sxe(`MESSAGES 100`).OK(`A001`)
 		c.C(`A002 status inbox (messages)`).Sxe(`MESSAGES 0`).OK(`A002`)
@@ -36,7 +36,7 @@ func TestMove(t *testing.T) {
 }
 
 func TestMoveTryCreate(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// There are 100 messages in the origin.
 		c.Cf(`A001 status %v (messages)`, mbox).Sxe(`MESSAGES 100`).OK(`A001`)
 
@@ -51,7 +51,7 @@ func TestMoveTryCreate(t *testing.T) {
 }
 
 func TestMoveNonExistent(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// MOVE some of the messages out of the mailbox.
 		c.C(`A001 move 1:24,76:100 inbox`).OK(`A001`)
 
@@ -82,7 +82,7 @@ func _TestMoveBackAndForthRepeated(t *testing.T) {
 }
 
 func TestMoveBackAndForth(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// There are 100 messages in the origin and no messages in the destination.
 		c.Cf(`A001 status %v (messages)`, mbox).Sxe(`MESSAGES 100`).OK(`A001`)
 		c.C(`A002 status inbox (messages)`).Sxe(`MESSAGES 0`).OK(`A002`)
@@ -105,7 +105,7 @@ func TestMoveBackAndForth(t *testing.T) {
 }
 
 func TestMoveCopyDuplicates(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		// 4 messages in inbox.
 		c.doAppend("inbox", "To: 1@pm.me").expect("OK")
 		c.doAppend("inbox", "To: 2@pm.me").expect("OK")
@@ -150,7 +150,7 @@ func TestMoveCopyDuplicates(t *testing.T) {
 }
 
 func TestMoveDuplicate(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, s *testSession) {
 		origID := s.mailboxCreated("user", []string{"orig"})
 		destID := s.mailboxCreated("user", []string{"dest"})
 

--- a/tests/multi_test.go
+++ b/tests/multi_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestCreateMulti(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		c[1].C("A003 CREATE owatagusiam")
 		c[1].S("A003 OK (^_^)")
 
@@ -15,7 +15,7 @@ func TestCreateMulti(t *testing.T) {
 }
 
 func TestExistsUpdates(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// First client selects in INBOX to receive EXISTS update.
 		c[1].C("A006 select INBOX")
 		c[1].Se("A006 OK [READ-WRITE] (^_^)")
@@ -32,7 +32,7 @@ func TestExistsUpdates(t *testing.T) {
 }
 
 func TestExistsUpdatesInSeparateMailboxes(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		c[1].C("A003 CREATE owatagusiam")
 		c[1].S("A003 OK (^_^)")
 
@@ -50,7 +50,7 @@ func TestExistsUpdatesInSeparateMailboxes(t *testing.T) {
 }
 
 func TestFetchUpdates(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`, `\Seen`).expect("OK")
 
 		// First client selects in INBOX to receive FETCH update.
@@ -73,7 +73,7 @@ func TestFetchUpdates(t *testing.T) {
 }
 
 func TestExpungeUpdates(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// Generate three messages, the first two unseen, the third seen.
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
@@ -128,7 +128,7 @@ func TestExpungeUpdates(t *testing.T) {
 }
 
 func TestSequenceNumbersPerSession(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// Generate five messages.
 		c[1].doAppend(`inbox`, `To: 1@pm.me`).expect("OK")
 		c[1].doAppend(`inbox`, `To: 2@pm.me`).expect("OK")

--- a/tests/multi_user_test.go
+++ b/tests/multi_user_test.go
@@ -5,10 +5,10 @@ import (
 )
 
 func TestMultiUser(t *testing.T) {
-	runTest(t, []credentials{
+	runTest(t, defaultServerOptions(t, withCredentials([]credentials{
 		{usernames: []string{"user1"}, password: "pass"},
 		{usernames: []string{"user2"}, password: "pass"},
-	}, "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	})), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		c[1].C(`A001 login user1 pass`).OK(`A001`)
 		c[2].C(`B001 login user2 pass`).OK(`B001`)
 

--- a/tests/noop_test.go
+++ b/tests/noop_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNoop(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("a001 noop")
 		c.S("a001 OK (^_^)")
 	})

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSelectWhileSyncing(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// Define some mailbox names.
 		mailboxNames := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
 
@@ -53,7 +53,7 @@ func TestSelectWhileSyncing(t *testing.T) {
 }
 
 func TestTwoFetchesAtOnce(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		mboxID := s.mailboxCreated("user", []string{"mbox"})
 
 		for i := 0; i < 1000; i++ {

--- a/tests/path_config_test.go
+++ b/tests/path_config_test.go
@@ -3,7 +3,7 @@ package tests
 import "testing"
 
 func TestPathConfig_ProtonPathConfig(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		s.setFolderPrefix("user", "Folders")
 		s.setLabelPrefix("user", "Labels")
 
@@ -52,7 +52,7 @@ func TestPathConfig_ProtonPathConfig(t *testing.T) {
 }
 
 func TestPathConfig_DotDelimiter(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", ".", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, s *testSession) {
 		s.setFolderPrefix("user", "Folders")
 		s.setLabelPrefix("user", "Labels")
 

--- a/tests/recent_test.go
+++ b/tests/recent_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestRecentSelect(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 appends a new message to INBOX.
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
@@ -20,7 +20,7 @@ func TestRecentSelect(t *testing.T) {
 }
 
 func TestRecentStatus(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 appends a new message to INBOX.
 		c[1].doAppend("INBOX", `To: 1@pm.me`).expect("OK")
 
@@ -36,7 +36,7 @@ func TestRecentStatus(t *testing.T) {
 }
 
 func TestRecentFetch(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 appends a new message to INBOX.
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
@@ -63,7 +63,7 @@ func TestRecentFetch(t *testing.T) {
 }
 
 func TestRecentAppend(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 appends a new message to INBOX.
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
@@ -80,7 +80,7 @@ func TestRecentAppend(t *testing.T) {
 }
 
 func TestRecentStore(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		mbox, done := c[1].doCreateTempDir()
 		defer done()
 
@@ -111,7 +111,7 @@ func TestRecentStore(t *testing.T) {
 }
 
 func TestRecentExists(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2, 3}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 and B both select INBOX.
 		c[1].C("A006 select INBOX").OK("A006")
 		c[2].C("A006 select INBOX").OK("A006")
@@ -130,7 +130,7 @@ func TestRecentExists(t *testing.T) {
 }
 
 func TestRecentIDLEExists(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 selects INBOX and IDLEs.
 		c[1].C("A006 select INBOX").OK("A006")
 		c[1].C("A007 IDLE")
@@ -148,7 +148,7 @@ func TestRecentIDLEExists(t *testing.T) {
 }
 
 func TestRecentIDLEExpunge(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// Client 1 creates a second mailbox and begins to IDLE inside it.
 		c[1].C("A002 CREATE folder").OK("A002")
 		c[1].C("A006 select folder").OK("A006")

--- a/tests/remote_test.go
+++ b/tests/remote_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestRemoteCopy(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		s.setFolderPrefix("user", "Folders")
 		s.setLabelPrefix("user", "Labels")
 
@@ -39,7 +39,7 @@ func TestRemoteCopy(t *testing.T) {
 }
 
 func TestRemoteDeletionPool(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// Create a mailbox for the test to run in.
 		mboxID1 := s.mailboxCreated("user", []string{"mbox1"})
 		mboxID2 := s.mailboxCreated("user", []string{"mbox2"})

--- a/tests/rename_test.go
+++ b/tests/rename_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRename(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("blurdybloop"))
 		require.NoError(t, client.Create("foo"))
 		require.NoError(t, client.Create("foo/bar"))
@@ -26,7 +26,7 @@ func TestRename(t *testing.T) {
 }
 
 func TestRenameHierarchy(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", "/", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("foo/bar/zap"))
 
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "foo", "foo/bar", "foo/bar/zap"})
@@ -59,7 +59,7 @@ func TestRenameAddHierarchy(t *testing.T) {
 
 	for i, tc := range testCases {
 		logrus.Trace(" --- test case ", i, " ---")
-		runOneToOneTestClientWithAuth(t, "user", "pass", ".", func(client *client.Client, _ *testSession) {
+		runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(client *client.Client, _ *testSession) {
 			require.NoError(t, client.Create("foo.bar"))
 			matchMailboxNamesClient(t, client, "", "*", initialMailbox)
 
@@ -87,7 +87,7 @@ func TestRenameAddHierarchy(t *testing.T) {
 }
 
 func TestRenameBadHierarchy(t *testing.T) {
-	runOneToOneTestClientWithAuth(t, "user", "pass", ".", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("foo.bar"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "foo", "foo.bar"})
 		require.Error(t, client.Rename("foo", "foo.foo"))
@@ -98,7 +98,7 @@ func TestRenameBadHierarchy(t *testing.T) {
 }
 
 func TestRenameInbox(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Put all the 100 messages into the inbox.
 		c.C("tag move 1:* inbox").OK("tag")
 		c.C("tag status inbox (messages)").Sxe("MESSAGES 100").OK("tag")
@@ -123,7 +123,7 @@ func TestRenameInbox(t *testing.T) {
 		c.C("tag status yet/another/mailbox (messages)").Sxe("MESSAGES 100").OK("tag")
 	})
 
-	runOneToOneTestClientWithAuth(t, "user", "pass", ".", func(client *client.Client, _ *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("INBOX.foo.bar"))
 		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "INBOX.foo", "INBOX.foo.bar"})
 

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -11,28 +11,28 @@ import (
 )
 
 // runOneToOneTest runs a test with one account and one connection.
-func runOneToOneTest(tb testing.TB, username, password, delimiter string, tests func(*testConnection, *testSession)) {
-	runTest(tb, []credentials{{
-		usernames: []string{username},
-		password:  password,
-	}}, delimiter, []int{1}, func(c map[int]*testConnection, s *testSession) {
+func runOneToOneTest(tb testing.TB, options *serverOptions, tests func(*testConnection, *testSession)) {
+	runTest(tb, options, []int{1}, func(c map[int]*testConnection, s *testSession) {
 		tests(c[1], s)
 	})
 }
 
 // runOneToOneTestWithAuth runs a test with one account and one connection. The connection is logged in.
-func runOneToOneTestWithAuth(tb testing.TB, username, password, delimiter string, tests func(*testConnection, *testSession)) {
-	runOneToOneTest(tb, username, password, delimiter, func(c *testConnection, s *testSession) {
-		withTag(func(tag string) { c.Cf("%v login %v %v", tag, username, password).OK(tag) })
+func runOneToOneTestWithAuth(tb testing.TB, options *serverOptions, tests func(*testConnection, *testSession)) {
+	runOneToOneTest(tb, options, func(c *testConnection, s *testSession) {
+		withTag(func(tag string) {
+			c.Cf("%v login %v %v", tag, options.defaultUsername(), options.defaultUserPassword()).OK(tag)
+		})
 
 		tests(c, s)
 	})
 }
 
 // runOneToOneTestWithData runs a test with one account and one connection. A mailbox is created with test data.
-func runOneToOneTestWithData(tb testing.TB, username, password, delimiter string, tests func(*testConnection, *testSession, string, string)) {
-	runOneToOneTestWithAuth(tb, username, password, delimiter, func(c *testConnection, s *testSession) {
-		withData(s, username, func(mbox, mboxID string) {
+func runOneToOneTestWithData(tb testing.TB, options *serverOptions,
+	tests func(*testConnection, *testSession, string, string)) {
+	runOneToOneTestWithAuth(tb, options, func(c *testConnection, s *testSession) {
+		withData(s, options.defaultUsername(), func(mbox, mboxID string) {
 			withTag(func(tag string) { c.Cf("%v select %v", tag, mbox).OK(tag) })
 
 			tests(c, s, mbox, mboxID)
@@ -41,20 +41,20 @@ func runOneToOneTestWithData(tb testing.TB, username, password, delimiter string
 }
 
 // runManyToOneTest runs a test with one account and multiple connections.
-func runManyToOneTest(tb testing.TB, username, password, delimiter string, connIDs []int, tests func(map[int]*testConnection, *testSession)) {
-	runTest(tb, []credentials{{
-		usernames: []string{username},
-		password:  password,
-	}}, delimiter, connIDs, func(c map[int]*testConnection, s *testSession) {
+func runManyToOneTest(tb testing.TB, options *serverOptions, connIDs []int, tests func(map[int]*testConnection, *testSession)) {
+	runTest(tb, options, connIDs, func(c map[int]*testConnection, s *testSession) {
 		tests(c, s)
 	})
 }
 
 // runManyToOneTestWithAuth runs a test with one account and multiple connections. Each connection is logged in.
-func runManyToOneTestWithAuth(tb testing.TB, username, password, delimiter string, connIDs []int, tests func(map[int]*testConnection, *testSession)) {
-	runManyToOneTest(tb, username, password, delimiter, connIDs, func(c map[int]*testConnection, s *testSession) {
+func runManyToOneTestWithAuth(tb testing.TB, options *serverOptions,
+	connIDs []int, tests func(map[int]*testConnection, *testSession)) {
+	runManyToOneTest(tb, options, connIDs, func(c map[int]*testConnection, s *testSession) {
 		for _, c := range c {
-			withTag(func(tag string) { c.Cf("%v login %v %v", tag, username, password).OK(tag) })
+			withTag(func(tag string) {
+				c.Cf("%v login %v %v", tag, options.defaultUsername(), options.defaultUserPassword()).OK(tag)
+			})
 		}
 
 		tests(c, s)
@@ -62,9 +62,10 @@ func runManyToOneTestWithAuth(tb testing.TB, username, password, delimiter strin
 }
 
 // runManyToOneTestWithData runs a test with one account and multiple connections. A mailbox is created with test data.
-func runManyToOneTestWithData(tb testing.TB, username, password, delimiter string, connIDs []int, tests func(map[int]*testConnection, *testSession, string, string)) {
-	runManyToOneTestWithAuth(tb, username, password, delimiter, connIDs, func(c map[int]*testConnection, s *testSession) {
-		withData(s, username, func(mbox, mboxID string) {
+func runManyToOneTestWithData(tb testing.TB, options *serverOptions,
+	connIDs []int, tests func(map[int]*testConnection, *testSession, string, string)) {
+	runManyToOneTestWithAuth(tb, options, connIDs, func(c map[int]*testConnection, s *testSession) {
+		withData(s, options.defaultUsername(), func(mbox, mboxID string) {
 			for _, c := range c {
 				withTag(func(tag string) { c.Cf("%v select %v", tag, mbox).OK(tag) })
 			}
@@ -75,8 +76,8 @@ func runManyToOneTestWithData(tb testing.TB, username, password, delimiter strin
 }
 
 // runTest runs the mailserver and creates test connections to it.
-func runTest(tb testing.TB, creds []credentials, delimiter string, connIDs []int, tests func(map[int]*testConnection, *testSession)) {
-	runServer(tb, creds, delimiter, func(s *testSession) {
+func runTest(tb testing.TB, options *serverOptions, connIDs []int, tests func(map[int]*testConnection, *testSession)) {
+	runServer(tb, options, func(s *testSession) {
 		withConnections(tb, s, connIDs, func(c map[int]*testConnection) {
 			tests(c, s)
 		})
@@ -86,8 +87,8 @@ func runTest(tb testing.TB, creds []credentials, delimiter string, connIDs []int
 // -- IMAP client test helpers
 
 // runTestClient runs the mailserver and creates test connections to it using an imap client.
-func runTestClient(tb testing.TB, creds []credentials, delimiter string, connIDs []int, tests func(map[int]*client.Client, *testSession)) {
-	runServer(tb, creds, delimiter, func(s *testSession) {
+func runTestClient(tb testing.TB, options *serverOptions, connIDs []int, tests func(map[int]*client.Client, *testSession)) {
+	runServer(tb, options, func(s *testSession) {
 		withClients(tb, s, connIDs, func(clientMap map[int]*client.Client) {
 			tests(clientMap, s)
 		})
@@ -95,27 +96,24 @@ func runTestClient(tb testing.TB, creds []credentials, delimiter string, connIDs
 }
 
 // runOneToOneTestClient runs a test with one account and one connection using an imap client.
-func runOneToOneTestClient(tb testing.TB, username, password, delimiter string, test func(*client.Client, *testSession)) {
-	runTestClient(tb, []credentials{{
-		usernames: []string{username},
-		password:  password,
-	}}, delimiter, []int{1}, func(c map[int]*client.Client, s *testSession) {
+func runOneToOneTestClient(tb testing.TB, options *serverOptions, test func(*client.Client, *testSession)) {
+	runTestClient(tb, options, []int{1}, func(c map[int]*client.Client, s *testSession) {
 		test(c[1], s)
 	})
 }
 
 // runOneToOneTestClientWithAuth runs a test with one account and one connection using an imap client. The connection is logged in.
-func runOneToOneTestClientWithAuth(tb testing.TB, username, password, delimiter string, test func(*client.Client, *testSession)) {
-	runOneToOneTestClient(tb, username, password, delimiter, func(client *client.Client, s *testSession) {
-		require.NoError(tb, client.Login(username, password))
+func runOneToOneTestClientWithAuth(tb testing.TB, options *serverOptions, test func(*client.Client, *testSession)) {
+	runOneToOneTestClient(tb, options, func(client *client.Client, s *testSession) {
+		require.NoError(tb, client.Login(options.defaultUsername(), options.defaultUserPassword()))
 		test(client, s)
 	})
 }
 
 // runOneToOneTestClientWithData runs a test with one account and one connection using an imap client. A mailbox is created with test data.
-func runOneToOneTestClientWithData(tb testing.TB, username, password, delimiter string, test func(*client.Client, *testSession, string, string)) {
-	runOneToOneTestClientWithAuth(tb, username, password, delimiter, func(client *client.Client, s *testSession) {
-		withData(s, username, func(mbox, mboxID string) {
+func runOneToOneTestClientWithData(tb testing.TB, options *serverOptions, test func(*client.Client, *testSession, string, string)) {
+	runOneToOneTestClientWithAuth(tb, options, func(client *client.Client, s *testSession) {
+		withData(s, options.defaultUsername(), func(mbox, mboxID string) {
 			_, err := client.Select(mbox, false)
 			require.NoError(s.tb, err)
 			test(client, s, mbox, mboxID)

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestSearchCharSet(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C("A001 search CHARSET UTF-8 TEXT foo")
 		c.S("* SEARCH 75")
 		c.OK("A001")
@@ -14,14 +14,14 @@ func TestSearchCharSet(t *testing.T) {
 
 // TODO: GOMSRV-184 .
 func _TestSearchCharSetInvalid(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C("A001 search CHARSET invalid-charset TEXT foo")
 		c.NO("A001")
 	})
 }
 
 func TestSearchAll(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C("A001 search all")
 		c.S("* SEARCH " + seq(1, 100))
 		c.OK("A001")
@@ -29,7 +29,7 @@ func TestSearchAll(t *testing.T) {
 }
 
 func TestSearchAnswered(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as answered.
 		c.C(`A001 STORE 10,20,30,40,50 +FLAGS (\Answered)`).OK("A001")
 
@@ -41,7 +41,7 @@ func TestSearchAnswered(t *testing.T) {
 }
 
 func TestSearchBcc(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search bcc "dovecot@procontrol.fi"`)
 		c.S("* SEARCH 49 50")
 		c.OK("A001")
@@ -49,13 +49,13 @@ func TestSearchBcc(t *testing.T) {
 }
 
 func TestSearchBefore(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// GOMSRV-132: Implement test.
 	})
 }
 
 func TestSearchBody(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search body "Content-Length saves just the size of mail body"`)
 		c.S("* SEARCH 50")
 		c.OK("A001")
@@ -63,7 +63,7 @@ func TestSearchBody(t *testing.T) {
 }
 
 func TestSearchCc(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search cc "Dovecot Mailinglist <dovecot@procontrol.fi>"`)
 		c.S("* SEARCH 53 55 60")
 		c.OK("A001")
@@ -71,7 +71,7 @@ func TestSearchCc(t *testing.T) {
 }
 
 func TestSearchDeleted(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as deleted.
 		c.C(`A001 STORE 10,20,30,40,50 +FLAGS (\Deleted)`).OK("A001")
 
@@ -83,7 +83,7 @@ func TestSearchDeleted(t *testing.T) {
 }
 
 func TestSearchDraft(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as draft.
 		c.C(`A001 STORE 10,20,30,40,50 +FLAGS (\Draft)`).OK("A001")
 
@@ -95,7 +95,7 @@ func TestSearchDraft(t *testing.T) {
 }
 
 func TestSearchFlagged(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as flagged.
 		c.C(`A001 STORE 10,20,30,40,50 +FLAGS (\Flagged)`).OK("A001")
 
@@ -107,7 +107,7 @@ func TestSearchFlagged(t *testing.T) {
 }
 
 func TestSearchFrom(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search from "\"Vanessa Lintner\" <reply@seekercenter.net>"`)
 		c.S("* SEARCH 5")
 		c.OK("A001")
@@ -119,7 +119,7 @@ func TestSearchFrom(t *testing.T) {
 }
 
 func TestSearchHeader(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search header Message-ID "<20020723193923.J22431@irccrew.org>"`)
 		c.S("* SEARCH 1")
 		c.OK("A001")
@@ -135,7 +135,7 @@ func TestSearchHeader(t *testing.T) {
 }
 
 func TestSearchKeyword(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as with a custom flag.
 		c.C(`A001 STORE 10,20,30,40,50 +FLAGS (my-special-flag)`).OK("A001")
 
@@ -147,7 +147,7 @@ func TestSearchKeyword(t *testing.T) {
 }
 
 func TestSearchLarger(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C("A001 search larger 9500")
 		c.S("* SEARCH 47 48")
 		c.OK("A001")
@@ -155,7 +155,7 @@ func TestSearchLarger(t *testing.T) {
 }
 
 func TestSearchNew(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially all messages are recent and none are seen. Thus they are all new.
 		c.C("A001 search new")
 		c.S("* SEARCH " + seq(1, 100))
@@ -172,7 +172,7 @@ func TestSearchNew(t *testing.T) {
 }
 
 func TestSearchNot(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as deleted.
 		c.C(`A001 STORE 50:* +FLAGS (\Deleted)`).OK("A001")
 
@@ -189,7 +189,7 @@ func TestSearchNot(t *testing.T) {
 }
 
 func TestSearchOld(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially all messages are recent so none are old.
 		c.C("A001 search old")
 		c.S("* SEARCH")
@@ -218,13 +218,13 @@ func TestSearchOld(t *testing.T) {
 }
 
 func TestSearchOn(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// GOMSRV-132: Implement test.
 	})
 }
 
 func TestSearchOr(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as deleted.
 		c.C(`A001 STORE 1:30 +FLAGS (\Deleted)`).OK("A001")
 
@@ -262,7 +262,7 @@ func TestSearchOr(t *testing.T) {
 }
 
 func TestSearchRecent(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially all messages are recent.
 		c.C("A001 search recent")
 		c.S("* SEARCH " + seq(1, 100))
@@ -287,7 +287,7 @@ func TestSearchRecent(t *testing.T) {
 }
 
 func TestSearchSeen(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially no messages are seen.
 		c.C("A001 search seen")
 		c.S("* SEARCH")
@@ -304,7 +304,7 @@ func TestSearchSeen(t *testing.T) {
 }
 
 func TestSearchSentBefore(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search sentbefore 10-Aug-2002`)
 		c.S("* SEARCH " + seq(1, 19))
 		c.OK("A001")
@@ -312,7 +312,7 @@ func TestSearchSentBefore(t *testing.T) {
 }
 
 func TestSearchSentOn(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search senton 22-Aug-2002`)
 		c.S("* SEARCH 21")
 		c.OK("A001")
@@ -320,7 +320,7 @@ func TestSearchSentOn(t *testing.T) {
 }
 
 func TestSearchSentSince(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search sentsince 13-Nov-2002`)
 		c.S("* SEARCH " + seq(93, 100))
 		c.OK("A001")
@@ -328,13 +328,13 @@ func TestSearchSentSince(t *testing.T) {
 }
 
 func TestSearchSince(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// GOMSRV-132: Implement test.
 	})
 }
 
 func TestSearchSmaller(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C("A001 search smaller 1250")
 		c.S("* SEARCH 1 8 83")
 		c.OK("A001")
@@ -342,7 +342,7 @@ func TestSearchSmaller(t *testing.T) {
 }
 
 func TestSearchSubject(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search subject "first test mail"`)
 		c.S("* SEARCH 1")
 		c.OK("A001")
@@ -358,7 +358,7 @@ func TestSearchSubject(t *testing.T) {
 }
 
 func TestSearchText(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Search something from the header.
 		c.C(`A001 search text "Message-ID: <006701c24183$c7f10d60$0200a8c0@eero>"`)
 		c.S("* SEARCH 20")
@@ -372,7 +372,7 @@ func TestSearchText(t *testing.T) {
 }
 
 func TestSearchTo(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search to "Timo Sirainen <tss@iki.fi>"`)
 		c.S("* SEARCH 49")
 		c.OK("A001")
@@ -380,7 +380,7 @@ func TestSearchTo(t *testing.T) {
 }
 
 func TestUIDSearchTo(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Remove some messages to ensure sequence doesn't match uid
 		c.C(`A002 STORE 10,20,30,40,50 +FLAGS (\DELETED)`).OK("A002")
 		c.C(`A003 EXPUNGE`).OK("A003")
@@ -392,7 +392,7 @@ func TestUIDSearchTo(t *testing.T) {
 }
 
 func TestSearchUID(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search uid 1`)
 		c.S("* SEARCH 1")
 		c.OK("A001")
@@ -412,7 +412,7 @@ func TestSearchUID(t *testing.T) {
 }
 
 func TestSearchUIDAfterDelete(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Remove some messages to ensure sequence doesn't match uid
 		c.C(`A002 STORE 5,6,7 +FLAGS (\DELETED)`).OK("A002")
 		c.C(`A003 EXPUNGE`).OK("A003")
@@ -424,7 +424,7 @@ func TestSearchUIDAfterDelete(t *testing.T) {
 }
 
 func TestSearchUnanswered(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially, nothing is answered; everything is unanswered.
 		c.C("A001 search unanswered")
 		c.S("* SEARCH " + seq(1, 100))
@@ -446,7 +446,7 @@ func TestSearchUnanswered(t *testing.T) {
 }
 
 func TestSearchUndeleted(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially, nothing is deleted; everything is undeleted.
 		c.C("A001 search undeleted")
 		c.S("* SEARCH " + seq(1, 100))
@@ -468,7 +468,7 @@ func TestSearchUndeleted(t *testing.T) {
 }
 
 func TestSearchUndraft(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially, nothing is draft; everything is undraft.
 		c.C("A001 search undraft")
 		c.S("* SEARCH " + seq(1, 100))
@@ -490,7 +490,7 @@ func TestSearchUndraft(t *testing.T) {
 }
 
 func TestSearchUnflagged(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially, nothing is flagged; everything is unflagged.
 		c.C("A001 search unflagged")
 		c.S("* SEARCH " + seq(1, 100))
@@ -512,7 +512,7 @@ func TestSearchUnflagged(t *testing.T) {
 }
 
 func TestSearchUnkeyword(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially, nothing has a custom flag; everything is "unkeyword".
 		c.C("A001 search unkeyword my-special-flag")
 		c.S("* SEARCH " + seq(1, 100))
@@ -534,7 +534,7 @@ func TestSearchUnkeyword(t *testing.T) {
 }
 
 func TestSearchUnseen(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Initially, nothing is seen; everything is unseen.
 		c.C("A001 search unseen")
 		c.S("* SEARCH " + seq(1, 100))
@@ -556,7 +556,7 @@ func TestSearchUnseen(t *testing.T) {
 }
 
 func TestSearchSeqSet(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search 1`)
 		c.S("* SEARCH 1")
 		c.OK("A001")
@@ -576,7 +576,7 @@ func TestSearchSeqSet(t *testing.T) {
 }
 
 func TestSearchSeqSetFrom(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A001 search 1:2,4:6,30:31 from "\"Vanessa Lintner\" <reply@seekercenter.net>"`)
 		c.S("* SEARCH 5")
 		c.OK("A001")
@@ -584,7 +584,7 @@ func TestSearchSeqSetFrom(t *testing.T) {
 }
 
 func TestUIDSearchSeqSetFrom(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		c.C(`A002 STORE 1:4,10:80 +FLAGS (\DELETED)`).OK("A002")
 		c.C(`A003 EXPUNGE`).OK("A003")
 
@@ -595,7 +595,7 @@ func TestUIDSearchSeqSetFrom(t *testing.T) {
 }
 
 func TestSearchList(t *testing.T) {
-	runOneToOneTestWithData(t, "user", "pass", "/", func(c *testConnection, s *testSession, mbox, mboxID string) {
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox, mboxID string) {
 		// Set some messages as deleted.
 		c.C(`A001 STORE 1:30 +FLAGS (\Deleted)`).OK("A001")
 

--- a/tests/select_test.go
+++ b/tests/select_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestSelect(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE Archive")
 		c.S("A002 OK (^_^)")
 
@@ -46,14 +46,14 @@ func TestSelect(t *testing.T) {
 }
 
 func TestSelectNoSuchMailbox(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("a003 select What")
 		c.Sx("a003 NO .*")
 	})
 }
 
 func TestSelectUTF7(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// Test we can create a mailbox with a UTF-7 name.
 		c.C("A003 CREATE &ZeVnLIqe-").OK("A003")
 

--- a/tests/sequence_range_test.go
+++ b/tests/sequence_range_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestSequenceRange(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("a001 CREATE mbox1")
 		c.S("a001 OK (^_^)")
 		c.C("a002 CREATE mbox2")
@@ -65,7 +65,7 @@ func TestSequenceRange(t *testing.T) {
 }
 
 func TestUIDSequenceRange(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// UID based operation will send an OK response for any grammatically valid UID sequence set
 		// if no message match the UID sequence set, the operations simply return OK with no untagged response before.
 

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -46,11 +46,12 @@ type Connector interface {
 type testSession struct {
 	tb testing.TB
 
-	listener    net.Listener
-	server      *gluon.Server
-	userIDs     map[string]string
-	conns       map[string]Connector
-	userDBPaths map[string]string
+	listener      net.Listener
+	server        *gluon.Server
+	userIDs       map[string]string
+	conns         map[string]Connector
+	userDBPaths   map[string]string
+	serverOptions *serverOptions
 }
 
 func newTestSession(
@@ -60,14 +61,16 @@ func newTestSession(
 	userIDs map[string]string,
 	conns map[string]Connector,
 	userDBPaths map[string]string,
+	options *serverOptions,
 ) *testSession {
 	return &testSession{
-		tb:          tb,
-		listener:    listener,
-		server:      server,
-		userIDs:     userIDs,
-		conns:       conns,
-		userDBPaths: userDBPaths,
+		tb:            tb,
+		listener:      listener,
+		server:        server,
+		userIDs:       userIDs,
+		conns:         conns,
+		userDBPaths:   userDBPaths,
+		serverOptions: options,
 	}
 }
 

--- a/tests/starttls_test.go
+++ b/tests/starttls_test.go
@@ -3,7 +3,7 @@ package tests
 import "testing"
 
 func TestStartTLS(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		c.C("A001 starttls")
 		c.S("A001 OK (^_^) Begin TLS negotiation now")
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -46,7 +46,7 @@ var (
 )
 
 func TestErrorsWhenAuthenticated(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		for i, command := range notAuthenticatedCommands {
 			c.C(fmt.Sprintf("%d %v", i, command))
 			c.Sx(fmt.Sprintf("%d BAD %v", i, session.ErrAlreadyAuthenticated))
@@ -55,7 +55,7 @@ func TestErrorsWhenAuthenticated(t *testing.T) {
 }
 
 func TestErrorsWhenNotAuthenticated(t *testing.T) {
-	runOneToOneTest(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		for i, command := range append(authenticatedCommands, selectedCommands...) {
 			c.C(fmt.Sprintf("%d %v", i, command))
 			c.Sx(fmt.Sprintf("%d NO %v", i, session.ErrNotAuthenticated))
@@ -70,7 +70,7 @@ func TestErrorsWhenNotAuthenticated(t *testing.T) {
 }
 
 func TestErrorsWhenNotSelected(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		for i, command := range selectedCommands {
 			c.C(fmt.Sprintf("%d %v", i, command))
 			c.Sx(fmt.Sprintf("%d NO %v", i, backend.ErrSessionNotSelected))

--- a/tests/status_test.go
+++ b/tests/status_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestStatus(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", ".", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("B001 CREATE blurdybloop")
 		c.S("B001 OK (^_^)")
 

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
 		c.S("b001 OK (^_^)")
 
@@ -54,7 +54,7 @@ func TestStore(t *testing.T) {
 }
 
 func TestStoreSilent(t *testing.T) {
-	runManyToOneTestWithAuth(t, "user", "pass", "/", []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// one message in INBOX
 		c[1].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
@@ -113,7 +113,7 @@ func TestStoreSilent(t *testing.T) {
 }
 
 func TestUIDStore(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
 		c.S("b001 OK (^_^)")
 
@@ -162,7 +162,7 @@ func TestUIDStore(t *testing.T) {
 }
 
 func TestFlagsDuplicateAndCaseInsensitive(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
 		c.C(`A001 SELECT INBOX`)

--- a/tests/subscribe_test.go
+++ b/tests/subscribe_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", ".", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE #news.comp.mail.mime")
 		c.S("A002 OK (^_^)")
 

--- a/tests/unselect_test.go
+++ b/tests/unselect_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUnselect(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
 		c.S("b001 OK (^_^)")
 

--- a/tests/unsubscribe_test.go
+++ b/tests/unsubscribe_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUnsubscribe(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", ".", func(c *testConnection, _ *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE #news.comp.mail.mime")
 		c.S("A002 OK (^_^)")
 

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMessageCreatedUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		// Create a mailbox for the test to run in.
 		mboxID := s.mailboxCreated("user", []string{"mbox"})
 
@@ -40,7 +40,7 @@ func TestMessageCreatedUpdate(t *testing.T) {
 }
 
 func TestMessageCreatedNoopUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		// Create a mailbox for the test to run in.
 		other := s.mailboxCreated("user", []string{"other"})
 
@@ -75,7 +75,7 @@ func TestMessageCreatedNoopUpdate(t *testing.T) {
 }
 
 func TestMessageCreatedIDLEUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		// Create a mailbox for the test to run in.
 		other := s.mailboxCreated("user", []string{"other"})
 
@@ -118,7 +118,7 @@ func TestMessageCreatedIDLEUpdate(t *testing.T) {
 }
 
 func TestMessageRemovedUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		// Create a mailbox for the test to run in.
 		mboxID := s.mailboxCreated("user", []string{"mbox"})
 
@@ -183,7 +183,7 @@ func TestMessageRemovedUpdate(t *testing.T) {
 }
 
 func TestMessageRemovedUpdateRepeated(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		// Create a mailbox for the test to run in.
 		mboxID := s.mailboxCreated("user", []string{"mbox"})
 
@@ -206,7 +206,7 @@ func TestMessageRemovedUpdateRepeated(t *testing.T) {
 }
 
 func TestMailboxCreatedUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		c.C(`A82 LIST "" *`)
 		c.S(`* LIST (\Unmarked) "/" "INBOX"`)
 		c.S(`A82 OK (^_^)`)
@@ -221,7 +221,7 @@ func TestMailboxCreatedUpdate(t *testing.T) {
 }
 
 func TestMessageSeenUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		mailboxID := s.mailboxCreated("user", []string{"mbox"})
 		messageID := s.messageCreatedFromFile("user", mailboxID, "testdata/multipart-mixed.eml")
 
@@ -246,7 +246,7 @@ func TestMessageSeenUpdate(t *testing.T) {
 }
 
 func TestMessageFlaggedUpdate(t *testing.T) {
-	runOneToOneTestWithAuth(t, "user", "pass", "/", func(c *testConnection, s *testSession) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		mailboxID := s.mailboxCreated("user", []string{"mbox"})
 		messageID := s.messageCreatedFromFile("user", mailboxID, "testdata/multipart-mixed.eml")
 


### PR DESCRIPTION
This patch refactors the test code so that tests can simulate multiple
tests runs with persistent data. You can now run multiple successive
invocations of `runTest` and friend and the data will persist provide
you use a fixed `pathGenerator`. See `TestMessageErasedFromDBOnStartup`
as an example.

Finally, the test invocations have been refactor to accept a
`serverOptions` type so that any future changes to the server startup
can be made without having to rewrite all the helpers.