### PR TITLE
test(GODT-1615): Add more tests to trigger SQL error & Improve fix

### DIFF
--- a/tests/benchmark_big_mailbox_test.go
+++ b/tests/benchmark_big_mailbox_test.go
@@ -2,19 +2,68 @@ package tests
 
 import (
 	"fmt"
+	goimap "github.com/emersion/go-imap"
+	"github.com/emersion/go-imap/client"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func BenchmarkBigMailboxStatus(b *testing.B) {
-	b.Run("status", func(b *testing.B) {
-		runOneToOneTestWithAuth(b, defaultServerOptions(b), func(c *testConnection, s *testSession) {
-			mboxID := s.mailboxCreated("user", []string{"mbox"})
+	runOneToOneTestWithAuth(b, defaultServerOptions(b), func(c *testConnection, s *testSession) {
+		mboxID := s.mailboxCreated("user", []string{"mbox"})
 
-			ids := s.batchMessageCreated("user", mboxID, 32515, func(n int) ([]byte, []string) {
-				return []byte(fmt.Sprintf(`To: %v@pm.me`, n)), []string{}
-			})
+		ids := s.batchMessageCreated("user", mboxID, 32515, func(n int) ([]byte, []string) {
+			return []byte(fmt.Sprintf(`To: %v@pm.me`, n)), []string{}
+		})
 
+		b.Run("status", func(b *testing.B) {
 			c.Cf(`A001 STATUS %v (MESSAGES)`, "mbox").Sx(fmt.Sprintf(`MESSAGES %v`, len(ids))).OK(`A001`)
 		})
+	})
+}
+
+func BenchmarkBigMailboxFetchSequence(b *testing.B) {
+	runOneToOneTestClientWithAuth(b, defaultServerOptions(b), func(client *client.Client, s *testSession) {
+		mboxID := s.mailboxCreated("user", []string{"mbox"})
+
+		ids := s.batchMessageCreated("user", mboxID, 128515, func(n int) ([]byte, []string) {
+			return []byte(fmt.Sprintf(`To: %v@pm.me`, n)), []string{}
+		})
+
+		_, err := client.Select("mbox", false)
+		require.NoError(b, err)
+
+		fetchResult := newFetchCommand(b, client).withItems(goimap.FetchAll).fetch("1:*")
+
+		if len(fetchResult.messages) != len(ids) {
+			panic("Fetch failed")
+		}
+	})
+}
+
+func BenchmarkBigMailboxFetchUID(b *testing.B) {
+	runOneToOneTestClientWithAuth(b, defaultServerOptions(b), func(client *client.Client, s *testSession) {
+		mboxID := s.mailboxCreated("user", []string{"mbox"})
+
+		ids := s.batchMessageCreated("user", mboxID, 128515, func(n int) ([]byte, []string) {
+			return []byte(fmt.Sprintf(`To: %v@pm.me`, n)), []string{}
+		})
+
+		_, err := client.Select("mbox", false)
+		require.NoError(b, err)
+
+		fetchResult := newFetchCommand(b, client).withItems(goimap.FetchAll).fetchUid("1:*")
+
+		if len(fetchResult.messages) != len(ids) {
+			panic("Fetch failed")
+		}
+	})
+}
+
+func BenchmarkListManyMailboxes(b *testing.B) {
+	runOneToOneTestClientWithAuth(b, defaultServerOptions(b), func(client *client.Client, s *testSession) {
+		s.batchMailboxCreated("user", 64515, func(i int) string { return fmt.Sprintf("mbox_%v", i) })
+
+		listMailboxesClient(b, client, "", "*")
 	})
 }

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -132,6 +132,28 @@ func (s *testSession) mailboxCreated(user string, name []string, withData ...str
 	return mboxID
 }
 
+func (s *testSession) batchMailboxCreated(user string, count int, mailboxNameGen func(number int) string) []string {
+	var mboxIDs []string
+
+	for i := 0; i < count; i++ {
+		mboxID := utils.NewRandomLabelID()
+
+		require.NoError(s.tb, s.conns[s.userIDs[user]].MailboxCreated(imap.Mailbox{
+			ID:             mboxID,
+			Name:           []string{mailboxNameGen(i)},
+			Flags:          defaultFlags,
+			PermanentFlags: defaultPermanentFlags,
+			Attributes:     defaultAttributes,
+		}))
+
+		mboxIDs = append(mboxIDs, mboxID)
+	}
+
+	s.conns[s.userIDs[user]].Flush()
+
+	return mboxIDs
+}
+
 func (s *testSession) mailboxCreatedCustom(user string, name []string, flags, permFlags, attrs imap.FlagSet) string {
 	mboxID := utils.NewRandomLabelID()
 


### PR DESCRIPTION
The previous pagination fix was not the most optimal possible. After
consulting with a database expert, if we sort the results by the row ID
and use a clause where the row ID is greater to the offset we are
currently evaluating, we can get better DB performance.

This patch also adds more tests to find other potential locations which
may trigger this error.

Finally we also fixed the error present in the listing of mailboxes.