### PR TITLE
fix: Don't split Body into parts if there are none

### DIFF
--- a/internal/backend/mailbox_fetch.go
+++ b/internal/backend/mailbox_fetch.go
@@ -219,6 +219,10 @@ func (m *Mailbox) fetchBodySection(section *proto.BodySection, literal []byte) (
 		root = root.Part(parts...)
 	}
 
+	if root == nil {
+		return nil, fmt.Errorf("Invalid Section Part")
+	}
+
 	switch keyword := section.OptionalKeyword.(type) {
 	case *proto.BodySection_Keyword:
 		// HEADER and TEXT keywords should handle embedded message/rfc822 parts!

--- a/rfc822/parser.go
+++ b/rfc822/parser.go
@@ -57,7 +57,15 @@ func (section *Section) Children() []*Section {
 
 func (section *Section) Part(identifier ...int) *Section {
 	if len(identifier) > 0 {
-		return section.Children()[identifier[0]-1].Part(identifier[1:]...)
+		children := section.Children()
+
+		if identifier[0] <= 0 || identifier[0]-1 > len(children) {
+			return nil
+		}
+
+		if len(children) != 0 {
+			return children[identifier[0]-1].Part(identifier[1:]...)
+		}
 	}
 
 	return section


### PR DESCRIPTION
Fix crash that occurred by attempting to access children parts that were
not present. Issue was discovered through Dovecot's IMAP tests. A new
unit test was added to check for this as well.