### PR TITLE
fix(GOMSRV-128): Remover server personality

### DIFF
--- a/internal/response/bad.go
+++ b/internal/response/bad.go
@@ -35,10 +35,6 @@ func (r *bad) String() string {
 		parts = append(parts, r.err.Error())
 	}
 
-	if r.tag != "*" {
-		parts = append(parts, faceBad)
-	}
-
 	return join(parts)
 }
 

--- a/internal/response/bad_test.go
+++ b/internal/response/bad_test.go
@@ -12,9 +12,9 @@ func TestBadUntagged(t *testing.T) {
 }
 
 func TestBadTagged(t *testing.T) {
-	assert.Equal(t, "tag BAD (>_<)", Bad("tag").String())
+	assert.Equal(t, "tag BAD", Bad("tag").String())
 }
 
 func TestBadError(t *testing.T) {
-	assert.Equal(t, "tag BAD erroooooor (>_<)", Bad("tag").WithError(errors.New("erroooooor")).String())
+	assert.Equal(t, "tag BAD erroooooor", Bad("tag").WithError(errors.New("erroooooor")).String())
 }

--- a/internal/response/bye.go
+++ b/internal/response/bye.go
@@ -18,7 +18,7 @@ func (r *bye) Send(s Session) error {
 }
 
 func (r *bye) String() string {
-	parts := []string{"*", "BYE", faceBye}
+	parts := []string{"*", "BYE"}
 
 	if r.msg != "" {
 		parts = append(parts, r.msg)

--- a/internal/response/bye_test.go
+++ b/internal/response/bye_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestBye(t *testing.T) {
-	assert.Equal(t, "* BYE (^_^)/~", Bye().String())
+	assert.Equal(t, "* BYE", Bye().String())
 }
 
 func TestByeMessage(t *testing.T) {
-	assert.Equal(t, "* BYE (^_^)/~ message", Bye().WithMessage("message").String())
+	assert.Equal(t, "* BYE message", Bye().WithMessage("message").String())
 }

--- a/internal/response/continuation.go
+++ b/internal/response/continuation.go
@@ -1,5 +1,7 @@
 package response
 
+import "strings"
+
 type continuation struct {
 	tag string
 }
@@ -15,5 +17,5 @@ func (r *continuation) Send(s Session) error {
 }
 
 func (r *continuation) String() string {
-	return join([]string{r.tag, faceCon})
+	return strings.Join([]string{r.tag, "Ready"}, " ")
 }

--- a/internal/response/continuation_test.go
+++ b/internal/response/continuation_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestContinuation(t *testing.T) {
-	assert.Equal(t, "+ (*_*)", Continuation().String())
+	assert.Equal(t, "+ Ready", Continuation().String())
 }

--- a/internal/response/format.go
+++ b/internal/response/format.go
@@ -2,14 +2,6 @@ package response
 
 import "strings"
 
-const (
-	faceOk  = "(^_^)"
-	faceNo  = "(~_~)"
-	faceBad = "(>_<)"
-	faceBye = "(^_^)/~"
-	faceCon = "(*_*)"
-)
-
 func join(items []string, withDel ...string) string {
 	var del string
 

--- a/internal/response/no.go
+++ b/internal/response/no.go
@@ -53,10 +53,6 @@ func (r *no) String() (res string) {
 		parts = append(parts, r.err.Error())
 	}
 
-	if r.tag != "*" {
-		parts = append(parts, faceNo)
-	}
-
 	return join(parts)
 }
 

--- a/internal/response/no_test.go
+++ b/internal/response/no_test.go
@@ -12,13 +12,13 @@ func TestNoUntagged(t *testing.T) {
 }
 
 func TestNoTagged(t *testing.T) {
-	assert.Equal(t, "tag NO (~_~)", No("tag").String())
+	assert.Equal(t, "tag NO", No("tag").String())
 }
 
 func TestNoError(t *testing.T) {
-	assert.Equal(t, "tag NO erroooooor (~_~)", No("tag").WithError(errors.New("erroooooor")).String())
+	assert.Equal(t, "tag NO erroooooor", No("tag").WithError(errors.New("erroooooor")).String())
 }
 
 func TestNoTryCreate(t *testing.T) {
-	assert.Equal(t, "tag NO [TRYCREATE] erroooooor (~_~)", No("tag").WithItems(ItemTryCreate()).WithError(errors.New("erroooooor")).String())
+	assert.Equal(t, "tag NO [TRYCREATE] erroooooor", No("tag").WithItems(ItemTryCreate()).WithError(errors.New("erroooooor")).String())
 }

--- a/internal/response/ok.go
+++ b/internal/response/ok.go
@@ -51,10 +51,6 @@ func (r *ok) String() string {
 		parts = append(parts, fmt.Sprintf("[%v]", join(items)))
 	}
 
-	if r.tag != "*" {
-		parts = append(parts, faceOk)
-	}
-
 	if r.msg != "" {
 		parts = append(parts, r.msg)
 	}

--- a/internal/response/ok_test.go
+++ b/internal/response/ok_test.go
@@ -13,7 +13,7 @@ func TestOkUntagged(t *testing.T) {
 }
 
 func TestOkTagged(t *testing.T) {
-	assert.Equal(t, `tag OK (^_^)`, Ok("tag").String())
+	assert.Equal(t, `tag OK`, Ok("tag").String())
 }
 
 func TestOkUnseen(t *testing.T) {

--- a/internal/session/handle_capability.go
+++ b/internal/session/handle_capability.go
@@ -13,7 +13,7 @@ func (s *Session) handleCapability(ctx context.Context, tag string, cmd *proto.C
 
 	ch <- response.Capability().WithCapabilities(s.caps...)
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("CAPABILITY")
 
 	return nil
 }

--- a/internal/session/handle_check.go
+++ b/internal/session/handle_check.go
@@ -13,7 +13,7 @@ func (s *Session) handleCheck(ctx context.Context, tag string, cmd *proto.Check,
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("CHECK")
 
 	return nil
 }

--- a/internal/session/handle_close.go
+++ b/internal/session/handle_close.go
@@ -28,7 +28,7 @@ func (s *Session) handleClose(ctx context.Context, tag string, cmd *proto.Close,
 
 	s.name = ""
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("CLOSE")
 
 	return nil
 }

--- a/internal/session/handle_create.go
+++ b/internal/session/handle_create.go
@@ -24,7 +24,7 @@ func (s *Session) handleCreate(ctx context.Context, tag string, cmd *proto.Creat
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("CREATE")
 
 	return nil
 }

--- a/internal/session/handle_delete.go
+++ b/internal/session/handle_delete.go
@@ -24,7 +24,7 @@ func (s *Session) handleDelete(ctx context.Context, tag string, cmd *proto.Del, 
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("DELETE")
 
 	return nil
 }

--- a/internal/session/handle_examine.go
+++ b/internal/session/handle_examine.go
@@ -50,7 +50,7 @@ func (s *Session) handleExamine(ctx context.Context, tag string, cmd *proto.Exam
 		return err
 	}
 
-	ch <- response.Ok(tag).WithItems(response.ItemReadOnly())
+	ch <- response.Ok(tag).WithItems(response.ItemReadOnly()).WithMessage("EXAMINE")
 
 	return nil
 }

--- a/internal/session/handle_expunge.go
+++ b/internal/session/handle_expunge.go
@@ -21,7 +21,7 @@ func (s *Session) handleExpunge(ctx context.Context, tag string, cmd *proto.Expu
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("EXPUNGE")
 
 	return nil
 }
@@ -41,7 +41,7 @@ func (s *Session) handleUIDExpunge(ctx context.Context, tag string, cmd *proto.U
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("EXPUNGE")
 
 	return nil
 }

--- a/internal/session/handle_id.go
+++ b/internal/session/handle_id.go
@@ -17,7 +17,7 @@ func prepareServerResponse(info *internal.VersionInfo) response.Response {
 
 func (s *Session) handleIDGet(ctx context.Context, tag string, ch chan response.Response) error {
 	ch <- prepareServerResponse(s.version)
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("ID")
 
 	return nil
 }
@@ -34,7 +34,7 @@ func (s *Session) handleIDSet(ctx context.Context, tag string, cmd *proto.IDSet,
 	}
 
 	ch <- prepareServerResponse(s.version)
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("ID")
 
 	return nil
 }

--- a/internal/session/handle_idle.go
+++ b/internal/session/handle_idle.go
@@ -59,7 +59,7 @@ func (s *Session) handleIdle(ctx context.Context, tag string, cmd *proto.Idle, c
 
 			switch {
 			case cmd.GetDone() != nil:
-				return response.Ok(tag).Send(s)
+				return response.Ok(tag).WithMessage("IDLE").Send(s)
 
 			default:
 				return response.Bad(tag).Send(s)

--- a/internal/session/handle_list.go
+++ b/internal/session/handle_list.go
@@ -29,7 +29,7 @@ func (s *Session) handleList(ctx context.Context, tag string, cmd *proto.List, c
 				WithAttributes(match.Atts)
 		}
 
-		ch <- response.Ok(tag)
+		ch <- response.Ok(tag).WithMessage("LIST")
 
 		return nil
 	})

--- a/internal/session/handle_logout.go
+++ b/internal/session/handle_logout.go
@@ -18,7 +18,7 @@ func (s *Session) handleLogout(ctx context.Context, tag string, cmd *proto.Logou
 		return err
 	}
 
-	if err := response.Ok(tag).Send(s); err != nil {
+	if err := response.Ok(tag).WithMessage("LOGOUT").Send(s); err != nil {
 		return err
 	}
 

--- a/internal/session/handle_lsub.go
+++ b/internal/session/handle_lsub.go
@@ -29,7 +29,7 @@ func (s *Session) handleLsub(ctx context.Context, tag string, cmd *proto.Lsub, c
 				WithAttributes(match.Atts)
 		}
 
-		ch <- response.Ok(tag)
+		ch <- response.Ok(tag).WithMessage("LSUB")
 
 		return nil
 	})

--- a/internal/session/handle_rename.go
+++ b/internal/session/handle_rename.go
@@ -29,7 +29,7 @@ func (s *Session) handleRename(ctx context.Context, tag string, cmd *proto.Renam
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("RENAME")
 
 	return nil
 }

--- a/internal/session/handle_select.go
+++ b/internal/session/handle_select.go
@@ -51,7 +51,7 @@ func (s *Session) handleSelect(ctx context.Context, tag string, cmd *proto.Selec
 		return err
 	}
 
-	ch <- response.Ok(tag).WithItems(response.ItemReadWrite())
+	ch <- response.Ok(tag).WithItems(response.ItemReadWrite()).WithMessage("SELECT")
 
 	s.eventCh <- events.EventSelect{
 		SessionID: s.sessionID,

--- a/internal/session/handle_status.go
+++ b/internal/session/handle_status.go
@@ -56,7 +56,7 @@ func (s *Session) handleStatus(ctx context.Context, tag string, cmd *proto.Statu
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("STATUS")
 
 	return nil
 }

--- a/internal/session/handle_sub.go
+++ b/internal/session/handle_sub.go
@@ -24,7 +24,7 @@ func (s *Session) handleSub(ctx context.Context, tag string, cmd *proto.Sub, ch 
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("SUB")
 
 	return nil
 }

--- a/internal/session/handle_unselect.go
+++ b/internal/session/handle_unselect.go
@@ -15,7 +15,7 @@ func (s *Session) handleUnselect(ctx context.Context, tag string, cmd *proto.Uns
 
 	s.name = ""
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("UNSELECT")
 
 	return nil
 }

--- a/internal/session/handle_unsub.go
+++ b/internal/session/handle_unsub.go
@@ -24,7 +24,7 @@ func (s *Session) handleUnsub(ctx context.Context, tag string, cmd *proto.Unsub,
 		return err
 	}
 
-	ch <- response.Ok(tag)
+	ch <- response.Ok(tag).WithMessage("UNSUBSCRIBE")
 
 	return nil
 }

--- a/tests/close_test.go
+++ b/tests/close_test.go
@@ -16,7 +16,7 @@ func TestClose(t *testing.T) {
 	// There is currently no way to check for this with the go imap client.
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 
 		c.doAppend(`saved-messages`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`saved-messages`, `To: 2@pm.me`).expect("OK")
@@ -25,7 +25,7 @@ func TestClose(t *testing.T) {
 		c.doAppend(`saved-messages`, `To: 5@pm.me`, `\Seen`).expect("OK")
 
 		c.C(`A002 SELECT saved-messages`)
-		c.Se(`A002 OK [READ-WRITE] (^_^)`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
 
 		// TODO: Match flags in any order.
 		c.C(`A003 STORE 1 +FLAGS (\Deleted)`)
@@ -42,12 +42,12 @@ func TestClose(t *testing.T) {
 
 		// TODO: GOMSRV-106 - Ensure this also works for cases where multiple clients have the same mailbox open
 		c.C(`A202 CLOSE`)
-		c.S("A202 OK (^_^)")
+		c.S("A202 OK CLOSE")
 
 		// There are 2 messages in saved-messages.
 		c.C(`A006 STATUS saved-messages (MESSAGES)`)
 		c.S(`* STATUS "saved-messages" (MESSAGES 2)`)
-		c.S(`A006 OK (^_^)`)
+		c.S(`A006 OK STATUS`)
 	})
 }
 

--- a/tests/deleted_test.go
+++ b/tests/deleted_test.go
@@ -8,67 +8,67 @@ func TestDeleted(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// Create two mailboxes.
 		c.C("b001 CREATE mbox1")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 		c.C("b001 CREATE mbox2")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 
 		// Create a message in mbox1.
 		c.doAppend(`mbox1`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`mbox1`, `To: 2@pm.me`, `\Seen`).expect("OK")
 		c.C(`A002 SELECT mbox1`)
-		c.Se(`A002 OK [READ-WRITE] (^_^)`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
 
 		// Copy messages 1 to mbox2 and flag it as deleted in mbox 1.
 		c.C(`A003 COPY 1 mbox2`)
 		c.Sx(`A003 OK .*`)
 		c.C(`A004 STORE 1 +FLAGS (\Deleted)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Recent \Seen))`)
-		c.Sx(`A004 OK .* command completed in .*`)
+		c.OK("A004")
 		c.C(`B001 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Recent \Seen))`)
-		c.Sx(`B001 OK .* command completed in`)
+		c.OK("B001")
 		c.C(`B002 FETCH 2 (FLAGS)`)
 		c.S(`* 2 FETCH (FLAGS (\Recent \Seen))`)
-		c.Sx(`B002 OK .* command completed in`)
+		c.OK("B002")
 
 		// Check that the copy in mbox2 does not have the flag \Deleted.
 		c.C(`A005 SELECT mbox2`)
 		c.Se(`* 1 EXISTS`)
-		c.Se(`A005 OK [READ-WRITE] (^_^)`)
+		c.Se(`A005 OK [READ-WRITE] SELECT`)
 		c.C(`A006 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)
-		c.Sx(`A006 OK .* command completed in .*`)
+		c.OK(`A006`)
 
 		// Expunge the copy in mbox1.
 		// The message no longer has the recent flag.
 		c.C(`A007 SELECT mbox1`)
 		c.Se(`* 2 EXISTS`)
-		c.Se(`A007 OK [READ-WRITE] (^_^)`)
+		c.Se(`A007 OK [READ-WRITE] SELECT`)
 		c.C(`A008 EXPUNGE`)
 		c.S(`* 1 EXPUNGE`)
-		c.Sx(`A008 OK .*`)
+		c.OK(`A008`)
 		c.C(`A009 STATUS mbox1 (MESSAGES)`)
 		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
-		c.S(`A009 OK (^_^)`)
+		c.OK(`A009`)
 
 		// Check that the message is still in mbox2
 		// The message no longer has the recent flag.
 		c.C(`A00A SELECT mbox2`)
 		c.Se(`* 1 EXISTS`)
-		c.Se(`A00A OK [READ-WRITE] (^_^)`)
+		c.Se(`A00A OK [READ-WRITE] SELECT`)
 
 		// Flag, unflag, expunge and check the message is still there.
 		c.C(`A00B STORE 1 +FLAGS (\Deleted)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Seen))`)
-		c.Sx(`A00B OK .* command completed in .*`)
+		c.OK(`A00B`)
 		c.C(`A00C STORE 1 -FLAGS (\Deleted)`)
 		c.S(`* 1 FETCH (FLAGS (\Seen))`)
-		c.Sx(`A00C OK .* command completed in .*`)
+		c.OK(`A00C`)
 		c.C(`A00D EXPUNGE`)
-		c.S(`A00D OK (^_^)`)
+		c.S(`A00D OK EXPUNGE`)
 		c.C(`A00E STATUS mbox1 (MESSAGES)`)
 		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
-		c.S(`A00E OK (^_^)`)
+		c.S(`A00E OK STATUS`)
 	})
 }
 
@@ -76,58 +76,58 @@ func TestUIDDeleted(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		// Create two mailboxes
 		c.C("b001 CREATE mbox1")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 		c.C("b001 CREATE mbox2")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 
 		// Create a message in mbox1
 		c.doAppend(`mbox1`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`mbox1`, `To: 2@pm.me`, `\Seen`).expect("OK")
 		c.C(`A002 SELECT mbox1`)
-		c.Se(`A002 OK [READ-WRITE] (^_^)`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
 
 		// Copy message 2 to mbox2 and flag it as deleted in mbox 1
 		c.C(`A003 UID COPY 2 mbox2`)
 		c.Sx(`A003 OK .*`)
 		c.C(`A004 UID STORE 2 +FLAGS (\Deleted)`)
 		c.S(`* 2 FETCH (FLAGS (\Deleted \Recent \Seen) UID 2)`)
-		c.Sx(`A004 OK .* command completed in .*`)
+		c.OK(`A004`)
 
 		// Check that the copy in mbox2 is does not have the flag \Deleted
 		c.C(`A005 SELECT mbox2`)
 		c.Se(`* 1 EXISTS`)
-		c.Se(`A005 OK [READ-WRITE] (^_^)`)
+		c.Se(`A005 OK [READ-WRITE] SELECT`)
 		c.C(`A006 UID FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen) UID 1)`)
-		c.Sx(`A006 OK .* command completed in .*`)
+		c.OK(`A006`)
 
 		// Expunge the copy in mbox1
 		c.C(`A007 SELECT mbox1`)
 		c.Se(`* 2 EXISTS`)
-		c.Se(`A007 OK [READ-WRITE] (^_^)`)
+		c.Se(`A007 OK [READ-WRITE] SELECT`)
 		c.C(`A008 EXPUNGE`)
 		c.S(`* 2 EXPUNGE`)
 		c.Sx(`A008 OK .*`)
 		c.C(`A009 STATUS mbox1 (MESSAGES)`)
 		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
-		c.S(`A009 OK (^_^)`)
+		c.S(`A009 OK STATUS`)
 
 		// Check that the message is still in mbox2
 		c.C(`A00A SELECT mbox2`)
 		c.Se(`* 1 EXISTS`)
-		c.Se(`A00A OK [READ-WRITE] (^_^)`)
+		c.Se(`A00A OK [READ-WRITE] SELECT`)
 
 		// Flag,unflag, expunge and check the message is still there.
 		c.C(`A00B UID STORE 1 +FLAGS (\Deleted)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Seen) UID 1)`)
-		c.Sx(`A00B OK .* command completed in .*`)
+		c.OK(`A00B`)
 		c.C(`A00C UID STORE 1 -FLAGS (\Deleted)`)
 		c.S(`* 1 FETCH (FLAGS (\Seen) UID 1)`)
-		c.Sx(`A00C OK .* command completed in .*`)
+		c.OK(`A00C`)
 		c.C(`A00D EXPUNGE`)
-		c.S(`A00D OK (^_^)`)
+		c.S(`A00D OK EXPUNGE`)
 		c.C(`A00E STATUS mbox1 (MESSAGES)`)
 		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
-		c.S(`A00E OK (^_^)`)
+		c.S(`A00E OK STATUS`)
 	})
 }

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -16,7 +16,7 @@ func TestDraftScenario(t *testing.T) {
 		c.C("A002 NOOP")
 		c.S("* 1 EXISTS")
 		c.S("* 1 RECENT")
-		c.S("A002 OK (^_^)")
+		c.S("A002 OK")
 
 		c.C("A003 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
 		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm)")
@@ -29,7 +29,7 @@ func TestDraftScenario(t *testing.T) {
 		c.S("* 1 EXPUNGE")
 		c.S("* 1 EXISTS")
 		c.S("* 1 RECENT")
-		c.S("A002 OK (^_^)")
+		c.S("A002 OK")
 
 		c.C("A003 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
 		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm)")

--- a/tests/examine_test.go
+++ b/tests/examine_test.go
@@ -15,12 +15,12 @@ func TestExamineWithLiteral(t *testing.T) {
 	// IMAP client. The rest of the functionality is still tested in the IMAP client test.
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE Archive")
-		c.S("A002 OK (^_^)")
+		c.S("A002 OK CREATE")
 
 		c.doAppend(`Archive`, `To: 3@pm.me`, `\Seen`).expect("OK")
 
 		c.C("a007 examine {7}")
-		c.S("+ (*_*)")
+		c.S("+ Ready")
 		c.C("Archive")
 		c.S(`* FLAGS (\Deleted \Flagged \Seen)`,
 			`* 1 EXISTS`,
@@ -28,7 +28,7 @@ func TestExamineWithLiteral(t *testing.T) {
 			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
 			`* OK [UIDNEXT 2]`,
 			`* OK [UIDVALIDITY 1]`)
-		c.S(`a007 OK [READ-ONLY] (^_^)`)
+		c.S(`a007 OK [READ-ONLY] EXAMINE`)
 	})
 }
 

--- a/tests/fetch_body_test.go
+++ b/tests/fetch_body_test.go
@@ -15,12 +15,12 @@ func TestFetchBodySetsSeenFlag(t *testing.T) {
 		c.doAppendFromFile(`INBOX`, `testdata/multipart-mixed.eml`).expect("OK")
 
 		c.C(`A004 SELECT INBOX`)
-		c.Se(`A004 OK [READ-WRITE] (^_^)`)
+		c.Se(`A004 OK [READ-WRITE] SELECT`)
 
 		// The message initially has no flags except the recent flag.
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK("A005")
 
 		// Fetch part of the body; the Seen flag should be implicitly set and included in the response.
 		c.C(`A005 FETCH 1 (BODY[1.1])`)
@@ -29,7 +29,7 @@ func TestFetchBodySetsSeenFlag(t *testing.T) {
 			`**`,
 			` FLAGS (\Recent \Seen))`,
 		))
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK("A005")
 
 		// We receive an untagged FETCH response indicating the flag was set.
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)
@@ -37,7 +37,7 @@ func TestFetchBodySetsSeenFlag(t *testing.T) {
 		// The message now has the seen flag.
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK("A005")
 	})
 }
 
@@ -46,12 +46,12 @@ func TestFetchBodyPeekDoesNotSetSeenFlag(t *testing.T) {
 		c.doAppendFromFile(`INBOX`, `testdata/multipart-mixed.eml`).expect("OK")
 
 		c.C(`A004 SELECT INBOX`)
-		c.Se(`A004 OK [READ-WRITE] (^_^)`)
+		c.Se(`A004 OK [READ-WRITE] SELECT`)
 
 		// The message initially has no flags other than the recent flag.
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.Sx(`A005 OK command completed in .*`)
 
 		// Fetch part of the body via BODY.PEEK; the Seen flag should NOT be implicitly set.
 		c.C(`A005 FETCH 1 (BODY.PEEK[1.1])`)
@@ -60,12 +60,12 @@ func TestFetchBodyPeekDoesNotSetSeenFlag(t *testing.T) {
 			`**`,
 			`)`,
 		))
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.Sx(`A005 OK command completed in .*`)
 
 		// The message still has no flags other than recent.
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.Sx(`A005 OK command completed in .*`)
 	})
 }
 
@@ -74,17 +74,17 @@ func TestFetchStructure(t *testing.T) {
 		c.doAppendFromFile(`INBOX`, `testdata/multipart-mixed.eml`, `\Seen`).expect("OK")
 
 		c.C(`A004 SELECT INBOX`)
-		c.Se(`A004 OK [READ-WRITE] (^_^)`)
+		c.Se(`A004 OK [READ-WRITE] SELECT`)
 
 		// TODO: Dovecot says the base64 part is 0 lines long... it's obviously 1 line long, dovecot bug?
 		c.C(`A005 FETCH 1 (BODY)`)
 		c.S(`* 1 FETCH (BODY ((("text" "plain" ("charset" "utf-8" "format" "flowed") NIL NIL "7bit" 25 2)("text" "html" ("charset" "utf-8") NIL NIL "7bit" 197 10) "alternative")("text" "plain" ("charset" "UTF-8" "name" "thing.txt" "x-mac-creator" "0" "x-mac-type" "0") NIL NIL "base64" 32 1) "mixed"))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.Sx(`A005 OK command completed in .*`)
 
 		// TODO: Dovecot says the base64 part is 0 lines long... it's obviously 1 line long, dovecot bug?
 		c.C(`A005 FETCH 1 (BODYSTRUCTURE)`)
 		c.S(`* 1 FETCH (BODYSTRUCTURE ((("text" "plain" ("charset" "utf-8" "format" "flowed") NIL NIL "7bit" 25 2 NIL NIL NIL NIL)("text" "html" ("charset" "utf-8") NIL NIL "7bit" 197 10 NIL NIL NIL NIL) "alternative" ("boundary" "------------62DCF50B21CF279F489F0184") NIL NIL NIL)("text" "plain" ("charset" "UTF-8" "name" "thing.txt" "x-mac-creator" "0" "x-mac-type" "0") NIL NIL "base64" 32 1 NIL ("attachment" ("filename" "thing.txt")) NIL NIL) "mixed" ("boundary" "------------4AC5F36D876D5EED478B5FF9") NIL "en-US" NIL))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.Sx(`A005 OK command completed in .*`)
 	})
 }
 

--- a/tests/id_test.go
+++ b/tests/id_test.go
@@ -31,7 +31,7 @@ func TestIdContextLookup(t *testing.T) {
 		// NOTE: We are only recording this with APPEND since it was the easiest command to verify the data has been
 		// record properly in the context, as APPEND will always require a communication with the remote connector.
 		c.C("A004 APPEND INBOX (\\Seen) {26}")
-		c.S("+ (*_*)")
+		c.S("+ Ready")
 		c.C("To: 00010203-0405-4607-880").OK("A004")
 
 		s.flush("user")

--- a/tests/idle_test.go
+++ b/tests/idle_test.go
@@ -8,11 +8,11 @@ func TestIDLEExistsUpdates(t *testing.T) {
 	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// First client selects in INBOX to receive EXISTS update.
 		c[1].C("A006 select INBOX")
-		c[1].Se("A006 OK [READ-WRITE] (^_^)")
+		c[1].Se("A006 OK [READ-WRITE] SELECT")
 
 		// First client starts to IDLE.
 		c[1].C("A007 IDLE")
-		c[1].S("+ (*_*)")
+		c[1].S("+ Ready")
 
 		// Second client appends to INBOX to generate EXISTS updates.
 		// The client is not selected and thus doesn't itself receive responses.
@@ -24,7 +24,7 @@ func TestIDLEExistsUpdates(t *testing.T) {
 
 		// First client stops idling.
 		c[1].C("DONE")
-		c[1].S(`A007 OK (^_^)`)
+		c[1].OK(`A007`)
 
 		// Further stuff doesn't trigger any issues.
 		c[2].doAppend(`INBOX`, `To: 3@pm.me`, `\Seen`).expect("OK")
@@ -39,7 +39,7 @@ func TestIDLEPendingUpdates(t *testing.T) {
 		c[2].C("B001 UID MOVE 1,2,3 INBOX").OK("B001")
 
 		// Begin IDLE.
-		c[1].C("A002 IDLE").S("+ (*_*)")
+		c[1].C("A002 IDLE").S("+ Ready")
 
 		// Generate some additional updates.
 		c[2].C("B002 UID MOVE 4,5,6 INBOX").OK("B002")

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -9,38 +9,38 @@ import (
 func TestList(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE #news/comp/mail/mime")
-		c.S("A002 OK (^_^)")
+		c.OK("A002")
 
 		c.C("A003 CREATE /usr/staff/jones")
-		c.S("A003 OK (^_^)")
+		c.OK("A003")
 
 		c.C("A004 CREATE ~/Mail/meetings")
-		c.S("A004 OK (^_^)")
+		c.OK("A004")
 
 		c.C("A005 CREATE ~/Mail/foo/bar")
-		c.S("A005 OK (^_^)")
+		c.OK("A005")
 
 		// Delete the parent, leaving the child behind.
 		// The deleted parent will be reported with \Noselect.
 		c.C("A005 DELETE ~/Mail/foo")
-		c.S("A005 OK (^_^)")
+		c.OK("A005")
 
 		c.C(`A101 LIST "" ""`)
 		c.S(`* LIST (\Noselect) "/" ""`)
-		c.S(`A101 OK (^_^)`)
+		c.OK("A101")
 
 		c.C(`A102 LIST #news/comp/mail/misc ""`)
 		c.S(`* LIST (\Noselect) "/" "#news/"`)
-		c.S(`A102 OK (^_^)`)
+		c.OK("A102")
 
 		c.C(`A103 LIST /usr/staff/jones ""`)
 		c.S(`* LIST (\Noselect) "/" "/"`)
-		c.S(`A103 OK (^_^)`)
+		c.OK("A103")
 
 		c.C(`A202 LIST ~/Mail/ %`)
 		c.S(`* LIST (\Noselect) "/" "~/Mail/foo"`,
 			`* LIST (\Unmarked) "/" "~/Mail/meetings"`)
-		c.S(`A202 OK (^_^)`)
+		c.OK("A202")
 	})
 }
 
@@ -57,13 +57,13 @@ func TestListFlagsAndAttributes(t *testing.T) {
 		c.C(`A103 LIST "" *`)
 		c.S(`* LIST (\Unmarked) "/" "INBOX"`,
 			`* LIST (\Noinferiors \Unmarked) "/" "custom-attributes"`)
-		c.S(`A103 OK (^_^)`)
+		c.OK(`A103`)
 
 		s.messageCreatedFromFile("user", mailboxID, "testdata/multipart-mixed.eml")
 
 		c.C(`A103 LIST "" *`)
 		c.S(`* LIST (\Unmarked) "/" "INBOX"`,
 			`* LIST (\Marked \Noinferiors) "/" "custom-attributes"`)
-		c.S(`A103 OK (^_^)`)
+		c.OK(`A103`)
 	})
 }

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -19,9 +19,9 @@ func TestLoginQuoted(t *testing.T) {
 func TestLoginLiteral(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C(`A001 login {4}`)
-		c.S(`+ (*_*)`)
+		c.S(`+ Ready`)
 		c.C(`user {4}`)
-		c.S(`+ (*_*)`)
+		c.S(`+ Ready`)
 		c.C(`pass`)
 		c.OK(`A001`)
 	})
@@ -74,9 +74,9 @@ func TestLoginFailure(t *testing.T) {
 func TestLoginLiteralFailure(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C(`A001 login {7}`)
-		c.S(`+ (*_*)`)
+		c.S(`+ Ready`)
 		c.C(`baduser {7}`)
-		c.S(`+ (*_*)`)
+		c.S(`+ Ready`)
 		c.C(`badpass`)
 		c.NO(`A001`)
 	})
@@ -85,6 +85,6 @@ func TestLoginLiteralFailure(t *testing.T) {
 func TestLoginCapabilities(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A001 login user pass")
-		c.S(`A001 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT] (^_^)`)
+		c.S(`A001 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT]`)
 	})
 }

--- a/tests/logout_test.go
+++ b/tests/logout_test.go
@@ -7,8 +7,8 @@ import (
 func TestLogout(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("a001 logout")
-		c.S("* BYE (^_^)/~")
-		c.S("a001 OK (^_^)")
+		c.S("* BYE")
+		c.OK("a001")
 		c.expectClosed()
 	})
 }

--- a/tests/lsub_test.go
+++ b/tests/lsub_test.go
@@ -7,37 +7,37 @@ import (
 func TestLsub(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("B002 CREATE #news.comp.mail.mime")
-		c.S("B002 OK (^_^)")
+		c.OK("B002")
 
 		c.C(`A003 UNSUBSCRIBE "#news.comp.mail.mime"`)
-		c.S(`A003 OK (^_^)`)
+		c.OK("A003")
 
 		c.C("B003 CREATE #news.comp.mail.misc")
-		c.S("B003 OK (^_^)")
+		c.OK("B003")
 
 		c.C(`A003 UNSUBSCRIBE "#news.comp.mail.misc"`)
-		c.S(`A003 OK (^_^)`)
+		c.OK("A003")
 
 		c.C(`A002 LSUB "#news." "comp.mail.*"`)
-		c.S(`A002 OK (^_^)`)
+		c.OK("A002")
 
 		c.C(`A003 SUBSCRIBE "#news.comp.mail.mime"`)
-		c.S(`A003 OK (^_^)`)
+		c.OK("A003")
 
 		c.C(`A004 LSUB "#news." "comp.mail.*"`)
 		c.S(`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`)
-		c.S(`A004 OK (^_^)`)
+		c.OK("A004")
 
 		c.C(`A005 SUBSCRIBE "#news.comp.mail.misc"`)
-		c.S(`A005 OK (^_^)`)
+		c.OK("A005")
 
 		c.C(`A006 LSUB "#news." "comp.mail.*"`)
 		c.S(`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`,
 			`* LSUB (\Unmarked) "." "#news.comp.mail.misc"`)
-		c.S(`A006 OK (^_^)`)
+		c.OK(`A006`)
 
 		c.C(`A007 LSUB "#news." "comp.%"`)
 		c.S(`* LSUB (\Noselect) "." "#news.comp.mail"`)
-		c.S(`A007 OK (^_^)`)
+		c.OK(`A007`)
 	})
 }

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -171,7 +171,7 @@ func TestMoveDuplicate(t *testing.T) {
 		// Initially there are three messages in the destination.
 		c[2].C(`B001 select dest`).OK(`B001`)
 		c[3].C(`C002 status dest (messages)`).Sxe(`MESSAGES 3`).OK(`C002`)
-		c[2].C(`B002 idle`).S("+ (*_*)")
+		c[2].C(`B002 idle`).S("+ Ready")
 
 		// Copy three messages into the destination.
 		// They receive UIDs 4:6 in the destination.

--- a/tests/multi_test.go
+++ b/tests/multi_test.go
@@ -7,10 +7,10 @@ import (
 func TestCreateMulti(t *testing.T) {
 	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		c[1].C("A003 CREATE owatagusiam")
-		c[1].S("A003 OK (^_^)")
+		c[1].OK("A003")
 
 		c[2].C("A003 CREATE owatagusiam")
-		c[2].S("A003 NO a mailbox with that name already exists (~_~)")
+		c[2].S("A003 NO a mailbox with that name already exists")
 	})
 }
 
@@ -18,7 +18,7 @@ func TestExistsUpdates(t *testing.T) {
 	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		// First client selects in INBOX to receive EXISTS update.
 		c[1].C("A006 select INBOX")
-		c[1].Se("A006 OK [READ-WRITE] (^_^)")
+		c[1].Se("A006 OK [READ-WRITE] SELECT")
 
 		// Second client appends to INBOX to generate EXISTS update.
 		c[2].doAppend(`INBOX`, `To: 1@pm.me`, `\Seen`).expect("OK")
@@ -27,25 +27,25 @@ func TestExistsUpdates(t *testing.T) {
 		c[1].C("b001 noop")
 		c[1].S(`* 1 EXISTS`)
 		c[1].S(`* 1 RECENT`)
-		c[1].S("b001 OK (^_^)")
+		c[1].OK("b001")
 	})
 }
 
 func TestExistsUpdatesInSeparateMailboxes(t *testing.T) {
 	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
 		c[1].C("A003 CREATE owatagusiam")
-		c[1].S("A003 OK (^_^)")
+		c[1].S("A003 OK CREATE")
 
 		// First client selects in owatagusiam to ignore EXISTS updates from INBOX.
 		c[1].C("A006 select owatagusiam")
-		c[1].Se("A006 OK [READ-WRITE] (^_^)")
+		c[1].Se("A006 OK [READ-WRITE] SELECT")
 
 		// Second client appends to INBOX to generate EXISTS update.
 		c[2].doAppend(`INBOX`, `To: 1@pm.me`, `\Seen`).expect("OK")
 
 		// First client does not receive the EXISTS update from INBOX.
 		c[1].C("b001 noop")
-		c[1].S("b001 OK (^_^)")
+		c[1].OK("b001")
 	})
 }
 
@@ -55,11 +55,11 @@ func TestFetchUpdates(t *testing.T) {
 
 		// First client selects in INBOX to receive FETCH update.
 		c[1].C("A006 select INBOX")
-		c[1].Se("A006 OK [READ-WRITE] (^_^)")
+		c[1].Se("A006 OK [READ-WRITE] SELECT")
 
 		// Second client selects in INBOX and then sets some flags to generate a FETCH update.
 		c[2].C("b006 select INBOX")
-		c[2].Se("b006 OK [READ-WRITE] (^_^)")
+		c[2].Se("b006 OK [READ-WRITE] SELECT")
 
 		c[2].C(`B007 STORE 1 +FLAGS (\Deleted)`)
 		c[2].S(`* 1 FETCH (FLAGS (\Deleted \Seen))`)
@@ -68,7 +68,7 @@ func TestFetchUpdates(t *testing.T) {
 		// First client receives the FETCH update.
 		c[1].C("c001 noop")
 		c[1].S(`* 1 FETCH (FLAGS (\Deleted \Recent \Seen))`)
-		c[1].S("c001 OK (^_^)")
+		c[1].OK("c001")
 	})
 }
 
@@ -81,49 +81,49 @@ func TestExpungeUpdates(t *testing.T) {
 
 		// Both clients select in inbox.
 		c[1].C("A006 select INBOX")
-		c[1].Se("A006 OK [READ-WRITE] (^_^)")
+		c[1].Se("A006 OK [READ-WRITE] SELECT")
 
 		c[2].C("A007 select INBOX")
-		c[2].Se("A007 OK [READ-WRITE] (^_^)")
+		c[2].Se("A007 OK [READ-WRITE] SELECT")
 
 		// For both clients, the message with sequence number 3 is seen.
 		c[1].C(`A005 FETCH 3 (FLAGS UID)`)
 		c[1].S(`* 3 FETCH (FLAGS (\Recent \Seen) UID 3)`)
-		c[1].Sx(`A005 OK .* command completed in .*`)
+		c[1].OK(`A005`)
 		c[2].C(`B005 FETCH 3 (FLAGS UID)`)
 		c[2].S(`* 3 FETCH (FLAGS (\Seen) UID 3)`)
-		c[2].Sx(`B005 OK .* command completed in .*`)
+		c[2].OK(`B005`)
 
 		// First client marks the first message as deleted.
 		c[1].C(`B003 STORE 1 +FLAGS (\Deleted)`)
 		c[1].S(`* 1 FETCH (FLAGS (\Deleted \Recent))`)
-		c[1].Sx("B003 OK .*")
+		c[1].OK("B003")
 
 		// Second client sees the flag has been changed.
 		c[2].C("c001 noop")
 		c[2].S(`* 1 FETCH (FLAGS (\Deleted))`)
-		c[2].S("c001 OK (^_^)")
+		c[2].OK("c001")
 
 		// First client expunges the first message (seq numbers are shifted down by 1).
 		c[1].C(`B202 EXPUNGE`)
 		c[1].S(`* 1 EXPUNGE`)
-		c[1].S("B202 OK (^_^)")
+		c[1].OK("B202")
 
 		// Second client doesn't yet know that the messages were expunged
 		// and it still thinks the seen message has seq 3 / uid 2
 		// (actually, it was decremented, so it should now have seq 2 / uid 2)
 		c[2].C(`B006 FETCH 3 (FLAGS UID)`)
 		c[2].S(`* 3 FETCH (FLAGS (\Seen) UID 3)`)
-		c[2].Sx(`B006 OK .* command completed in .*`)
+		c[2].OK(`B006`)
 
 		// Second client then does noop and gets the expunge update.
 		// Its seqs are then decremented; the seen message should now have seq 2 / uid 2.
 		c[2].C("c002 noop")
 		c[2].S(`* 1 EXPUNGE`)
-		c[2].S("c002 OK (^_^)")
+		c[2].OK("c002")
 		c[2].C(`B007 FETCH 2 (FLAGS UID)`)
 		c[2].S(`* 2 FETCH (FLAGS (\Seen) UID 3)`)
-		c[2].Sx(`B007 OK .* command completed in .*`)
+		c[2].OK(`B007`)
 	})
 }
 

--- a/tests/noop_test.go
+++ b/tests/noop_test.go
@@ -7,6 +7,6 @@ import (
 func TestNoop(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("a001 noop")
-		c.S("a001 OK (^_^)")
+		c.OK("a001")
 	})
 }

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -38,10 +38,10 @@ func TestSelectWhileSyncing(t *testing.T) {
 		// Select a bunch of mailboxes.
 		for i := 0; i < 100; i++ {
 			c[2].C("A006 select " + mailboxNames[rand.Int()%len(mailboxNames)]) //nolint:gosec
-			c[2].Se("A006 OK [READ-WRITE] (^_^)")
+			c[2].Se("A006 OK [READ-WRITE] SELECT")
 
 			c[2].C("A006 select INBOX")
-			c[2].Se("A006 OK [READ-WRITE] (^_^)")
+			c[2].Se("A006 OK [READ-WRITE] SELECT")
 		}
 
 		// Stop appending.
@@ -61,7 +61,7 @@ func TestTwoFetchesAtOnce(t *testing.T) {
 		}
 
 		c.C("A006 select mbox")
-		c.Se("A006 OK [READ-WRITE] (^_^)")
+		c.Se("A006 OK [READ-WRITE] SELECT")
 
 		// Do some fetches in parallel.
 		c.C(`A005 FETCH 1:200 (BODY[TEXT])`)
@@ -73,17 +73,17 @@ func TestTwoFetchesAtOnce(t *testing.T) {
 		// The fetch commands will complete eventually; who knows which will be processed first.
 		// TODO: Also check the untagged FETCH responses.
 		c.Sxe(
-			`A005 OK .* command completed in .*`,
-			`A006 OK .* command completed in .*`,
-			`A007 OK .* command completed in .*`,
-			`A008 OK .* command completed in .*`,
-			`A009 OK .* command completed in .*`,
+			`A005 OK command completed in .*`,
+			`A006 OK command completed in .*`,
+			`A007 OK command completed in .*`,
+			`A008 OK command completed in .*`,
+			`A009 OK command completed in .*`,
 		)
 
 		// We should then be able to logout fine.
 		c.C("A010 logout")
-		c.S("* BYE (^_^)/~")
-		c.S("A010 OK (^_^)")
+		c.S("* BYE")
+		c.OK("A010")
 
 		// Logging out should close the connection.
 		c.expectClosed()

--- a/tests/recent_test.go
+++ b/tests/recent_test.go
@@ -134,7 +134,7 @@ func TestRecentIDLEExists(t *testing.T) {
 		// Client 1 selects INBOX and IDLEs.
 		c[1].C("A006 select INBOX").OK("A006")
 		c[1].C("A007 IDLE")
-		c[1].S("+ (*_*)")
+		c[1].S("+ Ready")
 
 		// Client 2 appends two new messages to INBOX.
 		c[2].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
@@ -143,7 +143,7 @@ func TestRecentIDLEExists(t *testing.T) {
 		// Client 1 receives EXISTS and RECENT updates.
 		c[1].S(`* 1 EXISTS`, `* 1 RECENT`, `* 2 EXISTS`, `* 2 RECENT`)
 		c[1].C("DONE")
-		c[1].Sx(`A007 OK .*`)
+		c[1].OK(`A007`)
 	})
 }
 
@@ -153,7 +153,7 @@ func TestRecentIDLEExpunge(t *testing.T) {
 		c[1].C("A002 CREATE folder").OK("A002")
 		c[1].C("A006 select folder").OK("A006")
 		c[1].C("A007 IDLE")
-		c[1].S("+ (*_*)")
+		c[1].S("+ Ready")
 
 		// Client 2 appends two new messages to INBOX.
 		c[2].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
@@ -176,6 +176,6 @@ func TestRecentIDLEExpunge(t *testing.T) {
 		// The order of expunge results cannot be guaranteed (MOVE is handled in random order).
 		c[1].Sx(`\* \d EXPUNGE`, `\* \d EXPUNGE`)
 		c[1].C("DONE")
-		c[1].Sx(`A007 OK .*`)
+		c[1].OK(`A007`)
 	})
 }

--- a/tests/select_test.go
+++ b/tests/select_test.go
@@ -7,7 +7,7 @@ import (
 func TestSelect(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE Archive")
-		c.S("A002 OK (^_^)")
+		c.OK("A002")
 
 		c.doAppend(`INBOX`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`INBOX`, `To: 2@pm.me`).expect("OK")
@@ -21,7 +21,7 @@ func TestSelect(t *testing.T) {
 			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
 			`* OK [UIDNEXT 3]`,
 			`* OK [UIDVALIDITY 1]`)
-		c.S("A006 OK [READ-WRITE] (^_^)")
+		c.S("A006 OK [READ-WRITE] SELECT")
 
 		// Selecting again modifies the RECENT value.
 		c.C("A006 select INBOX")
@@ -32,7 +32,7 @@ func TestSelect(t *testing.T) {
 			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
 			`* OK [UIDNEXT 3]`,
 			`* OK [UIDVALIDITY 1]`)
-		c.S("A006 OK [READ-WRITE] (^_^)")
+		c.S("A006 OK [READ-WRITE] SELECT")
 
 		c.C("A007 select Archive")
 		c.S(`* FLAGS (\Deleted \Flagged \Seen)`,
@@ -41,7 +41,7 @@ func TestSelect(t *testing.T) {
 			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
 			`* OK [UIDNEXT 2]`,
 			`* OK [UIDVALIDITY 1]`)
-		c.S(`A007 OK [READ-WRITE] (^_^)`)
+		c.S(`A007 OK [READ-WRITE] SELECT`)
 	})
 }
 

--- a/tests/starttls_test.go
+++ b/tests/starttls_test.go
@@ -5,11 +5,11 @@ import "testing"
 func TestStartTLS(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		c.C("A001 starttls")
-		c.S("A001 OK (^_^) Begin TLS negotiation now")
+		c.S("A001 OK Begin TLS negotiation now")
 
 		c.upgradeConnection()
 
 		c.C("A002 noop")
-		c.S("A002 OK (^_^)")
+		c.OK("A002")
 	})
 }

--- a/tests/status_test.go
+++ b/tests/status_test.go
@@ -7,7 +7,7 @@ import (
 func TestStatus(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("B001 CREATE blurdybloop")
-		c.S("B001 OK (^_^)")
+		c.S("B001 OK CREATE")
 
 		c.doAppend(`blurdybloop`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`blurdybloop`, `To: 2@pm.me`).expect("OK")
@@ -15,6 +15,6 @@ func TestStatus(t *testing.T) {
 
 		c.C("A042 STATUS blurdybloop (MESSAGES UNSEEN)")
 		c.S(`* STATUS "blurdybloop" (MESSAGES 3 UNSEEN 2)`)
-		c.S("A042 OK (^_^)")
+		c.S("A042 OK STATUS")
 	})
 }

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -11,44 +11,44 @@ import (
 func TestStore(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 
 		c.doAppend(`saved-messages`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`saved-messages`, `To: 2@pm.me`).expect("OK")
 		c.doAppend(`saved-messages`, `To: 3@pm.me`, `\Seen`).expect("OK")
 
 		c.C(`A002 SELECT saved-messages`)
-		c.Se(`A002 OK [READ-WRITE] (^_^)`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
 
 		// TODO: Match flags in any order.
 		c.C(`A005 FETCH 1:* (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`,
 			`* 2 FETCH (FLAGS (\Recent))`,
 			`* 3 FETCH (FLAGS (\Recent \Seen))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Add \Deleted and \Draft to the first message.
 		c.C(`A003 STORE 1 +FLAGS (\Deleted \Draft)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Draft \Recent \Seen))`)
-		c.Sx(`A003 OK .* command completed in .*`)
+		c.OK(`A003`)
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Draft \Recent \Seen))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Remove \Seen from the second message (which does not have it)
 		c.C(`A003 STORE 2 -FLAGS (\Seen)`)
-		c.Sx(`A003 OK .* command completed in .*`)
+		c.OK(`A003`)
 		c.C(`A005 FETCH 2 (FLAGS)`)
 		c.S(`* 2 FETCH (FLAGS (\Recent))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.Sx(`A005`)
 
 		// Replace the third message's flags with \Flagged and \Answered.
 		c.C(`A003 STORE 3 FLAGS (\Flagged \Answered)`)
 		c.S(`* 3 FETCH (FLAGS (\Answered \Flagged \Recent))`)
-		c.Sx(`A003 OK .* command completed in .*`)
+		c.OK(`A003`)
 		c.C(`A005 FETCH 3 (FLAGS)`)
 		c.S(`* 3 FETCH (FLAGS (\Answered \Flagged \Recent))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Any attempt to alter the \Recent flags will fail
 		c.C(`A003 STORE 3 FLAGS (\Recent Test)`).BAD(`A003`)
@@ -66,97 +66,97 @@ func TestStoreSilent(t *testing.T) {
 		// Message is only recent in the first.
 		for i := 1; i <= 2; i++ {
 			c[i].C(`A001 SELECT INBOX`)
-			c[i].Sxe(`A001 OK`)
+			c[i].OK(`A001`)
 		}
 
 		// FLAGS. Both sessions get the untagged FETCH response
 		c[1].C(`A002 STORE 1 FLAGS (flag1 flag2)`)
 		c[1].S(`* 1 FETCH (FLAGS (\Recent flag1 flag2))`)
-		c[1].Sx(`A002 OK`)
+		c[1].OK(`A002`)
 		c[2].C(`B002 NOOP`)
 		c[2].S(`* 1 FETCH (FLAGS (flag1 flag2))`)
-		c[2].Sx(`B002 OK`)
+		c[2].OK(`B002`)
 
 		// +FLAGS. Both sessions get the untagged FETCH response
 		c[1].C(`A003 STORE 1 +FLAGS (flag3)`)
 		c[1].S(`* 1 FETCH (FLAGS (\Recent flag1 flag2 flag3))`)
-		c[1].Sx(`A003 OK`)
+		c[1].OK(`A003`)
 		c[2].C(`B003 NOOP`)
 		c[2].S(`* 1 FETCH (FLAGS (flag1 flag2 flag3))`)
-		c[2].Sx(`B003 OK`)
+		c[2].OK(`B003`)
 
 		// -FLAGS. Both sessions get the untagged FETCH response
 		c[1].C(`A004 STORE 1 -FLAGS (flag3 flag2)`)
 		c[1].S(`* 1 FETCH (FLAGS (\Recent flag1))`)
-		c[1].Sx(`A004 OK`)
+		c[1].OK(`A004`)
 		c[2].C(`B004 NOOP`)
 		c[2].S(`* 1 FETCH (FLAGS (flag1))`)
-		c[2].Sx(`B004 OK`)
+		c[2].OK(`B004`)
 
 		// FLAGS.SILENT Only session 2 gets the untagged FETCH response
 		c[1].C(`A005 STORE 1 FLAGS.SILENT (flag1 flag2)`)
-		c[1].Sx(`A005 OK`)
+		c[1].OK(`A005`)
 		c[2].C(`B005 NOOP`)
 		c[2].S(`* 1 FETCH (FLAGS (flag1 flag2))`)
-		c[2].Sx(`B005 OK`)
+		c[2].OK(`B005`)
 
 		// +FLAGS.SILENT Only session 2 gets the untagged FETCH response
 		c[1].C(`A006 STORE 1 +FLAGS.SILENT (flag3)`)
-		c[1].Sx(`A006 OK`)
+		c[1].OK(`A006`)
 		c[2].C(`B006 NOOP`)
 		c[2].S(`* 1 FETCH (FLAGS (flag1 flag2 flag3))`)
-		c[2].Sx(`B006 OK`)
+		c[2].OK(`B006`)
 
 		// -FLAGS.SILENT Only session 2 gets the untagged FETCH response
 		c[1].C(`A007 STORE 1 -FLAGS.SILENT (flag3 flag2)`)
-		c[1].Sx(`A007 OK`)
+		c[1].OK(`A007`)
 		c[2].C(`B007 NOOP`)
 		c[2].S(`* 1 FETCH (FLAGS (flag1))`)
-		c[2].Sx(`B007 OK`)
+		c[2].OK(`B007`)
 	})
 }
 
 func TestUIDStore(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 
 		c.doAppend(`saved-messages`, `To: 1@pm.me`, `\Seen`).expect("OK")
 		c.doAppend(`saved-messages`, `To: 2@pm.me`).expect("OK")
 		c.doAppend(`saved-messages`, `To: 3@pm.me`, `\Seen`).expect("OK")
 
 		c.C(`A002 SELECT saved-messages`)
-		c.Se(`A002 OK [READ-WRITE] (^_^)`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
 
 		// TODO: Match flags in any order.
 		c.C(`A005 FETCH 1:* (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`,
 			`* 2 FETCH (FLAGS (\Recent))`,
 			`* 3 FETCH (FLAGS (\Recent \Seen))`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Add \Deleted and \Draft to the first message.
 		c.C(`A003 UID STORE 1 +FLAGS (\Deleted \Draft)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Draft \Recent \Seen) UID 1)`)
-		c.Sx(`A003 OK .* command completed in .*`)
+		c.OK(`A003`)
 		c.C(`A005 UID FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Deleted \Draft \Recent \Seen) UID 1)`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Remove \Seen from the second message.
 		c.C(`A003 UID STORE 2 -FLAGS (\Seen)`)
-		c.Sx(`A003 OK .* command completed in .*`)
+		c.OK(`A003`)
 		c.C(`A005 UID FETCH 2 (FLAGS)`)
 		c.S(`* 2 FETCH (FLAGS (\Recent) UID 2)`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Replace the third message's flags with \Flagged and \Answered.
 		c.C(`A003 UID STORE 3 FLAGS (\Flagged \Answered)`)
 		c.S(`* 3 FETCH (FLAGS (\Answered \Flagged \Recent) UID 3)`)
-		c.Sx(`A003 OK .* command completed in .*`)
+		c.OK(`A003`)
 		c.C(`A005 UID FETCH 3 (FLAGS)`)
 		c.S(`* 3 FETCH (FLAGS (\Answered \Flagged \Recent) UID 3)`)
-		c.Sx(`A005 OK .* command completed in .*`)
+		c.OK(`A005`)
 
 		// Any attempt to alter the \Recent flags will fail
 		c.C(`A003 UID STORE 3 FLAGS (\Recent Test)`).BAD(`A003`)
@@ -170,50 +170,50 @@ func TestFlagsDuplicateAndCaseInsensitive(t *testing.T) {
 		c.doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
 		c.C(`A001 SELECT INBOX`)
-		c.Se(`A001 OK [READ-WRITE] (^_^)`)
+		c.Se(`A001 OK [READ-WRITE] SELECT`)
 
 		// no duplicates
 		c.C(`A002 STORE 1 FLAGS (flag1 flag1)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent flag1))`)
-		c.Sx(`A002 OK`)
+		c.OK(`A002`)
 
 		// no duplicates and case-insensitive
 		c.C(`A003 STORE 1 FLAGS (FLAG1 flag2 FLAG2)`)
 		c.S(`* 1 FETCH (FLAGS (FLAG1 \Recent flag2))`)
-		c.Sx(`A003 OK`)
+		c.OK(`A003`)
 
 		// unchanged, no untagged response
 		c.C(`A004 STORE 1 FLAGS (FLAG1 flag2 FLAG2)`)
-		c.Sx(`A004 OK`)
+		c.OK(`A004`)
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (FLAG1 \Recent flag2))`)
-		c.Sx(`A005 OK`)
+		c.OK(`A005`)
 
 		// +FLAGS with no changes, no untagged response
 		c.C(`A006 STORE 1 +FLAGS (flag1 flag2)`)
-		c.Sx(`A006 OK`)
+		c.OK(`A006`)
 
 		// +FLAGS with a new flag
 		c.C(`A007 STORE 1 +FLAGS (FLAG1 FLAG3)`)
 		c.S(`* 1 FETCH (FLAGS (FLAG1 FLAG3 \Recent flag2))`)
-		c.Sx(`A007 OK`)
+		c.OK(`A007`)
 
 		// +FLAGS with a empty flag list, no untagged response
 		c.C(`A008 STORE 1 +FLAGS ()`)
-		c.Sx(`A008 OK`)
+		c.OK(`A008`)
 
 		// -FLAGS with difference case
 		c.C(`A009 STORE 1 -FLAGS (flag3)`)
 		c.S(`* 1 FETCH (FLAGS (FLAG1 \Recent flag2))`)
-		c.Sx(`A009 OK`)
+		c.OK(`A009`)
 
 		// -FLAGS -with non-existing flag, no untagged
 		c.C(`A00A STORE 1 -FLAGS (flag3)`)
-		c.Sx(`A00A OK`)
+		c.OK(`A00A`)
 
 		// -FLAGS with empty list
 		c.C(`A00B STORE 1 -FLAGS ()`)
-		c.Sx(`A00B OK`)
+		c.OK(`A00B`)
 	})
 }
 
@@ -222,7 +222,7 @@ func TestStoreFlagsPersistBetweenRuns(t *testing.T) {
 
 	runOneToOneTestWithAuth(t, options, func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 		c.doAppend(`saved-messages`, `To: 2@pm.me`).expect("OK")
 	})
 

--- a/tests/subscribe_test.go
+++ b/tests/subscribe_test.go
@@ -7,19 +7,19 @@ import (
 func TestSubscribe(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE #news.comp.mail.mime")
-		c.S("A002 OK (^_^)")
+		c.S("A002 OK CREATE")
 
 		c.C("A003 SUBSCRIBE #this.name.does.not.exist")
-		c.S("A003 NO no such mailbox (~_~)")
+		c.S("A003 NO no such mailbox")
 
 		// Mailboxes are subscribed by default.
 		c.C("A004 UNSUBSCRIBE #news.comp.mail.mime")
-		c.S("A004 OK (^_^)")
+		c.OK("A004")
 
 		c.C("A004 SUBSCRIBE #news.comp.mail.mime")
-		c.S("A004 OK (^_^)")
+		c.OK("A004")
 
 		c.C("A005 SUBSCRIBE #news.comp.mail.mime")
-		c.S("A005 NO already subscribed to this mailbox (~_~)")
+		c.S("A005 NO already subscribed to this mailbox")
 	})
 }

--- a/tests/unselect_test.go
+++ b/tests/unselect_test.go
@@ -7,12 +7,12 @@ import (
 func TestUnselect(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE saved-messages")
-		c.S("b001 OK (^_^)")
+		c.S("b001 OK CREATE")
 
 		c.C(`A002 SELECT INBOX`)
-		c.Se(`A002 OK [READ-WRITE] (^_^)`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
 
 		c.C(`A202 UNSELECT`)
-		c.S("A202 OK (^_^)")
+		c.S("A202 OK UNSELECT")
 	})
 }

--- a/tests/unsubscribe_test.go
+++ b/tests/unsubscribe_test.go
@@ -7,15 +7,15 @@ import (
 func TestUnsubscribe(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
 		c.C("A002 CREATE #news.comp.mail.mime")
-		c.S("A002 OK (^_^)")
+		c.S("A002 OK CREATE")
 
 		c.C("A003 UNSUBSCRIBE #this.name.does.not.exist")
-		c.S("A003 NO no such mailbox (~_~)")
+		c.S("A003 NO no such mailbox")
 
 		c.C("A005 UNSUBSCRIBE #news.comp.mail.mime")
-		c.S("A005 OK (^_^)")
+		c.S("A005 OK UNSUBSCRIBE")
 
 		c.C("A006 UNSUBSCRIBE #news.comp.mail.mime")
-		c.S("A006 NO not subscribed to this mailbox (~_~)")
+		c.S("A006 NO not subscribed to this mailbox")
 	})
 }

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -11,11 +11,11 @@ func TestMessageCreatedUpdate(t *testing.T) {
 
 		// Select in the mailbox to receive EXISTS and RECENT updates.
 		c.C("A006 select mbox")
-		c.Se("A006 OK [READ-WRITE] (^_^)")
+		c.Se("A006 OK [READ-WRITE] SELECT")
 
 		// Start idling in INBOX to receive the updates.
 		c.C("A007 IDLE")
-		c.S("+ (*_*)")
+		c.S("+ Ready")
 
 		// Create some messages externally.
 		s.messageCreatedFromFile("user", mboxID, "testdata/multipart-mixed.eml")
@@ -26,7 +26,7 @@ func TestMessageCreatedUpdate(t *testing.T) {
 
 		// Stop idling.
 		c.C("DONE")
-		c.S("A007 OK (^_^)")
+		c.OK("A007")
 
 		// Create a third message externally.
 		s.messageCreatedFromFile("user", mboxID, "testdata/text-plain.eml")
@@ -35,7 +35,7 @@ func TestMessageCreatedUpdate(t *testing.T) {
 		c.C("A007 NOOP")
 		c.S("* 3 EXISTS")
 		c.S("* 3 RECENT")
-		c.S("A007 OK (^_^)")
+		c.OK("A007")
 	})
 }
 
@@ -83,7 +83,7 @@ func TestMessageCreatedIDLEUpdate(t *testing.T) {
 		c.C(`A001 select other`).OK(`A001`)
 
 		// Begin IDLE.
-		c.C(`A002 IDLE`).S(`+ (*_*)`)
+		c.C(`A002 IDLE`).S(`+ Ready`)
 
 		// Create two messages externally.
 		s.messageCreatedFromFile("user", other, "testdata/multipart-mixed.eml")
@@ -103,7 +103,7 @@ func TestMessageCreatedIDLEUpdate(t *testing.T) {
 		c.C(`DONE`).OK(`A002`)
 		c.C(`A003 select inbox`).OK(`A003`)
 		c.C(`A004 select other`).OK(`A004`)
-		c.C(`A005 IDLE`).S(`+ (*_*)`)
+		c.C(`A005 IDLE`).S(`+ Ready`)
 
 		// Create two more messages externally.
 		s.messageCreatedFromFile("user", other, "testdata/multipart-mixed.eml")
@@ -130,11 +130,11 @@ func TestMessageRemovedUpdate(t *testing.T) {
 
 		// Select in the mailbox to receive EXPUNGE updates.
 		c.C("A006 select mbox")
-		c.Se("A006 OK [READ-WRITE] (^_^)")
+		c.Se("A006 OK [READ-WRITE] SELECT")
 
 		// Start idling in INBOX to receive the EXPUNGE updates.
 		c.C("A007 IDLE")
-		c.S("+ (*_*)")
+		c.S("+ Ready")
 
 		// Remove the first message.
 		s.messageRemoved("user", messageID1, mboxID)
@@ -158,7 +158,7 @@ func TestMessageRemovedUpdate(t *testing.T) {
 
 		// Stop idling.
 		c.C("DONE")
-		c.S("A007 OK (^_^)")
+		c.OK("A007")
 
 		// Remove the fourth message.
 		s.messageRemoved("user", messageID4, mboxID)
@@ -167,18 +167,18 @@ func TestMessageRemovedUpdate(t *testing.T) {
 		// Therefore, we still think there is one message in the mailbox!
 		c.C("A007 FETCH 1:* (UID)")
 		c.S("* 1 FETCH (UID 4)")
-		c.Sx("A007 OK .* command completed in .*")
+		c.OK("A007")
 
 		// Processing the previous fetch shouldn't have led to an EXPUNGE;
 		// a subsequent fetch will return the same result!
 		c.C("A007 FETCH 1:* (UID)")
 		c.S("* 1 FETCH (UID 4)")
-		c.Sx("A007 OK .* command completed in .*")
+		c.OK("A007")
 
 		// Do NOOP to finally receive the EXPUNGE update.
 		c.C("A007 NOOP")
 		c.S("* 1 EXPUNGE")
-		c.S("A007 OK (^_^)")
+		c.OK("A007")
 	})
 }
 
@@ -191,16 +191,16 @@ func TestMessageRemovedUpdateRepeated(t *testing.T) {
 			messageID := s.messageCreatedFromFile("user", mboxID, "testdata/multipart-mixed.eml")
 
 			c.C("A006 select mbox")
-			c.Se("A006 OK [READ-WRITE] (^_^)")
+			c.Se("A006 OK [READ-WRITE] SELECT")
 
 			c.C("A007 IDLE")
-			c.S("+ (*_*)")
+			c.S("+ Ready")
 
 			s.messageRemoved("user", messageID, mboxID)
 			c.S("* 1 EXPUNGE")
 
 			c.C("DONE")
-			c.S("A007 OK (^_^)")
+			c.OK("A007")
 		}
 	})
 }
@@ -209,14 +209,14 @@ func TestMailboxCreatedUpdate(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
 		c.C(`A82 LIST "" *`)
 		c.S(`* LIST (\Unmarked) "/" "INBOX"`)
-		c.S(`A82 OK (^_^)`)
+		c.OK("A82")
 
 		s.mailboxCreated("user", []string{"some-mailbox"})
 
 		c.C(`A82 LIST "" *`)
 		c.S(`* LIST (\Unmarked) "/" "some-mailbox"`,
 			`* LIST (\Unmarked) "/" "INBOX"`)
-		c.S(`A82 OK (^_^)`)
+		c.OK("A82")
 	})
 }
 


### PR DESCRIPTION
The emoticon personality was interfering with the IMAP tests from the
dovecot suit. These have now been removed.

Since the responses require a bit of text after, we have added the
originating command's name where no other message exited before. This
requirement was previously masked by the emoticon response.