### PR TITLE
fix(GODT-1715): Fix more IMAP tests reports

### DIFF
--- a/internal/session/handle_append.go
+++ b/internal/session/handle_append.go
@@ -38,7 +38,7 @@ func (s *Session) handleAppend(ctx context.Context, tag string, cmd *proto.Appen
 			return err
 		}
 
-		ch <- response.Ok(tag).WithItems(response.ItemAppendUID(mailbox.UIDValidity(), messageUID))
+		ch <- response.Ok(tag).WithItems(response.ItemAppendUID(mailbox.UIDValidity(), messageUID)).WithMessage("APPEND")
 
 		return nil
 	}); errors.Is(err, backend.ErrNoSuchMailbox) {

--- a/internal/session/handle_login.go
+++ b/internal/session/handle_login.go
@@ -30,7 +30,7 @@ func (s *Session) handleLogin(ctx context.Context, tag string, cmd *proto.Login,
 
 	s.state = state
 
-	ch <- response.Ok(tag).WithItems(response.ItemCapability(s.caps...))
+	ch <- response.Ok(tag).WithItems(response.ItemCapability(s.caps...)).WithMessage("Logged in")
 
 	s.eventCh <- events.EventLogin{
 		SessionID: s.sessionID,

--- a/internal/session/handle_select.go
+++ b/internal/session/handle_select.go
@@ -36,12 +36,12 @@ func (s *Session) handleSelect(ctx context.Context, tag string, cmd *proto.Selec
 		ch <- response.Flags().WithFlags(flags)
 		ch <- response.Exists().WithCount(mailbox.Count())
 		ch <- response.Recent().WithCount(len(mailbox.GetMessagesWithFlag(imap.FlagRecent)))
-		ch <- response.Ok().WithItems(response.ItemPermanentFlags(permFlags))
-		ch <- response.Ok().WithItems(response.ItemUIDNext(mailbox.UIDNext()))
-		ch <- response.Ok().WithItems(response.ItemUIDValidity(mailbox.UIDValidity()))
+		ch <- response.Ok().WithItems(response.ItemPermanentFlags(permFlags)).WithMessage("Flags permitted")
+		ch <- response.Ok().WithItems(response.ItemUIDNext(mailbox.UIDNext())).WithMessage("Predicted next UID")
+		ch <- response.Ok().WithItems(response.ItemUIDValidity(mailbox.UIDValidity())).WithMessage("UIDs valid")
 
 		if unseen := mailbox.GetMessagesWithoutFlag(imap.FlagSeen); len(unseen) > 0 {
-			ch <- response.Ok().WithItems(response.ItemUnseen(unseen[0]))
+			ch <- response.Ok().WithItems(response.ItemUnseen(unseen[0])).WithMessage("Unseen messages")
 		}
 
 		s.name = mailbox.Name()


### PR DESCRIPTION
Add missing message text to responses reported by Gluon to satisfy IMAP
spec.