### PR TITLE
fix(GODT-1729): Fix header parsing of fields without space

### DIFF
--- a/rfc822/header.go
+++ b/rfc822/header.go
@@ -270,15 +270,23 @@ func mergeMultiline(line []byte) string {
 	var res [][]byte
 
 	for line := range forLines(bufio.NewReader(bytes.NewReader(line))) {
-		res = append(res, bytes.TrimSpace(line))
+		trimmed := bytes.TrimSpace(line)
+		if trimmed != nil {
+			res = append(res, trimmed)
+		}
 	}
 
 	return string(bytes.Join(res, []byte(" ")))
 }
 
-// TODO: What if there isn't a space after the colon?
 func splitLine(line []byte) [][]byte {
-	return bytes.SplitN(line, []byte(`: `), 2)
+	result := bytes.SplitN(line, []byte(`:`), 2)
+
+	if len(result) > 1 && len(result[1]) > 0 && result[1][0] == ' ' {
+		result[1] = result[1][1:]
+	}
+
+	return result
 }
 
 // TODO: Don't assume line ending is \r\n. Bad.

--- a/rfc822/header_test.go
+++ b/rfc822/header_test.go
@@ -14,6 +14,8 @@ func TestHeader_Raw(t *testing.T) {
 }
 
 func TestHeader_Has(t *testing.T) {
+	const literal = "To: somebody\r\nFrom: somebody else\r\nSubject: this is\r\n\ta multiline field\r\nFrom: duplicate entry\r\nReferences:\r\n\t <foo@bar.com>\r\n\r\n"
+
 	header := ParseHeader([]byte(literal))
 
 	assert.Equal(t, true, header.Has("To"))
@@ -25,9 +27,12 @@ func TestHeader_Has(t *testing.T) {
 	assert.Equal(t, true, header.Has("Subject"))
 	assert.Equal(t, true, header.Has("subject"))
 	assert.Equal(t, false, header.Has("subjectt"))
+	assert.Equal(t, true, header.Has("References"))
 }
 
 func TestHeader_Get(t *testing.T) {
+	const literal = "To: somebody\r\nFrom: somebody else\r\nSubject: this is\r\n\ta multiline field\r\nFrom: duplicate entry\r\nReferences:\r\n\t <foo@bar.com>\r\n\r\n"
+
 	header := ParseHeader([]byte(literal))
 
 	assert.Equal(t, "somebody", header.Get("To"))
@@ -36,6 +41,7 @@ func TestHeader_Get(t *testing.T) {
 	assert.Equal(t, "somebody else", header.Get("from"))
 	assert.Equal(t, "this is a multiline field", header.Get("Subject"))
 	assert.Equal(t, "this is a multiline field", header.Get("subject"))
+	assert.Equal(t, "<foo@bar.com>", header.Get("References"))
 }
 
 func TestHeader_GetRaw(t *testing.T) {


### PR DESCRIPTION
Fix the header parsing of fields that do not have a space after the
colon.