### PR TITLE
fix(GODT-1729): Fix In-Reply-To header parsing

### DIFF
--- a/imap/envelope.go
+++ b/imap/envelope.go
@@ -72,7 +72,7 @@ func envelope(header *rfc822.Header) (fmt.Stringer, error) {
 	if !header.Has("In-Reply-To") {
 		fields.add("")
 	} else {
-		fields.add(tryParseAddressList(header.Get("In-Reply-To")))
+		fields.add(header.Get("In-Reply-To"))
 	}
 
 	fields.add(header.Get("Message-Id"))


### PR DESCRIPTION
In-Reply-To should not be treated as an address list, but rather as a
regular string. A unit test was added to catch this in the future.