### PR TITLE
Fix: Add uniqueness constraint to mailbox names

### DIFF
--- a/connector/dummy.go
+++ b/connector/dummy.go
@@ -66,7 +66,7 @@ func NewDummy(usernames []string, password string, period time.Duration, flags, 
 		})
 	}()
 
-	conn.state.createLabel([]string{imap.Inbox}, false)
+	conn.state.createLabelWithID([]string{imap.Inbox}, "0", false)
 
 	return conn
 }

--- a/connector/dummy_state.go
+++ b/connector/dummy_state.go
@@ -84,6 +84,18 @@ func (state *dummyState) createLabel(name []string, exclusive bool) imap.Mailbox
 	return state.toMailbox(labelID)
 }
 
+func (state *dummyState) createLabelWithID(name []string, id string, exclusive bool) imap.Mailbox {
+	state.lock.Lock()
+	defer state.lock.Unlock()
+
+	state.labels[id] = &dummyLabel{
+		labelName: name,
+		exclusive: exclusive,
+	}
+
+	return state.toMailbox(id)
+}
+
 func (state *dummyState) updateLabel(labelID string, name []string) {
 	state.lock.Lock()
 	defer state.lock.Unlock()

--- a/connector/mock_connector/connector.go
+++ b/connector/mock_connector/connector.go
@@ -50,6 +50,20 @@ func (mr *MockConnectorMockRecorder) Authorize(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authorize", reflect.TypeOf((*MockConnector)(nil).Authorize), arg0, arg1)
 }
 
+// Close mocks base method.
+func (m *MockConnector) Close(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockConnectorMockRecorder) Close(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConnector)(nil).Close), arg0)
+}
+
 // CreateLabel mocks base method.
 func (m *MockConnector) CreateLabel(arg0 context.Context, arg1 []string) (imap.Mailbox, error) {
 	m.ctrl.T.Helper()

--- a/internal/backend/ent/migrate/schema.go
+++ b/internal/backend/ent/migrate/schema.go
@@ -12,7 +12,7 @@ var (
 	MailboxesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "mailbox_id", Type: field.TypeString},
-		{Name: "name", Type: field.TypeString},
+		{Name: "name", Type: field.TypeString, Unique: true},
 		{Name: "uid_next", Type: field.TypeInt, Default: 1},
 		{Name: "uid_validity", Type: field.TypeInt, Default: 1},
 		{Name: "subscribed", Type: field.TypeBool, Default: true},

--- a/internal/backend/ent/schema/mailbox.go
+++ b/internal/backend/ent/schema/mailbox.go
@@ -16,7 +16,7 @@ type Mailbox struct {
 func (Mailbox) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("MailboxID"),
-		field.String("Name"),
+		field.String("Name").Unique(),
 		field.Int("UIDNext").Default(1),
 		field.Int("UIDValidity").Default(1),
 		field.Bool("Subscribed").Default(true),

--- a/store/mock_store/store.go
+++ b/store/mock_store/store.go
@@ -33,6 +33,24 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// Delete mocks base method.
+func (m *MockStore) Delete(arg0 ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreMockRecorder) Delete(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), arg0...)
+}
+
 // Get mocks base method.
 func (m *MockStore) Get(arg0 string) ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Currently in the Dummy connector, we create a new default INBOX mailbox
on every `Sync`. While this works fine for short lived tests, it causes
issues for cases where we need to run the same state multiple times. In
these cases certain queries fail as the name of the INBOX is not unique.
We have hard coded the value of the INBOX mailbox to a `0` in order to
guarantee that it remains unique on every run.

Finally a constraint has been added to the database table to catch this
error in the future.