### PR TITLE
feat(GODT-1719): Gluon benchmark framework

### DIFF
--- a/benchmarks/gluon_bench/benchmarks/mailbox_create.go
+++ b/benchmarks/gluon_bench/benchmarks/mailbox_create.go
@@ -1,0 +1,22 @@
+package benchmarks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ProtonMail/gluon"
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/utils"
+)
+
+func BenchmarkMailboxCreate(ctx context.Context, server *gluon.Server, addr string) {
+	cl, err := utils.NewClient(addr)
+	defer utils.CloseClient(cl)
+
+	if err != nil {
+		panic("Failed to connect o server")
+	}
+
+	if err := utils.BuildMailbox(cl, "INBOX", 1000); err != nil {
+		panic(fmt.Sprintf("Benchmark Mailbox Create - Failed to create mailbox: %v", err))
+	}
+}

--- a/benchmarks/gluon_bench/main.go
+++ b/benchmarks/gluon_bench/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ProtonMail/gluon"
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/benchmarks"
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/reporter"
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/utils"
+	"github.com/ProtonMail/gluon/profiling"
+)
+
+var storePathFlag = flag.String("path", "", "Filepath where to write the database data. If not set a temp folder will be used.")
+var verboseFlag = flag.Bool("verbose", false, "Enable verbose logging.")
+var jsonReporterFlag = flag.String("json-reporter", "", "If specified, will generate a json report with the given filename.")
+var benchmarkRunsFlag = flag.Uint("bench-runs", 1, "Number of runs per benchmark.")
+var reuseStateFlag = flag.Bool("reuse-state", false, "When present, benchmarks will re-use previous run state, rather than a clean slate.")
+
+var benchmarkMap = map[string]func(context.Context, *gluon.Server, string){
+	"bench-mailbox-create": benchmarks.BenchmarkMailboxCreate,
+}
+
+type benchmarkEntry struct {
+	key     string
+	benchFn func(context.Context, *gluon.Server, string)
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Printf("Usage %v [options] benchmark0 benchmark1 ... benchmarkN\n", os.Args[0])
+		fmt.Printf("\nAvailable Benchmarks:\n")
+
+		for k, _ := range benchmarkMap {
+			fmt.Printf("  * %v\n", k)
+		}
+
+		fmt.Printf("\nOptions:\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	var benchmarks []benchmarkEntry
+
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+		return
+	}
+
+	for _, arg := range args {
+		if v, ok := benchmarkMap[arg]; ok {
+			benchmarks = append(benchmarks, benchmarkEntry{key: arg, benchFn: v})
+		}
+	}
+
+	if len(benchmarks) == 0 {
+		panic("No benchmarks selected")
+	}
+
+	var benchmarkReporter reporter.BenchmarkReporter
+
+	if len(*jsonReporterFlag) != 0 {
+		benchmarkReporter = reporter.NewJSONReporter(*jsonReporterFlag)
+	} else {
+		benchmarkReporter = &reporter.StdOutReporter{}
+	}
+
+	cmdProfiler := utils.NewDurationCmdProfilerBuilder()
+
+	var serverDirConfig utils.ServerDirConfig
+	if len(*storePathFlag) != 0 {
+		serverDirConfig = utils.NewPersistentServerDirConfig(*storePathFlag)
+	} else {
+		serverDirConfig = &utils.TmpServerDirConfig{}
+	}
+
+	benchmarkReports := make([]*reporter.BenchmarkReport, 0, len(benchmarks))
+
+	for _, v := range benchmarks {
+		if *verboseFlag {
+			fmt.Printf("Begin Benchmark: %v\n", v.key)
+		}
+
+		numRuns := *benchmarkRunsFlag
+
+		var benchmarkRuns = make([]*reporter.BenchmarkRun, 0, numRuns)
+
+		for r := uint(0); r < numRuns; r++ {
+			if *verboseFlag {
+				fmt.Printf("Benchmark Run: %v\n", r)
+			}
+
+			cmdProfiler.Clear()
+
+			scopedTimer := measureBenchmark(serverDirConfig, v.key, r, cmdProfiler, v.benchFn)
+			benchmarkRuns = append(benchmarkRuns, reporter.NewBenchmarkRun(scopedTimer.Elapsed(), cmdProfiler.Merge()))
+		}
+
+		benchmarkReports = append(benchmarkReports, reporter.NewBenchmarkReport(v.key, benchmarkRuns...))
+
+		if *verboseFlag {
+			fmt.Printf("End Benchmark: %v\n", v.key)
+		}
+	}
+
+	if benchmarkReporter != nil {
+		if *verboseFlag {
+			fmt.Printf("Generating Report\n")
+		}
+
+		if err := benchmarkReporter.ProduceReport(benchmarkReports); err != nil {
+			panic(fmt.Sprintf("Failed to produce benchmark report: %v", err))
+		}
+	}
+
+	if *verboseFlag {
+		fmt.Printf("Finished\n")
+	}
+}
+
+func measureBenchmark(dirConfig utils.ServerDirConfig, name string, iteration uint, cmdProfiler profiling.CmdProfilerBuilder, bench func(context.Context, *gluon.Server, string)) utils.ScopedTimer {
+	serverPath, err := dirConfig.Get()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get server directory: %v", err))
+	}
+
+	if !*reuseStateFlag {
+		serverPath = filepath.Join(serverPath, fmt.Sprintf("%v-%d", name, iteration))
+	} else {
+		serverPath = filepath.Join(serverPath, name)
+	}
+
+	if *verboseFlag {
+		fmt.Printf("Benchmark Data Path: %v\n", serverPath)
+	}
+
+	if err := os.MkdirAll(serverPath, 0o777); err != nil {
+		panic(fmt.Sprintf("Failed to create server directory '%v' : %v", serverPath, err))
+	}
+
+	ctx := context.Background()
+	server, address, err := newServer(ctx, serverPath, gluon.WithCmdProfiler(cmdProfiler))
+
+	if err != nil {
+		panic(fmt.Sprintf("Failed to start server: %v", err))
+	}
+
+	defer server.Close(ctx)
+
+	scopedTimer := utils.ScopedTimer{}
+	scopedTimer.Start()
+	bench(ctx, server, address)
+	scopedTimer.Stop()
+
+	return scopedTimer
+}

--- a/benchmarks/gluon_bench/reporter/json_reporter.go
+++ b/benchmarks/gluon_bench/reporter/json_reporter.go
@@ -1,0 +1,24 @@
+package reporter
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// JSONReporter produces a JSON data file with all the benchmark information.
+type JSONReporter struct {
+	outputPath string
+}
+
+func (j *JSONReporter) ProduceReport(reports []*BenchmarkReport) error {
+	result, err := json.Marshal(reports)
+	if err != nil {
+		return nil
+	}
+
+	return os.WriteFile(j.outputPath, []byte(result), 0o600)
+}
+
+func NewJSONReporter(output string) *JSONReporter {
+	return &JSONReporter{outputPath: output}
+}

--- a/benchmarks/gluon_bench/reporter/reporter.go
+++ b/benchmarks/gluon_bench/reporter/reporter.go
@@ -1,0 +1,31 @@
+package reporter
+
+import (
+	"time"
+
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/utils"
+	"github.com/ProtonMail/gluon/profiling"
+)
+
+type BenchmarkRun struct {
+	Duration   time.Duration
+	CmdTimings [profiling.CmdTypeTotal]utils.TimingCalculator
+}
+
+func NewBenchmarkRun(duration time.Duration, cmdTimings [profiling.CmdTypeTotal]utils.TimingCalculator) *BenchmarkRun {
+	return &BenchmarkRun{Duration: duration, CmdTimings: cmdTimings}
+}
+
+type BenchmarkReport struct {
+	Name string
+	Runs []*BenchmarkRun
+}
+
+func NewBenchmarkReport(name string, runs ...*BenchmarkRun) *BenchmarkReport {
+	return &BenchmarkReport{Name: name, Runs: runs}
+}
+
+// BenchmarkReporter is the interface that is required to be implemented by any report generation tool.
+type BenchmarkReporter interface {
+	ProduceReport(reports []*BenchmarkReport) error
+}

--- a/benchmarks/gluon_bench/reporter/stdout_reporter.go
+++ b/benchmarks/gluon_bench/reporter/stdout_reporter.go
@@ -1,0 +1,30 @@
+package reporter
+
+import (
+	"fmt"
+
+	"github.com/ProtonMail/gluon/profiling"
+)
+
+// StdOutReporter prints the benchmark report to os.Stdout.
+type StdOutReporter struct{}
+
+func (*StdOutReporter) ProduceReport(reports []*BenchmarkReport) error {
+	for i, v := range reports {
+		fmt.Printf("[%02d] Benchmark %v\n", i, v.Name)
+
+		for r, v := range v.Runs {
+			fmt.Printf("[%02d] Run %02d - Time: %v\n", i, r, v.Duration)
+
+			for n, v := range v.CmdTimings {
+				if v.SampleCount == 0 {
+					continue
+				}
+
+				fmt.Printf("[%02d] [%02d] [%v] %v\n", i, r, profiling.CmdTypeToString(n), v.String())
+			}
+		}
+	}
+
+	return nil
+}

--- a/benchmarks/gluon_bench/server.go
+++ b/benchmarks/gluon_bench/server.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"entgo.io/ent/dialect"
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/utils"
+
+	"net"
+	"path/filepath"
+	"time"
+
+	"github.com/ProtonMail/gluon"
+	"github.com/ProtonMail/gluon/connector"
+	"github.com/ProtonMail/gluon/imap"
+	"github.com/ProtonMail/gluon/store"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/sirupsen/logrus"
+)
+
+// newServer creates a new server and returns the server instance and address.
+func newServer(ctx context.Context, path string, options ...gluon.Option) (*gluon.Server, string, error) {
+	loggerIn := logrus.StandardLogger().WriterLevel(logrus.TraceLevel)
+	loggerOut := logrus.StandardLogger().WriterLevel(logrus.TraceLevel)
+
+	var opts []gluon.Option
+
+	opts = append(opts, gluon.WithLogger(loggerIn, loggerOut))
+	opts = append(opts, options...)
+
+	server, err := gluon.New(path, opts...)
+
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err := addUser(ctx, server, path, []string{utils.UserName}, utils.UserPassword); err != nil {
+		return nil, "", err
+	}
+
+	listener, err := net.Listen("tcp", "localhost:1143")
+	if err != nil {
+		return nil, "", err
+	}
+
+	go func() {
+		for err := range server.Serve(ctx, listener) {
+			logrus.WithError(err).Error("Error while serving")
+		}
+	}()
+
+	return server, listener.Addr().String(), nil
+}
+
+func addUser(ctx context.Context, server *gluon.Server, path string, addresses []string, password string) error {
+	hash := sha256.Sum256([]byte(addresses[0]))
+	id := hex.EncodeToString(hash[:])
+	connector := connector.NewDummy(
+		addresses,
+		password,
+		time.Second,
+		imap.NewFlagSet(`\Answered`, `\Seen`, `\Flagged`, `\Deleted`),
+		imap.NewFlagSet(`\Answered`, `\Seen`, `\Flagged`, `\Deleted`),
+		imap.NewFlagSet(),
+	)
+
+	storePath := filepath.Join(path, id+".store")
+	dbPath := filepath.Join(path, id+".db")
+
+	if *verboseFlag {
+		fmt.Printf("Adding user ID=%v\n  StorePath:'%v'\n  DBPath:'%v'\n", id, storePath, dbPath)
+	}
+
+	store, err := store.NewOnDiskStore(storePath, []byte(utils.UserPassword))
+	if err != nil {
+		return err
+	}
+
+	_, err = server.AddUser(
+		ctx,
+		connector,
+		store,
+		dialect.SQLite,
+		fmt.Sprintf("file:%v?cache=shared&_fk=1", dbPath))
+	if err != nil {
+		return err
+	}
+
+	if *verboseFlag {
+		fmt.Printf("Starting Connector Sync\n")
+	}
+
+	if err := connector.Sync(context.Background()); err != nil {
+		if *verboseFlag {
+			fmt.Printf("Error during Connector Sync\n")
+		}
+
+		return err
+	}
+
+	if *verboseFlag {
+		fmt.Printf("Finished Connector Sync\n")
+	}
+
+	return nil
+}

--- a/benchmarks/gluon_bench/utils/build_mailbox.go
+++ b/benchmarks/gluon_bench/utils/build_mailbox.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/emersion/go-imap/client"
+	"golang.org/x/exp/rand"
+)
+
+// BuildMailbox creates a mailbox of name `mailbox` and fills it up with `messageCount` random messages.
+func BuildMailbox(cl *client.Client, mailbox string, messageCount int) error {
+	messages := []string{MessageAfterNoonMeeting, MessageMultiPartMixed, MessageEmbedded}
+	messagesLen := len(messages)
+
+	for i := 0; i < messageCount; i++ {
+		if err := AppendToMailbox(cl, mailbox, messages[rand.Intn(messagesLen)], time.Now()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/benchmarks/gluon_bench/utils/client.go
+++ b/benchmarks/gluon_bench/utils/client.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-imap/client"
+)
+
+func NewClient(addr string) (*client.Client, error) {
+	client, err := client.Dial(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.Login(UserName, UserPassword); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func AppendToMailbox(cl *client.Client, mailboxName string, literal string, time time.Time, flags ...string) error {
+	return cl.Append(mailboxName, flags, time, strings.NewReader(literal))
+}
+
+func CloseClient(cl *client.Client) {
+	if err := cl.Logout(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to close client: %v\n", err)
+	}
+}

--- a/benchmarks/gluon_bench/utils/cmd_profiler.go
+++ b/benchmarks/gluon_bench/utils/cmd_profiler.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ProtonMail/gluon/profiling"
+)
+
+// DurationCmdProfiler records the duration of the duration between invocations of IMAP Commands.
+type DurationCmdProfiler struct {
+	calculator [profiling.CmdTypeTotal]TimingCalculator
+	start      [profiling.CmdTypeTotal]time.Time
+}
+
+func (c *DurationCmdProfiler) Start(cmdType int) {
+	// We can use time since Go 1.9 they have switch to monotonic clocks.
+	c.start[cmdType] = time.Now()
+}
+
+func (c *DurationCmdProfiler) Stop(cmdType int) {
+	elapsed := time.Now().Sub(c.start[cmdType])
+	c.calculator[cmdType].Sample(elapsed)
+}
+
+func NewDurationCmdProfiler() *DurationCmdProfiler {
+	return &DurationCmdProfiler{}
+}
+
+type DurationCmdProfilerBuilder struct {
+	mutex     sync.Mutex
+	profilers []*DurationCmdProfiler
+}
+
+func (c *DurationCmdProfilerBuilder) New() profiling.CmdProfiler {
+	profiler := NewDurationCmdProfiler()
+	c.profilers = append(c.profilers, profiler)
+
+	return profiler
+}
+
+func (c *DurationCmdProfilerBuilder) Collect(profiler profiling.CmdProfiler) {
+	switch v := profiler.(type) {
+	case *DurationCmdProfiler:
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+
+		c.profilers = append(c.profilers, v)
+	}
+}
+
+// Merge merges all collected command profilers into a single timing Calculator for each IMAP command.
+func (c *DurationCmdProfilerBuilder) Merge() [profiling.CmdTypeTotal]TimingCalculator {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	var result [profiling.CmdTypeTotal]TimingCalculator
+
+	for _, v := range c.profilers {
+		for i := 0; i < len(result); i++ {
+			result[i].Merge(&v.calculator[i])
+		}
+	}
+
+	return result
+}
+
+func (c *DurationCmdProfilerBuilder) Clear() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.profilers = nil
+}
+
+func NewDurationCmdProfilerBuilder() *DurationCmdProfilerBuilder {
+	return &DurationCmdProfilerBuilder{}
+}

--- a/benchmarks/gluon_bench/utils/constants.go
+++ b/benchmarks/gluon_bench/utils/constants.go
@@ -1,0 +1,4 @@
+package utils
+
+const UserName = "user"
+const UserPassword = "pass"

--- a/benchmarks/gluon_bench/utils/messages.go
+++ b/benchmarks/gluon_bench/utils/messages.go
@@ -1,0 +1,112 @@
+package utils
+
+// Hardcoded messages used to generate mailboxes
+
+const MessageMultiPartMixed = `Return-Path: <somebody@gmail.com>
+Received: from [10.1.1.121] ([185.159.157.131])
+        by smtp.gmail.com with ESMTPSA id t8sm14889112wrr.10.2021.03.26.12.01.23
+        for <somebody@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_128_GCM_SHA256 bits=128/128);
+        Fri, 26 Mar 2021 12:01:24 -0700 (PDT)
+To: somebody@gmail.com
+From: BQA <somebody@gmail.com>
+Subject: Simple test mail
+Message-ID: <d3b6e735-8fb4-9bde-1063-049b97f8f3ca@gmail.com>
+Date: Fri, 26 Mar 2021 20:01:23 +0100
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0)
+ Gecko/20100101 Thunderbird/78.8.1
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------4AC5F36D876D5EED478B5FF9"
+Content-Language: en-US
+
+This is a multi-part message in MIME format.
+--------------4AC5F36D876D5EED478B5FF9
+Content-Type: multipart/alternative;
+ boundary="------------62DCF50B21CF279F489F0184"
+
+
+--------------62DCF50B21CF279F489F0184
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+*this */is**/_html_
+**
+
+--------------62DCF50B21CF279F489F0184
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    <b>this </b><i>is<b> </b></i><u>html</u><br>
+    <b></b>
+  </body>
+</html>
+
+--------------62DCF50B21CF279F489F0184--
+
+--------------4AC5F36D876D5EED478B5FF9
+Content-Type: text/plain; charset=UTF-8; x-mac-type="0"; x-mac-creator="0";
+ name="thing.txt"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="thing.txt"
+
+dGhpcyBpcyBteSBhdHRhY2htZW50Cg==
+--------------4AC5F36D876D5EED478B5FF9--
+
+`
+
+const MessageAfterNoonMeeting = `Date: Mon, 7 Feb 1994 21:52:25 -0800 (PST)
+From: Fred Foobar <foobar@Blurdybloop.COM>
+Subject: afternoon meeting
+To: mooch@owatagu.siam.edu
+Message-Id: <B27397-0100000@Blurdybloop.COM>
+MIME-Version: 1.0
+Content-Type: TEXT/PLAIN; CHARSET=US-ASCII
+
+Hello Joe, do you think we can meet at 3:30 tomorrow?
+`
+
+const MessageEmbedded = `From: Nathaniel Borenstein <nsb@bellcore.com>
+To:  Ned Freed <ned@innosoft.com>
+Subject: Sample message
+MIME-Version: 1.0
+Content-type: multipart/mixed; boundary="simple boundary"
+
+This is the preamble.  It is to be ignored, though it
+is a handy place for mail composers to include an
+explanatory note to non-MIME compliant readers.
+--simple boundary
+Content-type: text/plain; charset=us-ascii
+
+This part does not end with a linebreak.
+--simple boundary
+Content-Disposition: attachment; filename=test.eml
+Content-Type: message/rfc822; name=test.eml
+X-Pm-Content-Encryption: on-import
+
+To: someone
+Subject: Fwd: embedded
+Content-type: multipart/mixed; boundary="embedded-boundary"
+
+--embedded-boundary
+Content-type: text/plain; charset=us-ascii
+
+This part is embedded
+
+--
+From me
+--embedded-boundary
+Content-type: text/plain; charset=us-ascii
+
+This part is also embedded
+--embedded-boundary--
+
+--simple boundary--
+This is the epilogue.  It is also to be ignored.`

--- a/benchmarks/gluon_bench/utils/server_dir_config.go
+++ b/benchmarks/gluon_bench/utils/server_dir_config.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"os"
+)
+
+// ServerDirConfig controls the directory where the server data will be generated.
+type ServerDirConfig interface {
+	Get() (string, error)
+}
+
+// PersistentServerDirConfig always returns a known path.
+type PersistentServerDirConfig struct {
+	path string
+}
+
+func NewPersistentServerDirConfig(path string) *PersistentServerDirConfig {
+	return &PersistentServerDirConfig{path: path}
+}
+
+func (p *PersistentServerDirConfig) Get() (string, error) {
+	if err := os.MkdirAll(p.path, 0o777); err != nil {
+		return "", err
+	}
+
+	return p.path, nil
+}
+
+// TmpServerDirConfig returns a temporary path that is generated on first use.
+type TmpServerDirConfig struct {
+	path string
+}
+
+func (t *TmpServerDirConfig) Get() (string, error) {
+	if len(t.path) == 0 {
+		path, err := os.MkdirTemp("", "gluon-bench-*")
+		if err != nil {
+			return "", err
+		}
+
+		t.path = path
+	}
+
+	return t.path, nil
+}

--- a/benchmarks/gluon_bench/utils/utils.go
+++ b/benchmarks/gluon_bench/utils/utils.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+// ScopedTimer tracks the duration between invocations to Start and Stop.
+type ScopedTimer struct {
+	start time.Time
+	end   time.Time
+}
+
+func (s *ScopedTimer) Start() {
+	s.start = time.Now()
+}
+
+func (s *ScopedTimer) Stop() {
+	s.end = time.Now()
+}
+
+func (s *ScopedTimer) Elapsed() time.Duration {
+	return s.end.Sub(s.start)
+}
+
+// TimingCalculator calculates the fastest , slowest and total duration of a given time period. Feed it duration
+// information via the Sample function.
+type TimingCalculator struct {
+	Fastest     time.Duration
+	Slowest     time.Duration
+	Total       time.Duration
+	SampleCount int64
+}
+
+func (t *TimingCalculator) Reset() {
+	t.Fastest = 0 * time.Second
+	t.Slowest = 0 * time.Second
+	t.Total = 0 * time.Second
+	t.SampleCount = 0
+}
+
+func (t *TimingCalculator) Sample(duration time.Duration) {
+	if t.Fastest == 0 || duration < t.Fastest {
+		t.Fastest = duration
+	}
+
+	if duration > t.Slowest {
+		t.Slowest = duration
+	}
+
+	t.Total += duration
+	t.SampleCount += 1
+}
+
+func (t *TimingCalculator) Merge(other *TimingCalculator) {
+	if other.Fastest < t.Fastest {
+		t.Fastest = other.Fastest
+	}
+
+	if other.Slowest > t.Slowest {
+		t.Slowest = other.Slowest
+	}
+
+	t.Total += other.Total
+	t.SampleCount += other.SampleCount
+}
+
+func (t *TimingCalculator) Average() time.Duration {
+	if t.Total == 0 {
+		return 0
+	}
+
+	return t.Total / time.Duration(t.SampleCount)
+}
+
+func (t *TimingCalculator) String() string {
+	return fmt.Sprintf("Fastest:%06dms Slowest:%06dms Average:%06dms Total:%08dms SampleCount:%04d",
+		t.Fastest.Milliseconds(), t.Slowest.Milliseconds(), t.Average().Milliseconds(), t.Total.Milliseconds(), t.SampleCount)
+}

--- a/internal/session/handle.go
+++ b/internal/session/handle.go
@@ -5,12 +5,14 @@ import (
 	"runtime/pprof"
 	"strconv"
 
+	"github.com/ProtonMail/gluon/profiling"
+
 	"github.com/ProtonMail/gluon/internal/backend"
 	"github.com/ProtonMail/gluon/internal/parser/proto"
 	"github.com/ProtonMail/gluon/internal/response"
 )
 
-func (s *Session) handleOther(ctx context.Context, tag string, cmd *proto.Command) chan response.Response {
+func (s *Session) handleOther(ctx context.Context, tag string, cmd *proto.Command, profiler profiling.CmdProfiler) chan response.Response {
 	ch := make(chan response.Response)
 
 	go func() {
@@ -18,7 +20,7 @@ func (s *Session) handleOther(ctx context.Context, tag string, cmd *proto.Comman
 		pprof.Do(ctx, labels, func(_ context.Context) {
 			defer close(ch)
 
-			if err := s.handleCommand(ctx, tag, cmd, ch); err != nil {
+			if err := s.handleCommand(ctx, tag, cmd, ch, profiler); err != nil {
 				if res, ok := response.FromError(err); ok {
 					ch <- res
 				} else {
@@ -31,19 +33,19 @@ func (s *Session) handleOther(ctx context.Context, tag string, cmd *proto.Comman
 	return ch
 }
 
-func (s *Session) handleCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response) error {
+func (s *Session) handleCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response, profiler profiling.CmdProfiler) error {
 	switch {
 	case
 		cmd.GetCapability() != nil,
 		cmd.GetIdGet() != nil,
 		cmd.GetIdSet() != nil,
 		cmd.GetNoop() != nil:
-		return s.handleAnyCommand(ctx, tag, cmd, ch)
+		return s.handleAnyCommand(ctx, tag, cmd, ch, profiler)
 
 	case
 		cmd.GetAuth() != nil,
 		cmd.GetLogin() != nil:
-		return s.handleNotAuthenticatedCommand(ctx, tag, cmd, ch)
+		return s.handleNotAuthenticatedCommand(ctx, tag, cmd, ch, profiler)
 
 	case
 		cmd.GetSelect() != nil,
@@ -57,8 +59,7 @@ func (s *Session) handleCommand(ctx context.Context, tag string, cmd *proto.Comm
 		cmd.GetLsub() != nil,
 		cmd.GetStatus() != nil,
 		cmd.GetAppend() != nil:
-		return s.handleAuthenticatedCommand(ctx, tag, cmd, ch)
-
+		return s.handleAuthenticatedCommand(ctx, tag, cmd, ch, profiler)
 	case
 		cmd.GetCheck() != nil,
 		cmd.GetClose() != nil,
@@ -71,27 +72,34 @@ func (s *Session) handleCommand(ctx context.Context, tag string, cmd *proto.Comm
 		cmd.GetCopy() != nil,
 		cmd.GetMove() != nil,
 		cmd.GetUid() != nil:
-		return s.handleSelectedCommand(ctx, tag, cmd, ch)
+		return s.handleSelectedCommand(ctx, tag, cmd, ch, profiler)
 
 	default:
 		panic("bad command")
 	}
 }
 
-func (s *Session) handleAnyCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response) error {
+func (s *Session) handleAnyCommand(ctx context.Context, tag string, cmd *proto.Command,
+	ch chan response.Response, profiler profiling.CmdProfiler) error {
 	switch {
 	case cmd.GetCapability() != nil:
 		// 6.1.1 CAPABILITY Command
 		return s.handleCapability(ctx, tag, cmd.GetCapability(), ch)
 
 	case cmd.GetNoop() != nil:
+		profiler.Start(profiling.CmdTypeNoop)
+		defer profiler.Stop(profiling.CmdTypeNoop)
 		// 6.1.2 NOOP Command
 		return s.handleNoop(ctx, tag, cmd.GetNoop(), ch)
 
 	case cmd.GetIdSet() != nil:
+		profiler.Start(profiling.CmdTypeID)
+		defer profiler.Stop(profiling.CmdTypeID)
 		// RFC 2971 ID
 		return s.handleIDSet(ctx, tag, cmd.GetIdSet(), ch)
 	case cmd.GetIdGet() != nil:
+		profiler.Start(profiling.CmdTypeID)
+		defer profiler.Stop(profiling.CmdTypeID)
 		// RFC 2971 ID
 		return s.handleIDGet(ctx, tag, ch)
 
@@ -100,13 +108,16 @@ func (s *Session) handleAnyCommand(ctx context.Context, tag string, cmd *proto.C
 	}
 }
 
-func (s *Session) handleNotAuthenticatedCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response) error {
+func (s *Session) handleNotAuthenticatedCommand(ctx context.Context, tag string, cmd *proto.Command,
+	ch chan response.Response, profiler profiling.CmdProfiler) error {
 	switch {
 	case cmd.GetAuth() != nil:
 		// 6.2.2. AUTHENTICATE Command
 		return ErrNotImplemented
 
 	case cmd.GetLogin() != nil:
+		profiler.Start(profiling.CmdTypeLogin)
+		defer profiler.Stop(profiling.CmdTypeLogin)
 		// 6.2.3. LOGIN Command
 		return s.handleLogin(ctx, tag, cmd.GetLogin(), ch)
 
@@ -115,7 +126,8 @@ func (s *Session) handleNotAuthenticatedCommand(ctx context.Context, tag string,
 	}
 }
 
-func (s *Session) handleAuthenticatedCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response) error {
+func (s *Session) handleAuthenticatedCommand(ctx context.Context, tag string, cmd *proto.Command,
+	ch chan response.Response, profiler profiling.CmdProfiler) error {
 	s.userLock.Lock()
 	defer s.userLock.Unlock()
 
@@ -125,46 +137,68 @@ func (s *Session) handleAuthenticatedCommand(ctx context.Context, tag string, cm
 
 	switch {
 	case cmd.GetSelect() != nil:
+		profiler.Start(profiling.CmdTypeSelect)
+		defer profiler.Stop(profiling.CmdTypeSelect)
 		// 6.3.1. SELECT Command
 		return s.handleSelect(ctx, tag, cmd.GetSelect(), ch)
 
 	case cmd.GetExamine() != nil:
+		profiler.Start(profiling.CmdTypeExamine)
+		defer profiler.Stop(profiling.CmdTypeExamine)
 		// 6.3.2. EXAMINE Command
 		return s.handleExamine(ctx, tag, cmd.GetExamine(), ch)
 
 	case cmd.GetCreate() != nil:
+		profiler.Start(profiling.CmdTypeCreate)
+		defer profiler.Stop(profiling.CmdTypeCreate)
 		// 6.3.3. CREATE Command
 		return s.handleCreate(ctx, tag, cmd.GetCreate(), ch)
 
 	case cmd.GetDel() != nil:
+		profiler.Start(profiling.CmdTypeDelete)
+		defer profiler.Stop(profiling.CmdTypeDelete)
 		// 6.3.4. DELETE Command
 		return s.handleDelete(ctx, tag, cmd.GetDel(), ch)
 
 	case cmd.GetRename() != nil:
+		profiler.Start(profiling.CmdTypeRename)
+		defer profiler.Stop(profiling.CmdTypeRename)
 		// 6.3.5. RENAME Command
 		return s.handleRename(ctx, tag, cmd.GetRename(), ch)
 
 	case cmd.GetSub() != nil:
+		profiler.Start(profiling.CmdTypeSubscribe)
+		defer profiler.Stop(profiling.CmdTypeSubscribe)
 		// 6.3.6. SUBSCRIBE Command
 		return s.handleSub(ctx, tag, cmd.GetSub(), ch)
 
 	case cmd.GetUnsub() != nil:
+		profiler.Start(profiling.CmdTypeUnsubscribe)
+		defer profiler.Stop(profiling.CmdTypeUnsubscribe)
 		// 6.3.7. UNSUBSCRIBE Command
 		return s.handleUnsub(ctx, tag, cmd.GetUnsub(), ch)
 
 	case cmd.GetList() != nil:
+		profiler.Start(profiling.CmdTypeList)
+		defer profiler.Stop(profiling.CmdTypeList)
 		// 6.3.8. LIST Command
 		return s.handleList(ctx, tag, cmd.GetList(), ch)
 
 	case cmd.GetLsub() != nil:
+		profiler.Start(profiling.CmdTypeLSub)
+		defer profiler.Stop(profiling.CmdTypeLSub)
 		// 6.3.9. Lsub Command
 		return s.handleLsub(ctx, tag, cmd.GetLsub(), ch)
 
 	case cmd.GetStatus() != nil:
+		profiler.Start(profiling.CmdTypeStatus)
+		defer profiler.Stop(profiling.CmdTypeStatus)
 		// 6.3.10. STATUS Command
 		return s.handleStatus(ctx, tag, cmd.GetStatus(), ch)
 
 	case cmd.GetAppend() != nil:
+		profiler.Start(profiling.CmdTypeAppend)
+		defer profiler.Stop(profiling.CmdTypeAppend)
 		// 6.3.11. APPEND Command
 		return s.handleAppend(ctx, tag, cmd.GetAppend(), ch)
 
@@ -173,7 +207,7 @@ func (s *Session) handleAuthenticatedCommand(ctx context.Context, tag string, cm
 	}
 }
 
-func (s *Session) handleSelectedCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response) error {
+func (s *Session) handleSelectedCommand(ctx context.Context, tag string, cmd *proto.Command, ch chan response.Response, profiler profiling.CmdProfiler) error {
 	s.userLock.Lock()
 	defer s.userLock.Unlock()
 
@@ -187,7 +221,7 @@ func (s *Session) handleSelectedCommand(ctx context.Context, tag string, cmd *pr
 			return err
 		}
 
-		if err := s.handleWithMailbox(ctx, tag, cmd, mailbox, ch); err != nil {
+		if err := s.handleWithMailbox(ctx, tag, cmd, mailbox, ch, profiler); err != nil {
 			return err
 		}
 
@@ -195,49 +229,72 @@ func (s *Session) handleSelectedCommand(ctx context.Context, tag string, cmd *pr
 	})
 }
 
-func (s *Session) handleWithMailbox(ctx context.Context, tag string, cmd *proto.Command, mailbox *backend.Mailbox, ch chan response.Response) error {
+func (s *Session) handleWithMailbox(ctx context.Context, tag string, cmd *proto.Command, mailbox *backend.Mailbox,
+	ch chan response.Response, profiler profiling.CmdProfiler) error {
 	switch {
 	case cmd.GetCheck() != nil:
+		profiler.Start(profiling.CmdTypeCheck)
+		defer profiler.Stop(profiling.CmdTypeCheck)
 		// 6.4.1. CHECK Command
 		return s.handleCheck(ctx, tag, cmd.GetCheck(), mailbox, ch)
 
 	case cmd.GetClose() != nil:
+		profiler.Start(profiling.CmdTypeClose)
+		defer profiler.Stop(profiling.CmdTypeClose)
 		// 6.4.2. CLOSE Command
 		return s.handleClose(ctx, tag, cmd.GetClose(), mailbox, ch)
 
 	case cmd.GetExpunge() != nil:
+		profiler.Start(profiling.CmdTypeExpunge)
+		defer profiler.Stop(profiling.CmdTypeExpunge)
 		// 6.4.3. EXPUNGE Command
 		return s.handleExpunge(ctx, tag, cmd.GetExpunge(), mailbox, ch)
 
 	case cmd.GetUidExpunge() != nil:
+		profiler.Start(profiling.CmdTypeExpunge)
+		defer profiler.Stop(profiling.CmdTypeExpunge)
 		// RFC4315 UIDPLUS Extension
 		return s.handleUIDExpunge(ctx, tag, cmd.GetUidExpunge(), mailbox, ch)
 
 	case cmd.GetUnselect() != nil:
+		profiler.Start(profiling.CmdTypeUnselect)
+		defer profiler.Stop(profiling.CmdTypeUnselect)
 		// RFC3691 UNSELECT Extension
 		return s.handleUnselect(ctx, tag, cmd.GetUnselect(), mailbox, ch)
 
 	case cmd.GetSearch() != nil:
+		profiler.Start(profiling.CmdTypeSearch)
+		defer profiler.Stop(profiling.CmdTypeSearch)
 		// 6.4.4. SEARCH Command
 		return s.handleSearch(ctx, tag, cmd.GetSearch(), mailbox, ch)
 
 	case cmd.GetFetch() != nil:
+		profiler.Start(profiling.CmdTypeFetch)
+		defer profiler.Stop(profiling.CmdTypeFetch)
 		// 6.4.5. FETCH Command
 		return s.handleFetch(ctx, tag, cmd.GetFetch(), mailbox, ch)
 
 	case cmd.GetStore() != nil:
+		profiler.Start(profiling.CmdTypeStore)
+		defer profiler.Stop(profiling.CmdTypeStore)
 		// 6.4.6. STORE Command
 		return s.handleStore(ctx, tag, cmd.GetStore(), mailbox, ch)
 
 	case cmd.GetCopy() != nil:
+		profiler.Start(profiling.CmdTypeCopy)
+		defer profiler.Stop(profiling.CmdTypeCopy)
 		// 6.4.7. COPY Command
 		return s.handleCopy(ctx, tag, cmd.GetCopy(), mailbox, ch)
 
 	case cmd.GetUid() != nil:
+		profiler.Start(profiling.CmdTypeUID)
+		defer profiler.Stop(profiling.CmdTypeUID)
 		// 6.4.8. UID Command
 		return s.handleUID(ctx, tag, cmd.GetUid(), mailbox, ch)
 
 	case cmd.GetMove() != nil:
+		profiler.Start(profiling.CmdTypeMove)
+		defer profiler.Stop(profiling.CmdTypeMove)
 		// RFC6851 MOVE Command
 		return s.handleMove(ctx, tag, cmd.GetMove(), mailbox, ch)
 

--- a/option.go
+++ b/option.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"io"
 
+	"github.com/ProtonMail/gluon/profiling"
+
 	"github.com/ProtonMail/gluon/internal"
 )
 
@@ -80,4 +82,17 @@ func WithVersionInfo(vmajor, vminor, vpatch int, name, vendor, supportURL string
 			SupportURL: supportURL,
 		},
 	}
+}
+
+type withCmdExecProfiler struct {
+	builder profiling.CmdProfilerBuilder
+}
+
+func (c *withCmdExecProfiler) config(server *Server) {
+	server.cmdExecProfBuilder = c.builder
+}
+
+// WithCmdProfiler allows a specific CmdProfilerBuilder to be set for the server's execution.
+func WithCmdProfiler(builder profiling.CmdProfilerBuilder) Option {
+	return &withCmdExecProfiler{builder: builder}
 }

--- a/profiling/cmd_profiler.go
+++ b/profiling/cmd_profiler.go
@@ -1,0 +1,125 @@
+package profiling
+
+const (
+	CmdTypeSelect      = 0
+	CmdTypeCreate      = 1
+	CmdTypeDelete      = 2
+	CmdTypeRename      = 3
+	CmdTypeSubscribe   = 4
+	CmdTypeUnsubscribe = 5
+	CmdTypeList        = 6
+	CmdTypeLSub        = 7
+	CmdTypeStatus      = 8
+	CmdTypeAppend      = 9
+	CmdTypeCheck       = 10
+	CmdTypeClose       = 11
+	CmdTypeExpunge     = 12
+	CmdTypeSearch      = 13
+	CmdTypeFetch       = 14
+	CmdTypeStore       = 15
+	CmdTypeCopy        = 16
+	CmdTypeUID         = 17
+	CmdTypeNoop        = 18
+	CmdTypeIdle        = 19
+	CmdTypeMove        = 20
+	CmdTypeID          = 21
+	CmdTypeLogout      = 22
+	CmdTypeUnselect    = 23
+	CmdTypeLogin       = 24
+	CmdTypeExamine     = 25
+	CmdTypeTotal       = 26
+)
+
+func CmdTypeToString(cmdType int) string {
+	switch cmdType {
+	case CmdTypeSelect:
+		return "SELECT "
+	case CmdTypeCreate:
+		return "CREATE "
+	case CmdTypeDelete:
+		return "DELETE "
+	case CmdTypeRename:
+		return "RENAME "
+	case CmdTypeSubscribe:
+		return "SUB    "
+	case CmdTypeUnsubscribe:
+		return "USUB   "
+	case CmdTypeList:
+		return "LIST   "
+	case CmdTypeLSub:
+		return "LSUB   "
+	case CmdTypeStatus:
+		return "STATUS "
+	case CmdTypeAppend:
+		return "APPEND "
+	case CmdTypeCheck:
+		return "CHECK  "
+	case CmdTypeClose:
+		return "CLOSE  "
+	case CmdTypeExpunge:
+		return "EXPUNGE"
+	case CmdTypeSearch:
+		return "SEARCH "
+	case CmdTypeFetch:
+		return "FETCH  "
+	case CmdTypeStore:
+		return "STORE  "
+	case CmdTypeCopy:
+		return "COPY   "
+	case CmdTypeUID:
+		return "UID    "
+	case CmdTypeNoop:
+		return "NOOP   "
+	case CmdTypeIdle:
+		return "IDLE   "
+	case CmdTypeMove:
+		return "MOVE   "
+	case CmdTypeID:
+		return "ID     "
+	case CmdTypeLogout:
+		return "LOGOUT "
+	case CmdTypeUnselect:
+		return "USELECT"
+	case CmdTypeLogin:
+		return "LOGIN  "
+	case CmdTypeExamine:
+		return "EXAMINE"
+
+	default:
+		return "Unknown"
+	}
+}
+
+// CmdProfiler is the interface that can be used to perform measurements related to the execution
+// scope of incoming IMAP commands.
+type CmdProfiler interface {
+	// Start will be called once the command has been received and interpreted.
+	Start(cmdType int)
+	// Stop will be called once the command has finished executing and all the replies sent to the client.
+	Stop(cmdType int)
+}
+
+// CmdProfilerBuilder is the interface through which an instance of the CmdProfiler gets created. One of these will be
+// created for each connecting IMAP client.
+type CmdProfilerBuilder interface {
+	// New creates a new CmdProfiler instance.
+	New() CmdProfiler
+
+	// Collect will be called when the IMAP client has disconnected/logged out.
+	Collect(profiler CmdProfiler)
+}
+
+// NullCmdProfiler represents a null implementation of CmdProfiler.
+type NullCmdProfiler struct{}
+
+func (*NullCmdProfiler) Start(int) {}
+
+func (*NullCmdProfiler) Stop(int) {}
+
+type NullCmdExecProfilerBuilder struct{}
+
+func (*NullCmdExecProfilerBuilder) New() CmdProfiler {
+	return &NullCmdProfiler{}
+}
+
+func (*NullCmdExecProfilerBuilder) Collect(CmdProfiler) {}


### PR DESCRIPTION
This patch adds gluon_bench in order to enable use to write benchmarks
that run gluon in the same process as the benchmark or externally. The
support for external processes will be added in a future patch.

The benchmark tool supports producing a report to stdout or a json file.
New reporters can be added as needed.

At the moment, there is only one benchmark which measures the time to
append 1000 message to a mailbox. More benchmark will follow in the
future.

Additionally, the tool also supports running multiple benchmarks for a
configurable number of consecutive times with or without persistent
state.

Finally, this patch also extends Gluon with support to profile the
execution of individual commands inside Gluon. This information is
collected by the benchmark tool to produce its reports.