### PR TITLE
feat(GODT-1917): Bechmark interface and server interface.

### DIFF
--- a/benchmarks/gluon_bench/benchmarks/benchmark.go
+++ b/benchmarks/gluon_bench/benchmarks/benchmark.go
@@ -1,0 +1,20 @@
+package benchmarks
+
+import (
+	"context"
+	"net"
+)
+
+type Benchmark interface {
+	// Name should return the name of the bechmark, it will also be used to match against cli args.
+	Name() string
+
+	// Setup sets up the benchmark state, this is not timed.
+	Setup(ctx context.Context, addr net.Addr) error
+
+	// Run performs the actual benchmark, this is timed.
+	Run(ctx context.Context, addr net.Addr) error
+
+	// TearDown clear the benchmark state, this is not timed.
+	TearDown(ctx context.Context, addr net.Addr) error
+}

--- a/benchmarks/gluon_bench/benchmarks/mailbox_create.go
+++ b/benchmarks/gluon_bench/benchmarks/mailbox_create.go
@@ -2,21 +2,32 @@ package benchmarks
 
 import (
 	"context"
-	"fmt"
+	"net"
 
-	"github.com/ProtonMail/gluon"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/utils"
 )
 
-func BenchmarkMailboxCreate(ctx context.Context, server *gluon.Server, addr string) {
-	cl, err := utils.NewClient(addr)
+type MailboxCreate struct{}
+
+func (b *MailboxCreate) Name() string {
+	return "mailbox-create"
+}
+
+func (*MailboxCreate) Setup(ctx context.Context, addr net.Addr) error {
+	return nil
+}
+
+func (*MailboxCreate) TearDown(ctx context.Context, addr net.Addr) error {
+	return nil
+}
+
+func (*MailboxCreate) Run(ctx context.Context, addr net.Addr) error {
+	cl, err := utils.NewClient(addr.String())
 	defer utils.CloseClient(cl)
 
 	if err != nil {
-		panic("Failed to connect o server")
+		return err
 	}
 
-	if err := utils.BuildMailbox(cl, "INBOX", 1000); err != nil {
-		panic(fmt.Sprintf("Benchmark Mailbox Create - Failed to create mailbox: %v", err))
-	}
+	return utils.BuildMailbox(cl, "INBOX", 1000)
 }

--- a/benchmarks/gluon_bench/server/remote.go
+++ b/benchmarks/gluon_bench/server/remote.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"net"
+
+	"github.com/ProtonMail/gluon/profiling"
+)
+
+// RemoteServer can't control the start or stopping of the server but can still be used to run the benchmarks
+// against an existing server.
+type RemoteServer struct {
+	address net.Addr
+}
+
+func (*RemoteServer) Close(ctx context.Context) error {
+	return nil
+}
+
+func (r *RemoteServer) Address() net.Addr {
+	return r.address
+}
+
+type RemoteServerBuilder struct {
+	address net.Addr
+}
+
+func NewRemoteServerBuilder(address string) (*RemoteServerBuilder, error) {
+	addr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RemoteServerBuilder{address: addr}, nil
+}
+
+func (r *RemoteServerBuilder) New(ctx context.Context, serverPath string, profiler profiling.CmdProfilerBuilder) (Server, error) {
+	return &RemoteServer{address: r.address}, nil
+}

--- a/benchmarks/gluon_bench/server/server.go
+++ b/benchmarks/gluon_bench/server/server.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"context"
+	"net"
+
+	"github.com/ProtonMail/gluon/profiling"
+)
+
+type Server interface {
+	// Close should close all server connections or shut down the server.
+	Close(ctx context.Context) error
+
+	// Address should return the server address.
+	Address() net.Addr
+}
+
+type ServerBuilder interface {
+	// New Create new Server instance at a given path and use the command profiler, if possible.
+	New(ctx context.Context, serverPath string, profiler profiling.CmdProfilerBuilder) (Server, error)
+}


### PR DESCRIPTION
This patch introduces the `benchmark.Benchmark` interface to enable
benchmark to setup and tear down before actually running their checks.
For instance, this will be used by fetch to determine the number of
messages present in the mailbox.

This patch also introduces the `server.Server` interface to enable the
benchmark to be run against an external server. Current implementations
include a local implementation (run in process) and remote server which
the benchmark doesn't start, but can still connect to.