### PR TITLE
test(GODT-1584): * should resolve without error with UID commands

### DIFF
--- a/tests/sequence_range_test.go
+++ b/tests/sequence_range_test.go
@@ -135,3 +135,17 @@ func TestUIDSequenceRange(t *testing.T) {
 		c.OK(`A017`)
 	})
 }
+
+func TestWildcard(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
+		// Create an empty mailbox.
+		c.C("tag create mbox").OK("tag")
+		c.C("tag select mbox").OK("tag")
+
+		// FETCH with wildcard returns BAD.
+		c.C("tag fetch * (flags)").BAD("tag")
+
+		// UID FETCH with wildcard returns OK.
+		c.C("tag uid fetch * (flags)").OK("tag")
+	})
+}


### PR DESCRIPTION
The * refers to the last message in a mailbox. When the mailbox is
empty, we copy dovecot's behaviour, which is to return treat this as an
error with normal commands but to resolve without error with UID
commands.