### PR TITLE
chore: Refactor Server so that it own's the user database

### DIFF
--- a/demo/demo.go
+++ b/demo/demo.go
@@ -3,18 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"time"
 
-	"entgo.io/ent/dialect"
 	"github.com/ProtonMail/gluon"
 	"github.com/ProtonMail/gluon/connector"
 	"github.com/ProtonMail/gluon/imap"
-	"github.com/ProtonMail/gluon/store"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/profile"
 	"github.com/sirupsen/logrus"
 )
@@ -53,7 +48,9 @@ func main() {
 	server, err := gluon.New(temp(), gluon.WithLogger(
 		loggerIn,
 		loggerOut,
-	))
+	),
+		gluon.WithDataPath(temp()),
+	)
 
 	defer server.Close(ctx)
 
@@ -91,17 +88,10 @@ func addUser(ctx context.Context, server *gluon.Server, addresses []string, pass
 		imap.NewFlagSet(),
 	)
 
-	store, err := store.NewOnDiskStore(temp(), []byte("passphrase"))
-	if err != nil {
-		return err
-	}
-
 	userID, err := server.AddUser(
 		ctx,
 		connector,
-		store,
-		dialect.SQLite,
-		fmt.Sprintf("file:%v?cache=shared&_fk=1", filepath.Join(temp(), fmt.Sprintf("%v.db", "userID"))),
+		password,
 	)
 	if err != nil {
 		return err

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -38,29 +38,31 @@ func New(dir string) (*Backend, error) {
 	}, nil
 }
 
+func (b *Backend) NewUserID() string {
+	return uuid.NewString()
+}
+
 func (b *Backend) SetDelimiter(delim string) {
 	b.delim = delim
 }
 
-func (b *Backend) AddUser(ctx context.Context, conn connector.Connector, store store.Store, client *ent.Client) (string, error) {
+func (b *Backend) AddUser(ctx context.Context, userID string, conn connector.Connector, store store.Store, client *ent.Client) error {
 	b.usersLock.Lock()
 	defer b.usersLock.Unlock()
 
-	userID := uuid.NewString()
-
 	remote, err := b.remote.AddUser(ctx, userID, conn)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	user, err := newUser(ctx, userID, client, remote, store, b.delim)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	b.users[userID] = user
 
-	return userID, nil
+	return nil
 }
 
 func (b *Backend) RemoveUser(ctx context.Context, userID string) error {

--- a/option.go
+++ b/option.go
@@ -4,9 +4,9 @@ import (
 	"crypto/tls"
 	"io"
 
-	"github.com/ProtonMail/gluon/profiling"
-
 	"github.com/ProtonMail/gluon/internal"
+	"github.com/ProtonMail/gluon/profiling"
+	"github.com/ProtonMail/gluon/store"
 )
 
 // Option represents a type that can be used to configure the server.
@@ -95,4 +95,28 @@ func (c *withCmdExecProfiler) config(server *Server) {
 // WithCmdProfiler allows a specific CmdProfilerBuilder to be set for the server's execution.
 func WithCmdProfiler(builder profiling.CmdProfilerBuilder) Option {
 	return &withCmdExecProfiler{builder: builder}
+}
+
+type withStoreBuilder struct {
+	builder store.StoreBuilder
+}
+
+func (w *withStoreBuilder) config(server *Server) {
+	server.storeBuilder = w.builder
+}
+
+func WithStoreBuilder(builder store.StoreBuilder) Option {
+	return &withStoreBuilder{builder: builder}
+}
+
+type withDataPath struct {
+	path string
+}
+
+func (w *withDataPath) config(server *Server) {
+	server.dataPath = w.path
+}
+
+func WithDataPath(path string) Option {
+	return &withDataPath{path: path}
 }

--- a/store/disk.go
+++ b/store/disk.go
@@ -124,3 +124,15 @@ func (c *onDiskStore) Delete(ids ...string) error {
 
 	return nil
 }
+
+func (c *onDiskStore) Close() error {
+	return nil
+}
+
+type OnDiskStoreBuilder struct{}
+
+func (*OnDiskStoreBuilder) New(path, userID, userPassword string) (Store, error) {
+	storePath := filepath.Join(path, userID)
+
+	return NewOnDiskStore(storePath, []byte(userPassword))
+}

--- a/store/memory.go
+++ b/store/memory.go
@@ -63,3 +63,12 @@ func (c *inMemoryStore) Delete(ids ...string) error {
 
 	return nil
 }
+
+func (c *inMemoryStore) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.data = make(map[string][]byte)
+
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -5,4 +5,9 @@ type Store interface {
 	Set(messageID string, literal []byte) error
 	Update(oldID, newID string) error
 	Delete(messageID ...string) error
+	Close() error
+}
+
+type StoreBuilder interface {
+	New(directory, userID, encryptionPassphrase string) (Store, error)
 }


### PR DESCRIPTION
Refactor Gluon Server so that it owns the data generate for each user.
The data store path can be configured with the `WithDataPath` option.

The `AddUser` function is now meant to be used to create new user which
has not been added before. `LoadUser` has been added load existing data
from disk.

`AddUser` and `LoadUser` have been simplified. Gluon internally controls
the database parameters and `Store` implementation. To override the
default disk storage implementation, use the `WithStoreBuilder` option.

The user's data path can be queried with `Server.GetUserDataPath()`.