### PR TITLE
fix(GODT-1618): properly handle empty LIST pattern

### DIFF
--- a/internal/backend/match_test.go
+++ b/internal/backend/match_test.go
@@ -30,6 +30,18 @@ func TestMatch(t *testing.T) {
 			want:      "/",
 		},
 		{
+			ref:       "some.",
+			pattern:   "",
+			delimiter: ".",
+			want:      "some.",
+		},
+		{
+			ref:       "some",
+			pattern:   "",
+			delimiter: ".",
+			want:      "",
+		},
+		{
 			ref:       "",
 			pattern:   "*",
 			delimiter: "/",
@@ -56,6 +68,13 @@ func TestMatch(t *testing.T) {
 			delimiter: "/",
 			name:      "~/Mail/foo/bar",
 			want:      "~/Mail/foo",
+		},
+		{
+			ref:       "some.",
+			pattern:   "thing",
+			delimiter: ".",
+			name:      "some.thing",
+			want:      "some.thing",
 		},
 	}
 

--- a/internal/backend/state.go
+++ b/internal/backend/state.go
@@ -41,7 +41,6 @@ func (state *State) UserID() string {
 
 func (state *State) List(ctx context.Context, ref, pattern string, subscribed bool, fn func(map[string]Match) error) error {
 	return state.tx(ctx, func(tx *ent.Tx) error {
-
 		mailboxes, err := DBGetAllMailboxes(ctx, tx.Client())
 		if err != nil {
 			return err


### PR DESCRIPTION
RFC3501 states:
    An empty ("" string) mailbox name argument is a special request to
    return the hierarchy delimiter and the root name of the name given
    in the reference. The value returned as the root MAY be the empty
    string if the reference is non-rooted or is an empty string.

We didn't return the empty string for non-rooted references.