### PR TITLE
Database RW Split

### DIFF
--- a/benchmarks/gluon_bench/store_benchmarks/create.go
+++ b/benchmarks/gluon_bench/store_benchmarks/create.go
@@ -2,12 +2,12 @@ package store_benchmarks
 
 import (
 	"context"
-	"github.com/ProtonMail/gluon/imap"
 
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/benchmark"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/flags"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/reporter"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/timing"
+	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/store"
 	"github.com/google/uuid"
 )

--- a/benchmarks/gluon_bench/store_benchmarks/delete.go
+++ b/benchmarks/gluon_bench/store_benchmarks/delete.go
@@ -2,12 +2,12 @@ package store_benchmarks
 
 import (
 	"context"
-	"github.com/ProtonMail/gluon/imap"
 
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/benchmark"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/flags"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/reporter"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/timing"
+	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/store"
 )
 

--- a/benchmarks/gluon_bench/store_benchmarks/get.go
+++ b/benchmarks/gluon_bench/store_benchmarks/get.go
@@ -2,13 +2,13 @@ package store_benchmarks
 
 import (
 	"context"
-	"github.com/ProtonMail/gluon/imap"
 	"math/rand"
 
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/benchmark"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/flags"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/reporter"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/timing"
+	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/store"
 )
 

--- a/benchmarks/gluon_bench/store_benchmarks/utils.go
+++ b/benchmarks/gluon_bench/store_benchmarks/utils.go
@@ -2,13 +2,13 @@ package store_benchmarks
 
 import (
 	"context"
-	"github.com/ProtonMail/gluon/imap"
 	"sync"
 	"time"
 
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/flags"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/reporter"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/timing"
+	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/store"
 	"github.com/google/uuid"
 )

--- a/internal/backend/db_mailbox.go
+++ b/internal/backend/db_mailbox.go
@@ -166,7 +166,7 @@ func DBGetMailboxMessageIDPairs(ctx context.Context, client *ent.Client, mailbox
 	}), nil
 }
 
-func DBGetUIDInterval(ctx context.Context, mbox *ent.Mailbox, begin, end int) ([]*ent.UID, error) {
+func DBGetUIDInterval(ctx context.Context, client *ent.Client, mbox *ent.Mailbox, begin, end int) ([]*ent.UID, error) {
 	return mbox.QueryUIDs().
 		Where(uid.UIDGTE(begin), uid.UIDLTE(end)).
 		WithMessage().
@@ -211,15 +211,15 @@ func DBGetMailboxByID(ctx context.Context, client *ent.Client, id imap.InternalM
 	return client.Mailbox.Query().Where(mailbox.MailboxID(id)).Only(ctx)
 }
 
-func DBGetMailboxMessages(ctx context.Context, mbox *ent.Mailbox) ([]*ent.UID, error) {
+func DBGetMailboxMessages(ctx context.Context, client *ent.Client, mbox *ent.Mailbox) ([]*ent.UID, error) {
 	return mbox.QueryUIDs().WithMessage().All(ctx)
 }
 
-func DBGetMailboxRecentCount(ctx context.Context, mbox *ent.Mailbox) (int, error) {
+func DBGetMailboxRecentCount(ctx context.Context, client *ent.Client, mbox *ent.Mailbox) (int, error) {
 	return mbox.QueryUIDs().Where(uid.Recent(true)).Count(ctx)
 }
 
-func DBGetMailboxMessagesForNewSnapshot(ctx context.Context, mbox *ent.Mailbox) ([]*ent.UID, error) {
+func DBGetMailboxMessagesForNewSnapshot(ctx context.Context, client *ent.Client, mbox *ent.Mailbox) ([]*ent.UID, error) {
 	var msgUIDs []*ent.UID
 
 	const QueryLimit = 16000

--- a/internal/backend/db_message.go
+++ b/internal/backend/db_message.go
@@ -440,8 +440,8 @@ func DBDeleteMessages(ctx context.Context, tx *ent.Tx, messageIDs ...imap.Intern
 	return nil
 }
 
-func DBGetMessageIDsMarkedDeleted(ctx context.Context, tx *ent.Tx) ([]imap.InternalMessageID, error) {
-	messages, err := tx.Message.Query().Where(message.Deleted(true)).Select(message.FieldMessageID).All(ctx)
+func DBGetMessageIDsMarkedDeleted(ctx context.Context, client *ent.Client) ([]imap.InternalMessageID, error) {
+	messages, err := client.Message.Query().Where(message.Deleted(true)).Select(message.FieldMessageID).All(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/mailbox_search.go
+++ b/internal/backend/mailbox_search.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ProtonMail/gluon/internal/backend/ent"
+
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/parser/proto"
 	"github.com/ProtonMail/gluon/rfc822"
@@ -197,13 +199,15 @@ func (m *Mailbox) matchSearchKeyBefore(ctx context.Context, candidates []*snapMs
 		return nil, err
 	}
 
-	return filter(candidates, func(message *snapMsg) (bool, error) {
-		msg, err := DBGetMessage(ctx, m.tx.Client(), message.ID.InternalID)
-		if err != nil {
-			return false, err
-		}
+	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+		return filter(candidates, func(message *snapMsg) (bool, error) {
+			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
+			if err != nil {
+				return false, err
+			}
 
-		return msg.Date.Before(beforeDate), nil
+			return msg.Date.Before(beforeDate), nil
+		})
 	})
 }
 
@@ -316,13 +320,15 @@ func (m *Mailbox) matchSearchKeyKeyword(ctx context.Context, candidates []*snapM
 }
 
 func (m *Mailbox) matchSearchKeyLarger(ctx context.Context, candidates []*snapMsg, key *proto.SearchKey) ([]*snapMsg, error) {
-	return filter(candidates, func(message *snapMsg) (bool, error) {
-		msg, err := DBGetMessage(ctx, m.tx.Client(), message.ID.InternalID)
-		if err != nil {
-			return false, err
-		}
+	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+		return filter(candidates, func(message *snapMsg) (bool, error) {
+			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
+			if err != nil {
+				return false, err
+			}
 
-		return msg.Size > int(key.GetSize()), nil
+			return msg.Size > int(key.GetSize()), nil
+		})
 	})
 }
 
@@ -355,13 +361,15 @@ func (m *Mailbox) matchSearchKeyOn(ctx context.Context, candidates []*snapMsg, k
 		return nil, err
 	}
 
-	return filter(candidates, func(message *snapMsg) (bool, error) {
-		msg, err := DBGetMessage(ctx, m.tx.Client(), message.ID.InternalID)
-		if err != nil {
-			return false, err
-		}
+	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+		return filter(candidates, func(message *snapMsg) (bool, error) {
+			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
+			if err != nil {
+				return false, err
+			}
 
-		return onDate.Truncate(24 * time.Hour).Equal(msg.Date.Truncate(24 * time.Hour)), nil
+			return onDate.Truncate(24 * time.Hour).Equal(msg.Date.Truncate(24 * time.Hour)), nil
+		})
 	})
 }
 
@@ -487,26 +495,30 @@ func (m *Mailbox) matchSearchKeySince(ctx context.Context, candidates []*snapMsg
 		return nil, err
 	}
 
-	return filter(candidates, func(message *snapMsg) (bool, error) {
-		msg, err := DBGetMessage(ctx, m.tx.Client(), message.ID.InternalID)
-		if err != nil {
-			return false, err
-		}
+	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+		return filter(candidates, func(message *snapMsg) (bool, error) {
+			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
+			if err != nil {
+				return false, err
+			}
 
-		date := convertToDateWithoutTZ(msg.Date)
+			date := convertToDateWithoutTZ(msg.Date)
 
-		return date.Equal(sinceDate) || date.After(sinceDate), nil
+			return date.Equal(sinceDate) || date.After(sinceDate), nil
+		})
 	})
 }
 
 func (m *Mailbox) matchSearchKeySmaller(ctx context.Context, candidates []*snapMsg, key *proto.SearchKey) ([]*snapMsg, error) {
-	return filter(candidates, func(message *snapMsg) (bool, error) {
-		msg, err := DBGetMessage(ctx, m.tx.Client(), message.ID.InternalID)
-		if err != nil {
-			return false, err
-		}
+	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+		return filter(candidates, func(message *snapMsg) (bool, error) {
+			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
+			if err != nil {
+				return false, err
+			}
 
-		return msg.Size < int(key.GetSize()), nil
+			return msg.Size < int(key.GetSize()), nil
+		})
 	})
 }
 

--- a/internal/backend/match.go
+++ b/internal/backend/match.go
@@ -19,6 +19,7 @@ type Match struct {
 
 func getMatches(
 	ctx context.Context,
+	client *ent.Client,
 	mailboxes []*ent.Mailbox,
 	ref, pattern, delimiter string,
 	subscribed bool,
@@ -36,7 +37,7 @@ func getMatches(
 					return flag.Value
 				}))
 
-				recent, err := DBGetMailboxRecentCount(ctx, mailbox)
+				recent, err := DBGetMailboxRecentCount(ctx, client, mailbox)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/backend/responders.go
+++ b/internal/backend/responders.go
@@ -26,12 +26,14 @@ func newExists(messageID imap.InternalMessageID, messageUID int) *exists {
 }
 
 func (u *exists) handle(ctx context.Context, tx *ent.Tx, snap *snapshot) ([]response.Response, error) {
-	remoteID, err := DBGetRemoteMessageID(ctx, tx.Client(), u.messageID)
+	client := tx.Client()
+
+	remoteID, err := DBGetRemoteMessageID(ctx, client, u.messageID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := snap.appendMessage(ctx, tx, MessageIDPair{InternalID: u.messageID, RemoteID: remoteID}); err != nil {
+	if err := snap.appendMessage(ctx, client, MessageIDPair{InternalID: u.messageID, RemoteID: remoteID}); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +81,7 @@ func (u *expunge) handle(ctx context.Context, tx *ent.Tx, snap *snapshot) ([]res
 		return nil, err
 	}
 
-	if err := snap.expungeMessage(ctx, tx, u.messageID); err != nil {
+	if err := snap.expungeMessage(u.messageID); err != nil {
 		return nil, err
 	}
 

--- a/internal/backend/snapshot.go
+++ b/internal/backend/snapshot.go
@@ -18,8 +18,8 @@ type snapshot struct {
 	messages *snapMsgList
 }
 
-func newSnapshot(ctx context.Context, state *State, mbox *ent.Mailbox) (*snapshot, error) {
-	msgUIDs, err := DBGetMailboxMessagesForNewSnapshot(ctx, mbox)
+func newSnapshot(ctx context.Context, state *State, client *ent.Client, mbox *ent.Mailbox) (*snapshot, error) {
+	msgUIDs, err := DBGetMailboxMessagesForNewSnapshot(ctx, client, mbox)
 	if err != nil {
 		return nil, err
 	}
@@ -218,8 +218,8 @@ func (snap *snapshot) getMessagesWithoutFlag(flag string) []*snapMsg {
 	})
 }
 
-func (snap *snapshot) appendMessage(ctx context.Context, tx *ent.Tx, messageID MessageIDPair) error {
-	msgUID, err := DBGetMailboxMessage(ctx, tx.Client(), snap.mboxID.InternalID, messageID.InternalID)
+func (snap *snapshot) appendMessage(ctx context.Context, client *ent.Client, messageID MessageIDPair) error {
+	msgUID, err := DBGetMailboxMessage(ctx, client, snap.mboxID.InternalID, messageID.InternalID)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (snap *snapshot) appendMessage(ctx context.Context, tx *ent.Tx, messageID M
 	return nil
 }
 
-func (snap *snapshot) expungeMessage(ctx context.Context, tx *ent.Tx, messageID imap.InternalMessageID) error {
+func (snap *snapshot) expungeMessage(messageID imap.InternalMessageID) error {
 	if ok := snap.messages.remove(messageID); !ok {
 		return ErrNoSuchMessage
 	}

--- a/internal/backend/state_actions.go
+++ b/internal/backend/state_actions.go
@@ -57,12 +57,12 @@ func (state *State) actionCreateMailbox(ctx context.Context, tx *ent.Tx, name st
 }
 
 // TODO(REFACTOR): What if another client is selected in the same mailbox -- should we send expunge updates?
-func (state *State) actionDeleteMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.LabelID, name string) error {
+func (state *State) actionDeleteMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.LabelID) error {
 	if err := state.remote.DeleteMailbox(ctx, state.metadataID, mboxID); err != nil {
 		return err
 	}
 
-	return state.apply(ctx, tx, imap.NewMailboxDeleted(mboxID))
+	return DBDeleteMailboxWithRemoteID(ctx, tx, mboxID)
 }
 
 func (state *State) actionUpdateMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.LabelID, oldName, newName string) error {
@@ -76,7 +76,7 @@ func (state *State) actionUpdateMailbox(ctx context.Context, tx *ent.Tx, mboxID 
 		return err
 	}
 
-	return state.apply(ctx, tx, imap.NewMailboxUpdated(mboxID, strings.Split(newName, state.delimiter)))
+	return DBRenameMailboxWithRemoteID(ctx, tx, mboxID, newName)
 }
 
 func (state *State) actionCreateMessage(ctx context.Context, tx *ent.Tx, mboxID MailboxIDPair, literal []byte, flags imap.FlagSet, date time.Time) (int, error) {

--- a/internal/session/handle.go
+++ b/internal/session/handle.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *Session) handleOther(ctx context.Context, tag string, cmd *proto.Command, profiler profiling.CmdProfiler) chan response.Response {
-	ch := make(chan response.Response)
+	ch := make(chan response.Response, 100)
 
 	go func() {
 		labels := pprof.Labels("go", "handleOther()", "SessionID", strconv.Itoa(s.sessionID))

--- a/internal/session/handle.go
+++ b/internal/session/handle.go
@@ -216,6 +216,7 @@ func (s *Session) handleSelectedCommand(ctx context.Context, tag string, cmd *pr
 
 	// TODO(REFACTOR): Should we flush both before and after?
 	return s.state.Selected(ctx, func(mailbox *backend.Mailbox) error {
+
 		if err := flush(ctx, mailbox, false, ch); err != nil {
 			return err
 		}

--- a/store/badger.go
+++ b/store/badger.go
@@ -1,11 +1,11 @@
 package store
 
 import (
-	"github.com/ProtonMail/gluon/imap"
 	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/ProtonMail/gluon/imap"
 	"github.com/dgraph-io/badger/v3"
 	"github.com/sirupsen/logrus"
 )

--- a/store/disk.go
+++ b/store/disk.go
@@ -4,9 +4,10 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"github.com/ProtonMail/gluon/imap"
 	"os"
 	"path/filepath"
+
+	"github.com/ProtonMail/gluon/imap"
 )
 
 type onDiskStore struct {

--- a/store/memory.go
+++ b/store/memory.go
@@ -2,8 +2,9 @@ package store
 
 import (
 	"errors"
-	"github.com/ProtonMail/gluon/imap"
 	"sync"
+
+	"github.com/ProtonMail/gluon/imap"
 )
 
 type inMemoryStore struct {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,11 +2,11 @@ package store_test
 
 import (
 	"fmt"
-	"github.com/ProtonMail/gluon/imap"
 	"runtime"
 	"sync"
 	"testing"
 
+	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/store"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/bradenaw/juniper/xslices"
+	"github.com/emersion/go-imap/client"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectWhileSyncing(t *testing.T) {
-	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, s *testSession) {
 		// Define some mailbox names.
 		mailboxNames := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
 
@@ -38,11 +40,12 @@ func TestSelectWhileSyncing(t *testing.T) {
 
 		// Select a bunch of mailboxes.
 		for i := 0; i < 100; i++ {
-			c[2].C("A006 select " + mailboxNames[rand.Int()%len(mailboxNames)]) //nolint:gosec
-			c[2].Se("A006 OK [READ-WRITE] SELECT")
+			mboxName := mailboxNames[rand.Int()%len(mailboxNames)] //nolint:gosec
+			_, err := client.Select(mboxName, false)
+			require.NoError(t, err)
 
-			c[2].C("A006 select INBOX")
-			c[2].Se("A006 OK [READ-WRITE] SELECT")
+			_, err = client.Select("INBOX", false)
+			require.NoError(t, err)
 		}
 
 		// Stop appending.


### PR DESCRIPTION
Ensure all the database queries are accessed through the scope of RWLock
    to avoid the infamous "database locked" error and to allow more parallel
    read only requests from clients.
    
 The RWLock guarantees that only one goroutine/thread can write to the
 datbase, therefore ensuring we never trigger the limitations of SQLite
 DB which causes the error.
    
 The removal of the global TX Lock now enables clients to perform more
 read only request in parallel.
    
 Going forward it is expected all database access to be accessed via the
 `DB` type.
