### PR TITLE
fix(GODT-1647): Address double call to `Connector.Close()`

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -140,6 +140,10 @@ func (b *Backend) Close(ctx context.Context) error {
 			return fmt.Errorf("failed to close backend user (%v): %w", userID, err)
 		}
 
+		if err := b.remote.RemoveUser(ctx, userID); err != nil {
+			return err
+		}
+
 		delete(b.users, userID)
 	}
 


### PR DESCRIPTION
Rework goroutine shutdown so that we don't need to call
`Connector.Close()` when closing the backend user.

Two separate channels have been added ensure the blocking go-routines
exit when the Server shuts down or an user has been removed.