### PR TITLE
Remove state & snapshot locks

### DIFF
--- a/internal/backend/context.go
+++ b/internal/backend/context.go
@@ -45,3 +45,38 @@ func AsSilent(parent context.Context) context.Context {
 func isSilent(ctx context.Context) bool {
 	return ctx.Value(handleSilentKey) != nil
 }
+
+type handleRemoteUpdateCtxType struct{}
+
+var handleRemoteUpdateCtxKey handleRemoteUpdateCtxType
+
+func isRemoteUpdateCtx(ctx context.Context) bool {
+	return ctx.Value(handleRemoteUpdateCtxKey) != nil
+}
+
+func NewRemoteUpdateCtx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, handleRemoteUpdateCtxKey, struct{}{})
+}
+
+type stateContextType struct{}
+
+var stateContextKey stateContextType
+
+func NewStateContext(ctx context.Context, s *State) context.Context {
+	if s == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, stateContextKey, s.stateID)
+}
+
+func getStateIDFromContext(ctx context.Context) (int, bool) {
+	v := ctx.Value(stateContextKey)
+	if v == nil {
+		return 0, false
+	}
+
+	stateID, ok := v.(int)
+
+	return stateID, ok
+}

--- a/internal/backend/mailbox_search.go
+++ b/internal/backend/mailbox_search.go
@@ -17,9 +17,7 @@ import (
 )
 
 func (m *Mailbox) Search(ctx context.Context, keys []*proto.SearchKey, decoder *encoding.Decoder) ([]int, error) {
-	snapMessages := snapshotRead(m.snap, func(s *snapshot) []*snapMsg {
-		return s.getAllMessages()
-	})
+	snapMessages := m.snap.getAllMessages()
 
 	messages, err := doSearch(ctx, m, snapMessages, keys, decoder)
 	if err != nil {
@@ -203,7 +201,7 @@ func (m *Mailbox) matchSearchKeyBefore(ctx context.Context, candidates []*snapMs
 		return nil, err
 	}
 
-	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+	return DBReadResult(ctx, m.state.db(), func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
 		return filter(candidates, func(message *snapMsg) (bool, error) {
 			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
 			if err != nil {
@@ -324,7 +322,7 @@ func (m *Mailbox) matchSearchKeyKeyword(ctx context.Context, candidates []*snapM
 }
 
 func (m *Mailbox) matchSearchKeyLarger(ctx context.Context, candidates []*snapMsg, key *proto.SearchKey) ([]*snapMsg, error) {
-	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+	return DBReadResult(ctx, m.state.db(), func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
 		return filter(candidates, func(message *snapMsg) (bool, error) {
 			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
 			if err != nil {
@@ -365,7 +363,7 @@ func (m *Mailbox) matchSearchKeyOn(ctx context.Context, candidates []*snapMsg, k
 		return nil, err
 	}
 
-	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+	return DBReadResult(ctx, m.state.db(), func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
 		return filter(candidates, func(message *snapMsg) (bool, error) {
 			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
 			if err != nil {
@@ -499,7 +497,7 @@ func (m *Mailbox) matchSearchKeySince(ctx context.Context, candidates []*snapMsg
 		return nil, err
 	}
 
-	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+	return DBReadResult(ctx, m.state.db(), func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
 		return filter(candidates, func(message *snapMsg) (bool, error) {
 			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
 			if err != nil {
@@ -514,7 +512,7 @@ func (m *Mailbox) matchSearchKeySince(ctx context.Context, candidates []*snapMsg
 }
 
 func (m *Mailbox) matchSearchKeySmaller(ctx context.Context, candidates []*snapMsg, key *proto.SearchKey) ([]*snapMsg, error) {
-	return DBReadResult(ctx, m.state.db, func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
+	return DBReadResult(ctx, m.state.db(), func(ctx context.Context, client *ent.Client) ([]*snapMsg, error) {
 		return filter(candidates, func(message *snapMsg) (bool, error) {
 			msg, err := DBGetMessage(ctx, client, message.ID.InternalID)
 			if err != nil {
@@ -585,9 +583,7 @@ func (m *Mailbox) matchSearchKeyTo(ctx context.Context, candidates []*snapMsg, k
 }
 
 func (m *Mailbox) matchSearchKeyUID(ctx context.Context, candidates []*snapMsg, key *proto.SearchKey) ([]*snapMsg, error) {
-	left, err := snapshotReadErr(m.snap, func(s *snapshot) ([]*snapMsg, error) {
-		return s.getMessagesInUIDRange(key.GetSequenceSet())
-	})
+	left, err := m.snap.getMessagesInUIDRange(key.GetSequenceSet())
 	if err != nil {
 		return nil, err
 	}
@@ -634,9 +630,7 @@ func (m *Mailbox) matchSearchKeyUnseen(ctx context.Context, candidates []*snapMs
 }
 
 func (m *Mailbox) matchSearchKeySeqSet(ctx context.Context, candidates []*snapMsg, key *proto.SearchKey) ([]*snapMsg, error) {
-	left, err := snapshotReadErr(m.snap, func(s *snapshot) ([]*snapMsg, error) {
-		return s.getMessagesInSeqRange(key.GetSequenceSet())
-	})
+	left, err := m.snap.getMessagesInSeqRange(key.GetSequenceSet())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/seqset.go
+++ b/internal/backend/seqset.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+
 	"github.com/ProtonMail/gluon/internal/parser/proto"
 )
 

--- a/internal/backend/state.go
+++ b/internal/backend/state.go
@@ -29,7 +29,6 @@ type State struct {
 	ro   bool
 
 	doneCh chan struct{}
-	stopCh chan struct{}
 
 	updatesQueue *queue.QueuedChannel[stateUpdate]
 
@@ -375,8 +374,6 @@ func (state *State) Done() <-chan struct{} {
 }
 
 func (state *State) Close(ctx context.Context) error {
-	defer close(state.stopCh)
-
 	return state.user.removeState(ctx, state.stateID)
 }
 

--- a/internal/backend/state_filters.go
+++ b/internal/backend/state_filters.go
@@ -1,0 +1,72 @@
+package backend
+
+import "github.com/ProtonMail/gluon/imap"
+
+type stateFilter interface {
+	filter(s *State) bool
+}
+
+type allStateFilter struct{}
+
+func (*allStateFilter) filter(s *State) bool {
+	return s.snap != nil
+}
+
+func newAllStateFilter() stateFilter {
+	return &allStateFilter{}
+}
+
+type mboxIDStateFilter struct {
+	mboxID imap.InternalMailboxID
+}
+
+func newMBoxIDStateFilter(mboxID imap.InternalMailboxID) stateFilter {
+	return &mboxIDStateFilter{mboxID: mboxID}
+}
+
+func (f *mboxIDStateFilter) filter(s *State) bool {
+	return s.snap != nil && s.snap.mboxID.InternalID == f.mboxID
+}
+
+type messageIDStateFilter struct {
+	messageID imap.InternalMessageID
+}
+
+func newMessageIDStateFilter(msgID imap.InternalMessageID) stateFilter {
+	return &messageIDStateFilter{messageID: msgID}
+}
+
+func (f *messageIDStateFilter) filter(s *State) bool {
+	return s.snap != nil && s.snap.hasMessage(f.messageID)
+}
+
+type messageAndMBoxIDStateFilter struct {
+	msgID  imap.InternalMessageID
+	mboxID imap.InternalMailboxID
+}
+
+func newMessageAndMBoxIDStateFilter(msgID imap.InternalMessageID, mboxID imap.InternalMailboxID) stateFilter {
+	return &messageAndMBoxIDStateFilter{msgID: msgID, mboxID: mboxID}
+}
+
+func (f *messageAndMBoxIDStateFilter) filter(s *State) bool {
+	return s.snap != nil && s.snap.mboxID.InternalID == f.mboxID && s.snap.hasMessage(f.msgID)
+}
+
+type anyMessageIDStateFilter struct {
+	messageIDs []imap.InternalMessageID
+}
+
+func (f *anyMessageIDStateFilter) filter(s *State) bool {
+	if s.snap == nil {
+		return false
+	}
+
+	for _, msgID := range f.messageIDs {
+		if s.snap.hasMessage(msgID) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/queue/ctqueue.go
+++ b/internal/queue/ctqueue.go
@@ -23,6 +23,14 @@ func NewCTQueue[T any]() *CTQueue[T] {
 	}
 }
 
+func NewCTQueueWithCapacity[T any](capacity int) *CTQueue[T] {
+	return &CTQueue[T]{
+		items:  make([]T, 0, capacity),
+		cond:   sync.NewCond(&sync.Mutex{}),
+		closed: 0,
+	}
+}
+
 func (ctq *CTQueue[T]) Push(val T) bool {
 	ctq.cond.L.Lock()
 	defer ctq.cond.L.Unlock()

--- a/internal/queue/queued_channel.go
+++ b/internal/queue/queued_channel.go
@@ -1,0 +1,49 @@
+package queue
+
+// QueuedChannel represents a channel on which queued items can be published without having to worry if the reader
+// has actually consumed existing items first or if there's no way of knowing ahead of time what the ideal channel
+// buffer size should be.
+type QueuedChannel[T any] struct {
+	ch      chan T
+	closeCh chan struct{}
+	queue   *CTQueue[T]
+}
+
+func NewQueuedChannel[T any](channelBufferSize int, capacity int) *QueuedChannel[T] {
+	queue := &QueuedChannel[T]{
+		ch:      make(chan T, channelBufferSize),
+		queue:   NewCTQueueWithCapacity[T](capacity),
+		closeCh: make(chan struct{}),
+	}
+
+	go func() {
+		for {
+			item, ok := queue.queue.Pop()
+			if !ok {
+				return
+			}
+
+			select {
+			case queue.ch <- item:
+
+			case <-queue.closeCh:
+				return
+			}
+		}
+	}()
+
+	return queue
+}
+
+func (q *QueuedChannel[T]) Queue(items ...T) bool {
+	return q.queue.PushMany(items...)
+}
+
+func (q *QueuedChannel[T]) GetChannel() <-chan T {
+	return q.ch
+}
+
+func (q *QueuedChannel[T]) Close() {
+	q.queue.Close()
+	close(q.closeCh)
+}

--- a/internal/session/handle.go
+++ b/internal/session/handle.go
@@ -24,6 +24,8 @@ func (s *Session) handleOther(
 		pprof.Do(ctx, labels, func(_ context.Context) {
 			defer close(ch)
 
+			ctx := backend.NewStateContext(ctx, s.state)
+
 			if err := s.handleCommand(ctx, tag, cmd, ch, profiler); err != nil {
 				if res, ok := response.FromError(err); ok {
 					ch <- res

--- a/internal/session/handle_idle.go
+++ b/internal/session/handle_idle.go
@@ -53,6 +53,12 @@ func (s *Session) handleIdle(ctx context.Context, tag string, cmd *proto.Idle, c
 			case <-s.state.Done():
 				return nil
 
+			case stateUpdate := <-s.state.GetStateUpdatesCh():
+				if err := s.state.ApplyUpdate(ctx, stateUpdate); err != nil {
+					logrus.WithError(err).Error("Failed to apply state update during idle")
+				}
+				continue
+
 			case <-ctx.Done():
 				return ctx.Err()
 			}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -145,6 +145,13 @@ func (s *Session) serve(ctx context.Context, cmdCh <-chan command) error {
 		case <-s.state.Done():
 			return nil
 
+		case stateUpdate := <-s.state.GetStateUpdatesCh():
+			if err := s.state.ApplyUpdate(ctx, stateUpdate); err != nil {
+				logrus.WithError(err).Error("Failed to apply state update")
+			}
+
+			continue
+
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
Prior to this patch the updates to other session states were applied
immediately by going through all the available states in `backend.user`
and applying the changes immediately.

This patch changes the architecture so that all state updates for other
session states are queued via a channel rather than executed
immediately. This removes the need for snapshot lock, snapshot messages
lock, IDLE lock and responder lock as we no longer have two sessions
accessing state from one another.

To ensure the current state is still update, we mark all context with
the stateID (when available) and if the stateID matches one of the
states in the list, the update is applied immediately.

The downside is that every state now has to verify that this update can
be executed locally rather than checking in advance.

Finally this patch also fixes some update code to remove unnecessary
memory duplication.

Note: The `userWrapper` is a temporary type that will be remove in the
next patch.