### PR TITLE
fix(GODT-1842): Handle mailbox deletion with multiple clients

### DIFF
--- a/internal/response/bye.go
+++ b/internal/response/bye.go
@@ -26,3 +26,15 @@ func (r *bye) String() string {
 
 	return join(parts)
 }
+
+func (r *bye) WithMailboxDeleted() *bye {
+	r.msg = "Mailbox was deleted, have to disconnect."
+
+	return r
+}
+
+func (r *bye) WithInconsistentState() *bye {
+	r.msg = "IMAP session state is inconsistent, please re-login."
+
+	return r
+}

--- a/internal/session/handle.go
+++ b/internal/session/handle.go
@@ -27,12 +27,15 @@ func (s *Session) handleOther(
 
 			ctx := state.NewStateContext(ctx, s.state)
 
-			if err := s.handleCommand(ctx, tag, cmd, ch, profiler); err != nil {
+			if exitResponse, err := s.handleCommand(ctx, tag, cmd, ch, profiler); err != nil {
 				if res, ok := response.FromError(err); ok {
 					ch <- res
 				} else {
 					ch <- response.No(tag).WithError(err)
 				}
+			} else if exitResponse != nil {
+				ch <- exitResponse
+				return
 			}
 		})
 	}()
@@ -40,25 +43,26 @@ func (s *Session) handleOther(
 	return ch
 }
 
+// handleCommand returns a response instance if a command needs to force an exit of the client.
 func (s *Session) handleCommand(
 	ctx context.Context,
 	tag string,
 	cmd *proto.Command,
 	ch chan response.Response,
 	profiler profiling.CmdProfiler,
-) error {
+) (response.Response, error) {
 	switch {
 	case
 		cmd.GetCapability() != nil,
 		cmd.GetIdGet() != nil,
 		cmd.GetIdSet() != nil,
 		cmd.GetNoop() != nil:
-		return s.handleAnyCommand(ctx, tag, cmd, ch, profiler)
+		return nil, s.handleAnyCommand(ctx, tag, cmd, ch, profiler)
 
 	case
 		cmd.GetAuth() != nil,
 		cmd.GetLogin() != nil:
-		return s.handleNotAuthenticatedCommand(ctx, tag, cmd, ch, profiler)
+		return nil, s.handleNotAuthenticatedCommand(ctx, tag, cmd, ch, profiler)
 
 	case
 		cmd.GetSelect() != nil,
@@ -85,10 +89,10 @@ func (s *Session) handleCommand(
 		cmd.GetCopy() != nil,
 		cmd.GetMove() != nil,
 		cmd.GetUid() != nil:
-		return s.handleSelectedCommand(ctx, tag, cmd, ch, profiler)
+		return nil, s.handleSelectedCommand(ctx, tag, cmd, ch, profiler)
 
 	default:
-		return fmt.Errorf("bad command")
+		return nil, fmt.Errorf("bad command")
 	}
 }
 
@@ -155,12 +159,12 @@ func (s *Session) handleAuthenticatedCommand(
 	cmd *proto.Command,
 	ch chan response.Response,
 	profiler profiling.CmdProfiler,
-) error {
+) (response.Response, error) {
 	s.userLock.Lock()
 	defer s.userLock.Unlock()
 
 	if s.state == nil {
-		return ErrNotAuthenticated
+		return nil, ErrNotAuthenticated
 	}
 
 	switch {
@@ -168,19 +172,19 @@ func (s *Session) handleAuthenticatedCommand(
 		profiler.Start(profiling.CmdTypeSelect)
 		defer profiler.Stop(profiling.CmdTypeSelect)
 		// 6.3.1. SELECT Command
-		return s.handleSelect(ctx, tag, cmd.GetSelect(), ch)
+		return nil, s.handleSelect(ctx, tag, cmd.GetSelect(), ch)
 
 	case cmd.GetExamine() != nil:
 		profiler.Start(profiling.CmdTypeExamine)
 		defer profiler.Stop(profiling.CmdTypeExamine)
 		// 6.3.2. EXAMINE Command
-		return s.handleExamine(ctx, tag, cmd.GetExamine(), ch)
+		return nil, s.handleExamine(ctx, tag, cmd.GetExamine(), ch)
 
 	case cmd.GetCreate() != nil:
 		profiler.Start(profiling.CmdTypeCreate)
 		defer profiler.Stop(profiling.CmdTypeCreate)
 		// 6.3.3. CREATE Command
-		return s.handleCreate(ctx, tag, cmd.GetCreate(), ch)
+		return nil, s.handleCreate(ctx, tag, cmd.GetCreate(), ch)
 
 	case cmd.GetDel() != nil:
 		profiler.Start(profiling.CmdTypeDelete)
@@ -192,46 +196,46 @@ func (s *Session) handleAuthenticatedCommand(
 		profiler.Start(profiling.CmdTypeRename)
 		defer profiler.Stop(profiling.CmdTypeRename)
 		// 6.3.5. RENAME Command
-		return s.handleRename(ctx, tag, cmd.GetRename(), ch)
+		return nil, s.handleRename(ctx, tag, cmd.GetRename(), ch)
 
 	case cmd.GetSub() != nil:
 		profiler.Start(profiling.CmdTypeSubscribe)
 		defer profiler.Stop(profiling.CmdTypeSubscribe)
 		// 6.3.6. SUBSCRIBE Command
-		return s.handleSub(ctx, tag, cmd.GetSub(), ch)
+		return nil, s.handleSub(ctx, tag, cmd.GetSub(), ch)
 
 	case cmd.GetUnsub() != nil:
 		profiler.Start(profiling.CmdTypeUnsubscribe)
 		defer profiler.Stop(profiling.CmdTypeUnsubscribe)
 		// 6.3.7. UNSUBSCRIBE Command
-		return s.handleUnsub(ctx, tag, cmd.GetUnsub(), ch)
+		return nil, s.handleUnsub(ctx, tag, cmd.GetUnsub(), ch)
 
 	case cmd.GetList() != nil:
 		profiler.Start(profiling.CmdTypeList)
 		defer profiler.Stop(profiling.CmdTypeList)
 		// 6.3.8. LIST Command
-		return s.handleList(ctx, tag, cmd.GetList(), ch)
+		return nil, s.handleList(ctx, tag, cmd.GetList(), ch)
 
 	case cmd.GetLsub() != nil:
 		profiler.Start(profiling.CmdTypeLSub)
 		defer profiler.Stop(profiling.CmdTypeLSub)
 		// 6.3.9. Lsub Command
-		return s.handleLsub(ctx, tag, cmd.GetLsub(), ch)
+		return nil, s.handleLsub(ctx, tag, cmd.GetLsub(), ch)
 
 	case cmd.GetStatus() != nil:
 		profiler.Start(profiling.CmdTypeStatus)
 		defer profiler.Stop(profiling.CmdTypeStatus)
 		// 6.3.10. STATUS Command
-		return s.handleStatus(ctx, tag, cmd.GetStatus(), ch)
+		return nil, s.handleStatus(ctx, tag, cmd.GetStatus(), ch)
 
 	case cmd.GetAppend() != nil:
 		profiler.Start(profiling.CmdTypeAppend)
 		defer profiler.Stop(profiling.CmdTypeAppend)
 		// 6.3.11. APPEND Command
-		return s.handleAppend(ctx, tag, cmd.GetAppend(), ch)
+		return nil, s.handleAppend(ctx, tag, cmd.GetAppend(), ch)
 
 	default:
-		return fmt.Errorf("bad command")
+		return nil, fmt.Errorf("bad command")
 	}
 }
 

--- a/internal/state/updates.go
+++ b/internal/state/updates.go
@@ -303,3 +303,21 @@ func (u *mailboxRemoteIDUpdateStateUpdate) Apply(ctx context.Context, tx *ent.Tx
 func (u *mailboxRemoteIDUpdateStateUpdate) String() string {
 	return fmt.Sprintf("MailboxRemoteIDUpdateStateUpdate: %v remote = %v", u.SnapFilter, u.remoteID.ShortID())
 }
+
+type mailboxDeletedStateUpdate struct {
+	MBoxIDStateFilter
+}
+
+func NewMailboxDeletedStateUpdate(mboxID imap.InternalMailboxID) Update {
+	return &mailboxDeletedStateUpdate{MBoxIDStateFilter: MBoxIDStateFilter{MboxID: mboxID}}
+}
+
+func (u *mailboxDeletedStateUpdate) Apply(ctx context.Context, tx *ent.Tx, s *State) error {
+	s.markInvalid()
+
+	return nil
+}
+
+func (u *mailboxDeletedStateUpdate) String() string {
+	return fmt.Sprintf("MailboxDeletedStateUpdate: %v", u.MBoxIDStateFilter.String())
+}

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -177,6 +177,7 @@ func (s *testConnection) doCreateTempDir() (string, func()) {
 	// Delete it afterwards.
 	return name, func() {
 		withTag(func(tag string) {
+			s.Cf("%v UNSELECT", tag)
 			s.Cf(`%v DELETE %v`, tag, name).OK(tag)
 		})
 	}


### PR DESCRIPTION
When a mailbox is deleted and selected, disconnect the client who issued
the deletion on success.

Other clients which also have this mailbox selected will be disconnected
through an update on their next command.

The above mimics the behavior of dovecot.