### PR TITLE
Untagged reponse behavior

### DIFF
--- a/internal/session/handle_check.go
+++ b/internal/session/handle_check.go
@@ -8,12 +8,10 @@ import (
 	"github.com/ProtonMail/gluon/internal/state"
 )
 
-func (s *Session) handleCheck(ctx context.Context, tag string, cmd *proto.Check, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleCheck(ctx context.Context, tag string, cmd *proto.Check, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	if err := flush(ctx, mailbox, true, ch); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- response.Ok(tag).WithMessage("CHECK")
-
-	return nil
+	return response.Ok(tag).WithMessage("CHECK"), nil
 }

--- a/internal/session/handle_close.go
+++ b/internal/session/handle_close.go
@@ -10,24 +10,22 @@ import (
 )
 
 // TODO(REFACTOR): No EXPUNGE responses are sent -- what about to other sessions also selected in this mailbox?
-func (s *Session) handleClose(ctx context.Context, tag string, cmd *proto.Close, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleClose(ctx context.Context, tag string, cmd *proto.Close, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	ctx = context2.AsClose(ctx)
 
 	if !mailbox.ReadOnly() {
 		if err := mailbox.Expunge(ctx, nil); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if err := flush(ctx, mailbox, true, ch); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := mailbox.Close(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- response.Ok(tag).WithMessage("CLOSE")
-
-	return nil
+	return response.Ok(tag).WithMessage("CLOSE"), nil
 }

--- a/internal/session/handle_copy.go
+++ b/internal/session/handle_copy.go
@@ -11,24 +11,24 @@ import (
 	"github.com/emersion/go-imap/utf7"
 )
 
-func (s *Session) handleCopy(ctx context.Context, tag string, cmd *proto.Copy, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleCopy(ctx context.Context, tag string, cmd *proto.Copy, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	nameUTF8, err := utf7.Encoding.NewDecoder().String(cmd.GetMailbox())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	item, err := mailbox.Copy(ctx, cmd.GetSequenceSet(), nameUTF8)
 	if errors.Is(err, state.ErrNoSuchMessage) {
-		return response.Bad(tag).WithError(err)
+		return response.Bad(tag).WithError(err), nil
 	} else if errors.Is(err, state.ErrNoSuchMailbox) {
-		return response.No(tag).WithError(err).WithItems(response.ItemTryCreate())
+		return response.No(tag).WithError(err).WithItems(response.ItemTryCreate()), nil
 	} else if err != nil {
 		reporter.MessageWithContext(ctx,
 			"Failed to copy messages",
 			reporter.Context{"error": err},
 		)
 
-		return err
+		return nil, err
 	}
 
 	response := response.Ok(tag)
@@ -37,7 +37,5 @@ func (s *Session) handleCopy(ctx context.Context, tag string, cmd *proto.Copy, m
 		response = response.WithItems(item)
 	}
 
-	ch <- response.WithMessage(okMessage(ctx))
-
-	return nil
+	return response.WithMessage(okMessage(ctx)), nil
 }

--- a/internal/session/handle_expunge.go
+++ b/internal/session/handle_expunge.go
@@ -9,40 +9,36 @@ import (
 	"github.com/ProtonMail/gluon/internal/state"
 )
 
-func (s *Session) handleExpunge(ctx context.Context, tag string, cmd *proto.Expunge, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleExpunge(ctx context.Context, tag string, cmd *proto.Expunge, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	if mailbox.ReadOnly() {
-		return ErrReadOnly
+		return nil, ErrReadOnly
 	}
 
 	if err := mailbox.Expunge(ctx, nil); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := flush(ctx, mailbox, true, ch); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- response.Ok(tag).WithMessage("EXPUNGE")
-
-	return nil
+	return response.Ok(tag).WithMessage("EXPUNGE"), nil
 }
 
-func (s *Session) handleUIDExpunge(ctx context.Context, tag string, cmd *proto.UIDExpunge, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleUIDExpunge(ctx context.Context, tag string, cmd *proto.UIDExpunge, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	ctx = context2.AsUID(ctx)
 
 	if mailbox.ReadOnly() {
-		return ErrReadOnly
+		return nil, ErrReadOnly
 	}
 
 	if err := mailbox.Expunge(ctx, cmd.GetSequenceSet()); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := flush(ctx, mailbox, true, ch); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- response.Ok(tag).WithMessage("EXPUNGE")
-
-	return nil
+	return response.Ok(tag).WithMessage("EXPUNGE"), nil
 }

--- a/internal/session/handle_fetch.go
+++ b/internal/session/handle_fetch.go
@@ -10,16 +10,16 @@ import (
 	"github.com/ProtonMail/gluon/reporter"
 )
 
-func (s *Session) handleFetch(ctx context.Context, tag string, cmd *proto.Fetch, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleFetch(ctx context.Context, tag string, cmd *proto.Fetch, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	if err := mailbox.Fetch(ctx, cmd.GetSequenceSet(), cmd.GetAttributes(), ch); errors.Is(err, state.ErrNoSuchMessage) {
-		return response.Bad(tag).WithError(err)
+		return response.Bad(tag).WithError(err), nil
 	} else if err != nil {
 		reporter.MessageWithContext(ctx,
 			"Failed to fetch messages",
 			reporter.Context{"error": err},
 		)
 
-		return err
+		return nil, err
 	}
 
 	var items []response.Item
@@ -28,9 +28,7 @@ func (s *Session) handleFetch(ctx context.Context, tag string, cmd *proto.Fetch,
 		items = append(items, response.ItemExpungeIssued())
 	}
 
-	ch <- response.Ok(tag).
+	return response.Ok(tag).
 		WithItems(items...).
-		WithMessage(okMessage(ctx))
-
-	return nil
+		WithMessage(okMessage(ctx)), nil
 }

--- a/internal/session/handle_move.go
+++ b/internal/session/handle_move.go
@@ -11,24 +11,24 @@ import (
 	"github.com/emersion/go-imap/utf7"
 )
 
-func (s *Session) handleMove(ctx context.Context, tag string, cmd *proto.Move, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleMove(ctx context.Context, tag string, cmd *proto.Move, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	nameUTF8, err := utf7.Encoding.NewDecoder().String(cmd.GetMailbox())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	item, err := mailbox.Move(ctx, cmd.GetSequenceSet(), nameUTF8)
 	if errors.Is(err, state.ErrNoSuchMessage) {
-		return response.Bad(tag).WithError(err)
+		return response.Bad(tag).WithError(err), nil
 	} else if errors.Is(err, state.ErrNoSuchMailbox) {
-		return response.No(tag).WithError(err).WithItems(response.ItemTryCreate())
+		return response.No(tag).WithError(err).WithItems(response.ItemTryCreate()), nil
 	} else if err != nil {
 		reporter.MessageWithContext(ctx,
 			"Failed to move messages from mailbox",
 			reporter.Context{"error": err},
 		)
 
-		return err
+		return nil, err
 	}
 
 	if item != nil {
@@ -36,10 +36,8 @@ func (s *Session) handleMove(ctx context.Context, tag string, cmd *proto.Move, m
 	}
 
 	if err := flush(ctx, mailbox, true, ch); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- response.Ok(tag).WithMessage(okMessage(ctx))
-
-	return nil
+	return response.Ok(tag).WithMessage(okMessage(ctx)), nil
 }

--- a/internal/session/handle_store.go
+++ b/internal/session/handle_store.go
@@ -11,29 +11,29 @@ import (
 	"github.com/ProtonMail/gluon/reporter"
 )
 
-func (s *Session) handleStore(ctx context.Context, tag string, cmd *proto.Store, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleStore(ctx context.Context, tag string, cmd *proto.Store, mailbox *state.Mailbox, ch chan response.Response) (response.Response, error) {
 	if cmd.GetAction().GetSilent() {
 		ctx = context2.AsSilent(ctx)
 	}
 
 	flags, err := validateStoreFlags(cmd.GetFlags())
 	if err != nil {
-		return response.Bad(tag).WithError(err)
+		return response.Bad(tag).WithError(err), nil
 	}
 
 	if err := mailbox.Store(ctx, cmd.GetSequenceSet(), cmd.GetAction().GetOperation(), flags); errors.Is(err, state.ErrNoSuchMessage) {
-		return response.Bad(tag).WithError(err)
+		return response.Bad(tag).WithError(err), nil
 	} else if err != nil {
 		reporter.MessageWithContext(ctx,
 			"Failed to store flags on messages",
 			reporter.Context{"error": err},
 		)
 
-		return err
+		return nil, err
 	}
 
 	if err := flush(ctx, mailbox, false, ch); err != nil {
-		return err
+		return nil, err
 	}
 
 	var items []response.Item
@@ -42,9 +42,7 @@ func (s *Session) handleStore(ctx context.Context, tag string, cmd *proto.Store,
 		items = append(items, response.ItemExpungeIssued())
 	}
 
-	ch <- response.Ok(tag).
+	return response.Ok(tag).
 		WithItems(items...).
-		WithMessage(okMessage(ctx))
-
-	return nil
+		WithMessage(okMessage(ctx)), nil
 }

--- a/internal/session/handle_uid.go
+++ b/internal/session/handle_uid.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ProtonMail/gluon/profiling"
 )
 
-func (s *Session) handleUID(ctx context.Context, tag string, cmd *proto.UID, mailbox *state.Mailbox, profiler profiling.CmdProfiler, ch chan response.Response) error {
+func (s *Session) handleUID(ctx context.Context, tag string, cmd *proto.UID, mailbox *state.Mailbox, profiler profiling.CmdProfiler, ch chan response.Response) (response.Response, error) {
 	switch cmd := cmd.GetCommand().(type) {
 	case *proto.UID_Copy:
 		profiler.Start(profiling.CmdTypeUIDCopy)

--- a/internal/session/handle_unselect.go
+++ b/internal/session/handle_unselect.go
@@ -8,12 +8,10 @@ import (
 	"github.com/ProtonMail/gluon/internal/state"
 )
 
-func (s *Session) handleUnselect(ctx context.Context, tag string, cmd *proto.Unselect, mailbox *state.Mailbox, ch chan response.Response) error {
+func (s *Session) handleUnselect(ctx context.Context, tag string, cmd *proto.Unselect, mailbox *state.Mailbox, _ chan response.Response) (response.Response, error) {
 	if err := mailbox.Close(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- response.Ok(tag).WithMessage("UNSELECT")
-
-	return nil
+	return response.Ok(tag).WithMessage("UNSELECT"), nil
 }

--- a/internal/state/mailbox_fetch.go
+++ b/internal/state/mailbox_fetch.go
@@ -104,8 +104,14 @@ func (m *Mailbox) fetchItems(ctx context.Context, msg *snapMsg, attributes []*pr
 			return 0, nil, err
 		}
 
-		if !msg.flags.Equals(newFlags[msg.ID.InternalID]) {
-			items = append(items, response.ItemFlags(newFlags[msg.ID.InternalID]))
+		newMessageFlags := newFlags[msg.ID.InternalID]
+
+		if !msg.flags.Equals(newMessageFlags) {
+			if err := m.snap.setMessageFlags(msg.ID.InternalID, newMessageFlags); err != nil {
+				return 0, nil, err
+			}
+
+			items = append(items, response.ItemFlags(newMessageFlags))
 		}
 	}
 

--- a/internal/state/responders.go
+++ b/internal/state/responders.go
@@ -85,8 +85,12 @@ func (u *exists) handle(ctx context.Context, tx *ent.Tx, snap *snapshot) ([]resp
 	res := []response.Response{response.Exists().WithCount(seq)}
 
 	if recent := len(snap.getMessagesWithFlag(imap.FlagRecent)); recent > 0 {
-		if err := db.ClearRecentFlag(ctx, tx, snap.mboxID.InternalID, u.messageID); err != nil {
+		if msgFlags, err := snap.getMessageFlags(u.messageID); err != nil {
 			return nil, err
+		} else if msgFlags.Contains(imap.FlagRecent) {
+			if err := db.ClearRecentFlag(ctx, tx, snap.mboxID.InternalID, u.messageID); err != nil {
+				return nil, err
+			}
 		}
 
 		res = append(res, response.Recent().WithCount(recent))

--- a/tests/fetch_body_test.go
+++ b/tests/fetch_body_test.go
@@ -31,9 +31,6 @@ func TestFetchBodySetsSeenFlag(t *testing.T) {
 		))
 		c.OK("A005")
 
-		// We receive an untagged FETCH response indicating the flag was set.
-		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)
-
 		// The message now has the seen flag.
 		c.C(`A005 FETCH 1 (FLAGS)`)
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -234,12 +234,16 @@ func TestMessageSeenUpdate(t *testing.T) {
 		s.messageSeen("user", messageID, true)
 
 		c.C("A003 FETCH 1 (FLAGS)")
+		c.S(`* 1 FETCH (FLAGS (\Recent)`)
+		// Unilateral update arrives after fetch.
 		c.S(`* 1 FETCH (FLAGS (\Recent \Seen)`)
 		c.OK("A003")
 
 		s.messageSeen("user", messageID, false)
 
 		c.C("A004 FETCH 1 (FLAGS)")
+		c.S(`* 1 FETCH (FLAGS (\Recent \Seen)`)
+		// Unilateral update arrives after fetch.
 		c.S(`* 1 FETCH (FLAGS (\Recent)`)
 		c.OK("A004")
 	})
@@ -254,11 +258,13 @@ func TestMessageFlaggedUpdate(t *testing.T) {
 
 		s.messageFlagged("user", messageID, true)
 		c.C("A003 FETCH 1 (FLAGS)")
-		c.S(`* 1 FETCH (FLAGS (\Flagged \Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent)`)
 		c.OK("A003")
 
 		s.messageFlagged("user", messageID, false)
 		c.C("A004 FETCH 1 (FLAGS)")
+		c.S(`* 1 FETCH (FLAGS (\Flagged \Recent)`)
+		// Unilateral updates arrive afterwards.
 		c.S(`* 1 FETCH (FLAGS (\Recent)`)
 		c.OK("A004")
 	})


### PR DESCRIPTION
This patch fixes the behavior of untagged responses to match dovecot.
All untagged responses are now sent at the end of the command before the
closing tag is sent and no longer before and after. Some of the unit
tests had to be updated to match this new behavior.

This patch also fixes fetch so that it applies the seen flag to the
snapshot on which fetch is operating. This is now possible as snapshots
aren't shared between sessions anymore.

