### PR TITLE
fix(GODT-1757): Recent flag behavior and snapshot db reads

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -120,6 +120,7 @@ func (b *Backend) GetState(username, password string, sessionID int) (*state.Sta
 	logrus.
 		WithField("userID", userID).
 		WithField("username", username).
+		WithField("stateID", state.StateID).
 		Debug("Created new IMAP state")
 
 	return state, nil

--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -223,11 +223,8 @@ func (user *user) applyMessagesCreated(ctx context.Context, update *imap.Message
 				return err
 			}
 
-			responders := xslices.Map(messageIDs, func(messageID ids.MessageIDPair) state.Responder {
-				return state.NewExists(messageID.InternalID, messageUIDs[messageID.InternalID])
-			})
+			user.queueStateUpdate(state.NewExistsStateUpdate(internalMailboxID, messageIDs, messageUIDs, nil))
 
-			user.queueStateUpdate(state.NewMailboxIDResponderStateUpdate(internalMailboxID, responders...))
 		}
 
 		return nil
@@ -347,8 +344,8 @@ func (user *user) setMessageMailboxes(ctx context.Context, tx *ent.Tx, messageID
 }
 
 // applyMessagesAddedToMailbox adds the messages to the given mailbox.
-func (user *user) applyMessagesAddedToMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.InternalMailboxID, messageIDs []imap.InternalMessageID) (map[imap.InternalMessageID]int, error) {
-	messageUIDs, update, err := state.AddMessagesToMailbox(ctx, tx, mboxID, messageIDs)
+func (user *user) applyMessagesAddedToMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.InternalMailboxID, messageIDs []imap.InternalMessageID) (map[imap.InternalMessageID]*ent.UID, error) {
+	messageUIDs, update, err := state.AddMessagesToMailbox(ctx, tx, mboxID, messageIDs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/state/updates_remote.go
+++ b/internal/state/updates_remote.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/contexts"
 	"github.com/ProtonMail/gluon/internal/db/ent"
@@ -24,6 +26,10 @@ func (u *RemoteAddMessageFlagsStateUpdate) Apply(ctx context.Context, tx *ent.Tx
 	return s.PushResponder(ctx, tx, NewFetch(u.MessageID, imap.NewFlagSet(u.flag), contexts.IsUID(ctx), contexts.IsSilent(ctx), false, FetchFlagOpAdd))
 }
 
+func (u *RemoteAddMessageFlagsStateUpdate) String() string {
+	return fmt.Sprintf("RemoteAddMessageFlagsStateUpdate %v flag = %v", u.MessageIDStateFilter, u.flag)
+}
+
 type RemoteRemoveMessageFlagsStateUpdate struct {
 	MessageIDStateFilter
 	flag string
@@ -38,6 +44,10 @@ func NewRemoteRemoveMessageFlagsStateUpdate(messageID imap.InternalMessageID, fl
 
 func (u *RemoteRemoveMessageFlagsStateUpdate) Apply(ctx context.Context, tx *ent.Tx, s *State) error {
 	return s.PushResponder(ctx, tx, NewFetch(u.MessageID, imap.NewFlagSet(u.flag), contexts.IsUID(ctx), contexts.IsSilent(ctx), false, FetchFlagOpRem))
+}
+
+func (u *RemoteRemoveMessageFlagsStateUpdate) String() string {
+	return fmt.Sprintf("RemoteRemoveMessageFlagsStateUpdate %v flag = %v", u.MessageIDStateFilter, u.flag)
 }
 
 type RemoteMessageDeletedStateUpdate struct {
@@ -57,4 +67,8 @@ func (u *RemoteMessageDeletedStateUpdate) Apply(ctx context.Context, tx *ent.Tx,
 		InternalID: u.MessageID,
 		RemoteID:   u.remoteID,
 	}}, s.snap.mboxID)
+}
+
+func (u *RemoteMessageDeletedStateUpdate) String() string {
+	return fmt.Sprintf("RemoteMessageDeletedStateUpdate %v remote ID = %v", u.MessageIDStateFilter, u.remoteID)
 }

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -23,6 +23,7 @@ func TestDraftScenario(t *testing.T) {
 
 		s.messageDeleted("user", messageID)
 		s.messageCreated("user", mailboxID, []byte("To: 4@4.pm"))
+		s.flush("user")
 
 		c.C("A002 NOOP")
 		c.S("* 1 EXPUNGE")

--- a/tests/recent_test.go
+++ b/tests/recent_test.go
@@ -119,9 +119,9 @@ func TestRecentExists(t *testing.T) {
 		// Client 3 appends a new message to INBOX.
 		c[3].doAppend(`INBOX`, `To: 1@pm.me`).expect("OK")
 
-		// Client 1 is notified of the new message first; it appears as recent to client 1.
+		// Client 1 is notified of the new message. No recent is sent as client 2 still has the mailbox selected.
 		c[1].C("A007 NOOP")
-		c[1].S("* 1 EXISTS", "* 1 RECENT").OK("A007")
+		c[1].S("* 1 EXISTS").OK("A007")
 
 		// Client 2 is notified of the new message second; it does not appear as recent to client 2.
 		c[2].C("A007 NOOP")
@@ -163,8 +163,8 @@ func TestRecentIDLEExpunge(t *testing.T) {
 		c[2].C("A006 select INBOX").OK("A006")
 		c[2].C("A006 move 1:* folder").OK("A006")
 
-		// Client 1 receives EXISTS and RECENT updates for those messages.
-		c[1].S(`* 1 EXISTS`, `* 1 RECENT`, `* 2 EXISTS`, `* 2 RECENT`)
+		// Client 1 receives EXISTS. Since Client 2 still has the mailbox selected, recent updates are not sent.
+		c[1].S(`* 1 EXISTS`, `* 2 EXISTS`)
 
 		// Client 2 moves those two messages back to INBOX.
 		// In doing so, it sees the messages in the folder; they are no longer recent.


### PR DESCRIPTION
This patch removes the need for the snapshots to read new messages from the database when they arrive via an `exists` responder.

We have also updated the behavior of the `Recent` flag to match dovecot's implementation. If a client append a message to a selected mailbox only that client will receive the recent flags. If a client appends a message to a non-selected mailbox, the first state which receives the update will apply the recent flag.

To achieve the latter, we added a new update `ExistsStateUpdate` which enforces the logic described above in a thread safe manner.