### PR TITLE
refactor(GODT-1757): Reduce db locks for responders

### DIFF
--- a/internal/state/mailbox.go
+++ b/internal/state/mailbox.go
@@ -300,9 +300,7 @@ func (m *Mailbox) expunge(ctx context.Context, messages []*snapMsg) error {
 }
 
 func (m *Mailbox) Flush(ctx context.Context, permitExpunge bool) ([]response.Response, error) {
-	return db.WriteResult(ctx, m.state.db(), func(ctx context.Context, tx *ent.Tx) ([]response.Response, error) {
-		return m.state.flushResponses(ctx, tx, permitExpunge)
-	})
+	return m.state.flushResponses(ctx, permitExpunge)
 }
 
 func (m *Mailbox) Close(ctx context.Context) error {


### PR DESCRIPTION
Currently the only one responder needs to modify db state to clear the recent flags. By changing the interface to return an update object we can lock the db for writing on demand rather than all the time.