### PR TITLE
fix: Fix remote server operation for gluon_bench

### DIFF
--- a/benchmarks/gluon_bench/imap_benchmarks/imap_benchmark_runner.go
+++ b/benchmarks/gluon_bench/imap_benchmarks/imap_benchmark_runner.go
@@ -3,7 +3,6 @@ package imap_benchmarks
 import (
 	"context"
 	"fmt"
-
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/benchmark"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/flags"
 	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/imap_benchmarks/server"
@@ -14,7 +13,6 @@ import (
 
 type IMAPBenchmarkRunner struct {
 	benchmark          IMAPBenchmark
-	serverBuilder      server.ServerBuilder
 	cmdProfilerBuilder *utils.DurationCmdProfilerBuilder
 	server             server.Server
 }
@@ -25,9 +23,22 @@ func (i *IMAPBenchmarkRunner) Name() string {
 
 // Setup sets up the benchmark state, this is not timed.
 func (i *IMAPBenchmarkRunner) Setup(ctx context.Context, benchmarkDir string) error {
+	var serverBuilder server.ServerBuilder
+
+	if len(*flags.IMAPRemoteServer) != 0 {
+		builder, err := server.NewRemoteServerBuilder(*flags.IMAPRemoteServer)
+		if err != nil {
+			panic(fmt.Sprintf("Invalid Server address: %v", err))
+		}
+
+		serverBuilder = builder
+	} else {
+		serverBuilder = &server.LocalServerBuilder{}
+	}
+
 	i.cmdProfilerBuilder.Clear()
 
-	server, err := i.serverBuilder.New(ctx, benchmarkDir, i.cmdProfilerBuilder)
+	server, err := serverBuilder.New(ctx, benchmarkDir, i.cmdProfilerBuilder)
 	if err != nil {
 		return err
 	}
@@ -74,22 +85,8 @@ func (i *IMAPBenchmarkRunner) TearDown(ctx context.Context) error {
 }
 
 func NewIMAPBenchmarkRunner(bench IMAPBenchmark) benchmark.Benchmark {
-	var serverBuilder server.ServerBuilder
-
-	if len(*flags.IMAPRemoteServer) != 0 {
-		builder, err := server.NewRemoteServerBuilder(*flags.IMAPRemoteServer)
-		if err != nil {
-			panic(fmt.Sprintf("Invalid Server address: %v", err))
-		}
-
-		serverBuilder = builder
-	} else {
-		serverBuilder = &server.LocalServerBuilder{}
-	}
-
 	return &IMAPBenchmarkRunner{
 		benchmark:          bench,
-		serverBuilder:      serverBuilder,
 		cmdProfilerBuilder: utils.NewDurationCmdProfilerBuilder(),
 	}
 }


### PR DESCRIPTION
Flags were being read before they were set.