### PR TITLE
feat: Add Select benchmark

### DIFF
--- a/benchmarks/gluon_bench/imap_benchmarks/select.go
+++ b/benchmarks/gluon_bench/imap_benchmarks/select.go
@@ -1,0 +1,53 @@
+package imap_benchmarks
+
+import (
+	"context"
+	"flag"
+	"net"
+
+	"github.com/ProtonMail/gluon/benchmarks/gluon_bench/benchmark"
+	"github.com/emersion/go-imap/client"
+)
+
+var selectReadOnlyFlag = flag.Bool("imap-select-readonly", false, "If set to true, perform a read only select (examine).")
+
+type Select struct {
+	*stateTracker
+}
+
+func NewSelect() benchmark.Benchmark {
+	return NewIMAPBenchmarkRunner(&Select{stateTracker: newStateTracker()})
+}
+
+func (*Select) Name() string {
+	return "imap-select"
+}
+
+func (s *Select) Setup(ctx context.Context, addr net.Addr) error {
+	return WithClient(addr, func(cl *client.Client) error {
+		if _, err := s.createAndFillRandomMBox(cl); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (s *Select) TearDown(ctx context.Context, addr net.Addr) error {
+	return s.cleanupWithAddr(addr)
+}
+
+func (s *Select) Run(ctx context.Context, addr net.Addr) error {
+	RunParallelClientsWithMailbox(addr, s.MBoxes[0], *fetchReadOnly, func(cl *client.Client, index uint) {
+		_, err := cl.Select(s.MBoxes[0], *selectReadOnlyFlag)
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	return nil
+}
+
+func init() {
+	benchmark.RegisterBenchmark(NewSelect())
+}


### PR DESCRIPTION
The append is currently slow because it takes a lot of time to load data from the mailbox. The select benchmark can be use to check this specific issue later once the append has been fixed.