### PR TITLE
fix(GODT-1570): Improve Append command perf

### DIFF
--- a/internal/session/responses.go
+++ b/internal/session/responses.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ProtonMail/gluon/internal/state"
 )
 
-func flush(ctx context.Context, mailbox *state.Mailbox, permitExpunge bool, resCh chan response.Response) error {
+func flush(ctx context.Context, mailbox state.AppendOnlyMailbox, permitExpunge bool, resCh chan response.Response) error {
 	res, err := mailbox.Flush(ctx, permitExpunge)
 	if err != nil {
 		return err

--- a/internal/state/mailbox.go
+++ b/internal/state/mailbox.go
@@ -27,6 +27,12 @@ type Mailbox struct {
 	readOnly bool
 }
 
+type AppendOnlyMailbox interface {
+	Append(ctx context.Context, literal []byte, flags imap.FlagSet, date time.Time) (imap.UID, error)
+	Flush(ctx context.Context, permitExpunge bool) ([]response.Response, error)
+	UIDValidity() imap.UID
+}
+
 func newMailbox(mbox *ent.Mailbox, state *State, snap *snapshot) *Mailbox {
 	return &Mailbox{
 		mbox: mbox,

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -44,6 +44,14 @@ func newSnapshot(ctx context.Context, state *State, client *ent.Client, mbox *en
 	return snap, nil
 }
 
+func newEmptySnapshot(state *State, mbox *ent.Mailbox) *snapshot {
+	return &snapshot{
+		mboxID:   ids.NewMailboxIDPair(mbox),
+		state:    state,
+		messages: newMsgList(),
+	}
+}
+
 func (snap *snapshot) hasMessage(messageID imap.InternalMessageID) bool {
 	return snap.messages.has(messageID)
 }


### PR DESCRIPTION
Do not load the entire mailbox from the database if it is not selected and only flush event if the mailbox is currently selected.