### PR TITLE
fix(GODT-1570): Fix too many SQL Variable in sync benchmark

### DIFF
--- a/internal/state/responders.go
+++ b/internal/state/responders.go
@@ -149,7 +149,7 @@ type ExistsStateUpdate struct {
 	targetStateSet bool
 }
 
-func NewExistsStateUpdate(mailboxID imap.InternalMailboxID, messageIDs []ids.MessageIDPair, uids map[imap.InternalMessageID]*ent.UID, s *State) Update {
+func NewExistsStateUpdate(mailboxID imap.InternalMailboxID, messages []db.CreateAndAddMessagesResult, s *State) Update {
 	var stateID StateID
 
 	var targetStateSet bool
@@ -159,9 +159,8 @@ func NewExistsStateUpdate(mailboxID imap.InternalMailboxID, messageIDs []ids.Mes
 		targetStateSet = true
 	}
 
-	responders := xslices.Map(messageIDs, func(messageID ids.MessageIDPair) *exists {
-		uid := uids[messageID.InternalID]
-		exists := newExists(ids.NewMessageIDPair(uid.Edges.Message), uid.UID, db.NewFlagSet(uid, uid.Edges.Message.Edges.Flags))
+	responders := xslices.Map(messages, func(result db.CreateAndAddMessagesResult) *exists {
+		exists := newExists(result.MessageID, result.UID, result.Flags)
 
 		return exists
 	})


### PR DESCRIPTION
Batch incoming connector updates for new message to 1000 messages per transaction to avoid running into too many SQL variables.

We batched at outside of the transaction level so as not to completely block the other threads forever until we are done processing a high number of updates.