### PR TITLE
refactor(GODT-1570): Reuse parsed contents for messages

### DIFF
--- a/benchmarks/gluon_bench/gluon_benchmarks/sync.go
+++ b/benchmarks/gluon_bench/gluon_benchmarks/sync.go
@@ -87,13 +87,25 @@ func (s *Sync) setupConnector(ctx context.Context) (utils.ConnectorImpl, error) 
 		[]byte(utils.MessageAfterNoonMeeting),
 	}
 
+	parsedMessages := make([]*imap.ParsedMessage, len(messages))
+
+	for i, m := range messages {
+		pmsg, err := imap.NewParsedMessage(m)
+		if err != nil {
+			return nil, err
+		}
+
+		parsedMessages[i] = pmsg
+	}
+
 	flagSet := imap.NewFlagSet("\\Recent")
 
 	s.mailboxes = make([]imap.LabelID, 0, len(mboxIDs))
 
 	for _, mboxID := range mboxIDs {
 		for i := uint(0); i < *syncMessageCountFlag; i++ {
-			if _, err := c.Connector().CreateMessage(ctx, mboxID, messages[rand.Intn(len(messages))], flagSet, time.Now()); err != nil {
+			randIndex := rand.Intn(len(messages))
+			if _, err := c.Connector().CreateMessage(ctx, mboxID, messages[randIndex], parsedMessages[randIndex], flagSet, time.Now()); err != nil {
 				return nil, err
 			}
 		}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -28,7 +28,7 @@ type Connector interface {
 	GetMessage(ctx context.Context, messageID imap.MessageID) (imap.Message, []imap.LabelID, error)
 
 	// CreateMessage creates a new message on the remote.
-	CreateMessage(ctx context.Context, labelID imap.LabelID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, error)
+	CreateMessage(ctx context.Context, labelID imap.LabelID, literal []byte, parsedMessage *imap.ParsedMessage, flags imap.FlagSet, date time.Time) (imap.Message, error)
 
 	// LabelMessages labels the given messages with the given label ID.
 	LabelMessages(ctx context.Context, messageIDs []imap.MessageID, labelID imap.LabelID) error

--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -192,9 +192,9 @@ func (user *user) applyMessagesCreated(ctx context.Context, update *imap.Message
 					request = &db.CreateMessageReq{
 						Message:    update.Message,
 						Literal:    literal,
-						Body:       update.Body,
-						Structure:  update.Structure,
-						Envelope:   update.Envelope,
+						Body:       update.ParsedMessage.Body,
+						Structure:  update.ParsedMessage.Structure,
+						Envelope:   update.ParsedMessage.Envelope,
 						InternalID: imap.InternalMessageID(internalID),
 					}
 

--- a/internal/backend/state_connector_impl.go
+++ b/internal/backend/state_connector_impl.go
@@ -65,12 +65,13 @@ func (sc *stateConnectorImpl) CreateMessage(
 	ctx context.Context,
 	mboxID imap.LabelID,
 	literal []byte,
+	parsedMessage *imap.ParsedMessage,
 	flags imap.FlagSet,
 	date time.Time,
 ) (imap.InternalMessageID, imap.Message, error) {
 	ctx = sc.newContextWithMetadata(ctx)
 
-	msg, err := sc.connector.CreateMessage(ctx, mboxID, literal, flags, date)
+	msg, err := sc.connector.CreateMessage(ctx, mboxID, literal, parsedMessage, flags, date)
 	if err != nil {
 		return "", imap.Message{}, err
 	}

--- a/internal/state/connector.go
+++ b/internal/state/connector.go
@@ -37,6 +37,7 @@ type Connector interface {
 		ctx context.Context,
 		mboxID imap.LabelID,
 		literal []byte,
+		message *imap.ParsedMessage,
 		flags imap.FlagSet,
 		date time.Time,
 	) (imap.InternalMessageID, imap.Message, error)


### PR DESCRIPTION
Update the `Connector.CreateMessage` to also require a parsed message type. This enabled the connector implementation to inspect the message without having to re-parse the message as we already do this before the connector request.

This patch separates the parsed message from the `MessageCreated` update so that we can use it in other locations in the code base.