### PR TITLE
improve header parsing code

### DIFF
--- a/imap/envelope_test.go
+++ b/imap/envelope_test.go
@@ -17,7 +17,10 @@ func TestEnvelope(t *testing.T) {
 	root, err := rfc822.Parse(b)
 	require.NoError(t, err)
 
-	envelope, err := imap.Envelope(root.ParseHeader())
+	header, err := root.ParseHeader()
+	require.NoError(t, err)
+
+	envelope, err := imap.Envelope(header)
 	require.NoError(t, err)
 
 	assert.Equal(t, "(\"Sat, 03 Apr 2021 15:13:53 +0000\" \"this is currently a draft\" ((NIL NIL \"somebody\" \"pm.me\")) ((NIL NIL \"somebody\" \"pm.me\")) ((NIL NIL \"somebody\" \"pm.me\")) ((\"Somebody\" NIL \"somebody\" \"pm.me\")) NIL NIL NIL \"<X9xiWTZnfxfC0wGLBI9t-WEJCOSO_pT67TjlDDKZxzs7TFRCvzCF8lCtqrflZ9n2Z8Ve3rhwYE-vzUGkgOJWaZK4VWMk_WbertE5uklqS8A=@pm.me>\")", envelope)

--- a/imap/update_message_created.go
+++ b/imap/update_message_created.go
@@ -28,7 +28,12 @@ func NewParsedMessage(literal []byte) (*ParsedMessage, error) {
 		return nil, fmt.Errorf("failed to build message body structure: %w", err)
 	}
 
-	envelope, err := Envelope(root.ParseHeader())
+	header, err := root.ParseHeader()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parser message header: %w", err)
+	}
+
+	envelope, err := Envelope(header)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build message envelope: %w", err)
 	}

--- a/internal/state/mailbox_fetch.go
+++ b/internal/state/mailbox_fetch.go
@@ -263,10 +263,20 @@ func (m *Mailbox) fetchBodySection(section *proto.BodySection, literal []byte) (
 			return root.Header(), nil
 
 		case proto.SectionKeyword_HeaderFields:
-			return root.ParseHeader().Fields(section.Fields), nil
+			header, err := root.ParseHeader()
+			if err != nil {
+				return nil, err
+			}
+
+			return header.Fields(section.Fields), nil
 
 		case proto.SectionKeyword_HeaderFieldsNot:
-			return root.ParseHeader().FieldsNot(section.Fields), nil
+			header, err := root.ParseHeader()
+			if err != nil {
+				return nil, err
+			}
+
+			return header.FieldsNot(section.Fields), nil
 
 		case proto.SectionKeyword_Text:
 			return root.Body(), nil

--- a/rfc822/encrypt.go
+++ b/rfc822/encrypt.go
@@ -28,7 +28,12 @@ func Encrypt(kr *crypto.KeyRing, r io.Reader) ([]byte, error) {
 
 	buf := new(bytes.Buffer)
 
-	result, err := writeEncryptedPart(kr, ParseHeader(header), bytes.NewReader(body))
+	headerParsed, err := ParseHeader(header)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := writeEncryptedPart(kr, headerParsed, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +173,12 @@ func writeEncryptedMultiPart(kr *crypto.KeyRing, w io.Writer, header *Header, r 
 			return err
 		}
 
-		result, err := writeEncryptedPart(kr, ParseHeader(header), bytes.NewReader(body))
+		headerParsed, err := ParseHeader(header)
+		if err != nil {
+			return err
+		}
+
+		result, err := writeEncryptedPart(kr, headerParsed, bytes.NewReader(body))
 		if err != nil {
 			return err
 		}

--- a/tests/parsed_message_test.go
+++ b/tests/parsed_message_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"github.com/ProtonMail/gluon/imap"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkParsedMessage(b *testing.B) {
+	literal, err := os.ReadFile("testdata/multipart-mixed.eml")
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := imap.NewParsedMessage(literal)
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
Applies the following improvements:

* Removed channel for parsing (unnecessary overhead)
* Improve merge multi-line and forLines - Do not use bytesReader and
 BufferedReader (unnecessary overhead)
* Cache parsed header - avoids recalculation

These changes alone improve these parsed message benchmark code by
about 40% on average.

