### PR TITLE
fix(GODT-1599): Make sure `search before/since/on` uses internal date.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.18
 
 require (
 	entgo.io/ent v0.11.2
+	github.com/ProtonMail/go-mbox v1.1.0
 	github.com/ProtonMail/gopenpgp/v2 v2.4.7
 	github.com/bradenaw/juniper v0.6.0
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/emersion/go-imap v1.2.1-0.20220429085312-746087b7a317
 	github.com/emersion/go-imap-uidplus v0.0.0-20200503180755-e75854c361e9
-	github.com/emersion/go-mbox v1.0.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/mattn/go-sqlite3 v1.14.13
@@ -57,5 +57,3 @@ require (
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/emersion/go-mbox => github.com/ProtonMail/go-mbox v0.0.0-20220912191848-2c87d986f209

--- a/go.mod
+++ b/go.mod
@@ -57,3 +57,5 @@ require (
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/emersion/go-mbox => github.com/ProtonMail/go-mbox v0.0.0-20220912191848-2c87d986f209

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f h1:J2FzIrXN82q5uyUraeJpLIm7U6PffRwje2ORho5yIik=
 github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/ProtonMail/go-mbox v0.0.0-20220912191848-2c87d986f209 h1:zmA9lu11McnHnS5MFztXFpP7oMGNXibyDHEFjA9NWoc=
+github.com/ProtonMail/go-mbox v0.0.0-20220912191848-2c87d986f209/go.mod h1:Yp9IVuuOYLEuMv4yjgDHvhb5mHOcYH6x92Oas3QqEZI=
 github.com/ProtonMail/go-mime v0.0.0-20220302105931-303f85f7fe0f h1:CGq7OieOz3wyQJ1fO8S0eO9TCW1JyvLrf8fhzz1i8ko=
 github.com/ProtonMail/go-mime v0.0.0-20220302105931-303f85f7fe0f/go.mod h1:NYt+V3/4rEeDuaev/zw1zCq8uqVEuPHzDPo3OZrlGJ4=
 github.com/ProtonMail/gopenpgp/v2 v2.4.7 h1:V3xeelvXgJiZXZuPtSSE+uYbtPw4RmbmyPqXDAESPhg=
@@ -50,8 +52,6 @@ github.com/emersion/go-imap v1.2.1-0.20220429085312-746087b7a317 h1:i0cBrdFLm8A/
 github.com/emersion/go-imap v1.2.1-0.20220429085312-746087b7a317/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
 github.com/emersion/go-imap-uidplus v0.0.0-20200503180755-e75854c361e9 h1:2Kbw3iu7fFeSso6RWIArVNUj1VGG2PvjetnPUW7bnis=
 github.com/emersion/go-imap-uidplus v0.0.0-20200503180755-e75854c361e9/go.mod h1:GfiSiw/du0221I3Cf4F0DqX3Bv5Xe580gIIATrQtnJg=
-github.com/emersion/go-mbox v1.0.2 h1:tE/rT+lEugK9y0myEymCCHnwlZN04hlXPrbKkxRBA5I=
-github.com/emersion/go-mbox v1.0.2/go.mod h1:Yp9IVuuOYLEuMv4yjgDHvhb5mHOcYH6x92Oas3QqEZI=
 github.com/emersion/go-message v0.15.0/go.mod h1:wQUEfE+38+7EW8p8aZ96ptg6bAb1iwdgej19uXASlE4=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 h1:OJyUGMJTzHTd1XQp98QTaHernxMYzRaOasRir9hUlFQ=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f h1:J2FzIrXN82q5uyUraeJpLIm7U6PffRwje2ORho5yIik=
 github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/ProtonMail/go-mbox v0.0.0-20220912191848-2c87d986f209 h1:zmA9lu11McnHnS5MFztXFpP7oMGNXibyDHEFjA9NWoc=
-github.com/ProtonMail/go-mbox v0.0.0-20220912191848-2c87d986f209/go.mod h1:Yp9IVuuOYLEuMv4yjgDHvhb5mHOcYH6x92Oas3QqEZI=
+github.com/ProtonMail/go-mbox v1.1.0 h1:vrEcpvX5YfOkld5Q2fil41gXnLbYWKbE2gezZr6rqBU=
+github.com/ProtonMail/go-mbox v1.1.0/go.mod h1:ToecLYsf8RlxhndDEdjUa+eIfxuTxSQcxUQcGF6XB3A=
 github.com/ProtonMail/go-mime v0.0.0-20220302105931-303f85f7fe0f h1:CGq7OieOz3wyQJ1fO8S0eO9TCW1JyvLrf8fhzz1i8ko=
 github.com/ProtonMail/go-mime v0.0.0-20220302105931-303f85f7fe0f/go.mod h1:NYt+V3/4rEeDuaev/zw1zCq8uqVEuPHzDPo3OZrlGJ4=
 github.com/ProtonMail/gopenpgp/v2 v2.4.7 h1:V3xeelvXgJiZXZuPtSSE+uYbtPw4RmbmyPqXDAESPhg=

--- a/tests/capability_test.go
+++ b/tests/capability_test.go
@@ -8,13 +8,13 @@ func TestCapability(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A001 Capability")
 		c.S(`* CAPABILITY IDLE IMAP4rev1 STARTTLS`)
-		c.S("A001 OK")
+		c.S("A001 OK CAPABILITY")
 
 		c.C(`A002 login "user" "pass"`)
-		c.S(`A002 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT]`)
+		c.S(`A002 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT] Logged in`)
 
 		c.C("A003 Capability")
 		c.S(`* CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT`)
-		c.S("A003 OK")
+		c.S("A003 OK CAPABILITY")
 	})
 }

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -96,12 +96,16 @@ func (s *testConnection) Sx(want ...string) *testConnection {
 		}); idx >= 0 {
 			want = slices.Delete(want, idx, idx+1)
 		} else {
-			bad = append(bad, string(bytes.TrimSpace(have)))
+			bad = append(bad, string(have))
 		}
 	}
 
 	if len(bad) > 0 {
-		require.Fail(s.tb, "Received unexpected responses", bad)
+		require.Failf(s.tb,
+			"Received unexpected responses",
+			"want: %q\nbut have:%q",
+			want, bad,
+		)
 	}
 
 	return s

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -83,7 +83,7 @@ func (s *testConnection) Cf(format string, a ...any) *testConnection {
 
 // S expects that the server returns the given lines (in any order).
 func (s *testConnection) S(want ...string) *testConnection {
-	return s.Sx(xslices.Map(want, func(want string) string { return regexp.QuoteMeta(want) })...)
+	return s.Sx(xslices.Map(want, func(want string) string { return "^" + regexp.QuoteMeta(want) + "\r\n" })...)
 }
 
 // Sx expects that the server returns lines matching the given regexps (in any order).
@@ -113,7 +113,7 @@ func (s *testConnection) Sx(want ...string) *testConnection {
 
 // Se expects that the server eventually returns the given lines (in any order).
 func (s *testConnection) Se(want ...string) *testConnection {
-	return s.Sxe(xslices.Map(want, func(want string) string { return regexp.QuoteMeta(want) })...)
+	return s.Sxe(xslices.Map(want, func(want string) string { return "^" + regexp.QuoteMeta(want) + "\r\n" })...)
 }
 
 // Sxe expects that the server eventually returns lines matching the given regexps (in any order).

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -18,7 +18,7 @@ func TestDraftScenario(t *testing.T) {
 		c.C("A002 NOOP")
 		c.S("* 1 EXISTS")
 		c.S("* 1 RECENT")
-		c.S("A002 OK")
+		c.OK("A002")
 
 		c.C("A003 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
 		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm)")
@@ -28,14 +28,14 @@ func TestDraftScenario(t *testing.T) {
 		s.messageCreated("user", mailboxID, []byte("To: 4@4.pm"), time.Now())
 		s.flush("user")
 
-		c.C("A002 NOOP")
+		c.C("A004 NOOP")
 		c.S("* 1 EXPUNGE")
 		c.S("* 1 EXISTS")
 		c.S("* 1 RECENT")
-		c.S("A002 OK")
+		c.OK("A004")
 
-		c.C("A003 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
+		c.C("A005 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
 		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm)")
-		c.OK("A003")
+		c.OK("A005")
 	})
 }

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -1,6 +1,9 @@
 package tests
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestDraftScenario(t *testing.T) {
 	// Simulate a draft update issued from the connector, which involves deleting the original message in drafts
@@ -10,7 +13,7 @@ func TestDraftScenario(t *testing.T) {
 
 		c.C("A002 SELECT Drafts").OK("A002")
 
-		messageID := s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"))
+		messageID := s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"), time.Now())
 
 		c.C("A002 NOOP")
 		c.S("* 1 EXISTS")
@@ -22,7 +25,7 @@ func TestDraftScenario(t *testing.T) {
 		c.OK("A003")
 
 		s.messageDeleted("user", messageID)
-		s.messageCreated("user", mailboxID, []byte("To: 4@4.pm"))
+		s.messageCreated("user", mailboxID, []byte("To: 4@4.pm"), time.Now())
 		s.flush("user")
 
 		c.C("A002 NOOP")

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -85,6 +85,6 @@ func TestLoginLiteralFailure(t *testing.T) {
 func TestLoginCapabilities(t *testing.T) {
 	runOneToOneTest(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("A001 login user pass")
-		c.S(`A001 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT]`)
+		c.S(`A001 OK [CAPABILITY IDLE IMAP4rev1 MOVE STARTTLS UIDPLUS UNSELECT] Logged in`)
 	})
 }

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -284,7 +284,42 @@ func TestSearchOld(t *testing.T) {
 
 func TestSearchOn(t *testing.T) {
 	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox string, mboxID imap.LabelID) {
-		// GOMSRV-132: Implement test.
+		// None
+		c.C(`A001 search on 13-Aug-1982`)
+		c.S("* SEARCH")
+		c.OK("A001")
+
+		// One
+		c.C(`A001 search on 23-Jul-2002`)
+		c.S("* SEARCH 1")
+		c.OK("A001")
+
+		// More
+		c.C(`A001 search on 26-Nov-2002`)
+		c.S("* SEARCH 99 100")
+		c.OK("A001")
+	})
+}
+
+func TestSearchSentOnAndOn(t *testing.T) {
+	// Test search senton/on when internal date (e.g. 11-Aug-2002) and
+	// header date (10-Aug-2002) are different.
+	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox string, mboxID imap.LabelID) {
+		c.C(`A001 search on 10-Aug-2002`)
+		c.S("* SEARCH")
+		c.OK("A001")
+
+		c.C(`A001 search senton 10-Aug-2002`)
+		c.S("* SEARCH 19")
+		c.OK("A001")
+
+		c.C(`A001 search on 11-Aug-2002`)
+		c.S("* SEARCH 19")
+		c.OK("A001")
+
+		c.C(`A001 search senton 11-Aug-2002`)
+		c.S("* SEARCH")
+		c.OK("A001")
 	})
 }
 
@@ -371,7 +406,7 @@ func TestSearchSeen(t *testing.T) {
 func TestSearchSentBefore(t *testing.T) {
 	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox string, mboxID imap.LabelID) {
 		c.C(`A001 search sentbefore 10-Aug-2002`)
-		c.S("* SEARCH " + seq(1, 19))
+		c.S("* SEARCH " + seq(1, 18))
 		c.OK("A001")
 	})
 }
@@ -411,7 +446,20 @@ func TestSearchSentSince(t *testing.T) {
 
 func TestSearchSince(t *testing.T) {
 	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox string, mboxID imap.LabelID) {
-		// GOMSRV-132: Implement test.
+		// None
+		c.C(`A001 search since 13-Aug-2200`)
+		c.S("* SEARCH")
+		c.OK("A001")
+
+		// All
+		c.C(`A001 search since 13-Aug-1982`)
+		c.S("* SEARCH " + seq(1, 100))
+		c.OK("A001")
+
+		// Latest messages
+		c.C(`A001 search since 26-Nov-2002`)
+		c.S("* SEARCH 99 100")
+		c.OK("A001")
 	})
 }
 

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -88,7 +88,20 @@ func TestSearchBcc(t *testing.T) {
 
 func TestSearchBefore(t *testing.T) {
 	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox string, mboxID imap.LabelID) {
-		// GOMSRV-132: Implement test.
+		// None
+		c.C(`A001 search before 13-Aug-1982`)
+		c.S("* SEARCH")
+		c.OK("A001")
+
+		// All
+		c.C(`A001 search before 13-Aug-2200`)
+		c.S("* SEARCH " + seq(1, 100))
+		c.OK("A001")
+
+		// Earliest messages
+		c.C(`A001 search before 30-Jul-2002`)
+		c.S("* SEARCH 1 2")
+		c.OK("A001")
 	})
 }
 

--- a/tests/select_test.go
+++ b/tests/select_test.go
@@ -17,10 +17,10 @@ func TestSelect(t *testing.T) {
 		c.S(`* FLAGS (\Deleted \Flagged \Seen)`,
 			`* 2 EXISTS`,
 			`* 2 RECENT`,
-			`* OK [UNSEEN 2]`,
-			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
-			`* OK [UIDNEXT 3]`,
-			`* OK [UIDVALIDITY 1]`)
+			`* OK [UNSEEN 2] Unseen messages`,
+			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)] Flags permitted`,
+			`* OK [UIDNEXT 3] Predicted next UID`,
+			`* OK [UIDVALIDITY 1] UIDs valid`)
 		c.S("A006 OK [READ-WRITE] SELECT")
 
 		// Selecting again modifies the RECENT value.
@@ -28,19 +28,19 @@ func TestSelect(t *testing.T) {
 		c.S(`* FLAGS (\Deleted \Flagged \Seen)`,
 			`* 2 EXISTS`,
 			`* 0 RECENT`,
-			`* OK [UNSEEN 2]`,
-			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
-			`* OK [UIDNEXT 3]`,
-			`* OK [UIDVALIDITY 1]`)
+			`* OK [UNSEEN 2] Unseen messages`,
+			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)] Flags permitted`,
+			`* OK [UIDNEXT 3] Predicted next UID`,
+			`* OK [UIDVALIDITY 1] UIDs valid`)
 		c.S("A006 OK [READ-WRITE] SELECT")
 
 		c.C("A007 select Archive")
 		c.S(`* FLAGS (\Deleted \Flagged \Seen)`,
 			`* 1 EXISTS`,
 			`* 1 RECENT`,
-			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)]`,
-			`* OK [UIDNEXT 2]`,
-			`* OK [UIDVALIDITY 1]`)
+			`* OK [PERMANENTFLAGS (\Deleted \Flagged \Seen)] Flags permitted`,
+			`* OK [UIDNEXT 2] Predicted next UID`,
+			`* OK [UIDVALIDITY 1] UIDs valid`)
 		c.S(`A007 OK [READ-WRITE] SELECT`)
 	})
 }

--- a/tests/sequence_range_test.go
+++ b/tests/sequence_range_test.go
@@ -40,7 +40,7 @@ func TestSequenceRange(t *testing.T) {
 		}
 		c.OK(`A010`)
 		c.C(`A011 COPY 1,3:* mbox2`)
-		c.S(`A011`)
+		c.OK(`A011`)
 		c.C(`A012 COPY 6:* mbox2`).BAD(`A012`)
 		c.C(`A012 COPY 6:* mbox2`).BAD(`A012`)
 		c.C(`A013 MOVE 1,5,3 mbox2`)

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/db/ent"
 	"github.com/ProtonMail/gluon/internal/utils"
+	"github.com/ProtonMail/go-mbox"
 	"github.com/emersion/go-imap/client"
-	"github.com/emersion/go-mbox"
 	"github.com/stretchr/testify/require"
 )
 
@@ -295,7 +295,6 @@ func forMessageInMBox(rr io.Reader, fn func(messageDelimiter, literal []byte)) e
 	}
 
 	return nil
-
 }
 
 func parseDateFromDelimiter(messageDelimiter string) (t time.Time, err error) {
@@ -303,5 +302,6 @@ func parseDateFromDelimiter(messageDelimiter string) (t time.Time, err error) {
 	if len(split) <= 3 {
 		return t, errors.New("not enough arguments in delimiter")
 	}
+
 	return time.Parse("Mon Jan _2 15:04:05 2006", strings.TrimSpace(strings.Join(split[2:], " ")))
 }

--- a/tests/testdata/dovecot-crlf
+++ b/tests/testdata/dovecot-crlf
@@ -995,7 +995,7 @@ maildir_copy_with_hardlinks=yes that'd be possible even with quota full.
 I guess I'll have to install quota support and start fixing.
 
 
-From marcelo@carpa.ciagri.usp.br  Fri Aug  9 22:05:26 2002
+From marcelo@carpa.ciagri.usp.br  Sun Aug 11 22:05:26 2002
 Received: with ECARTIS (v1.0.0; list dovecot); Fri, 09 Aug 2002 22:05:26 +0300 (EEST)
 Return-Path: <marcelo@carpa.ciagri.usp.br>
 Delivered-To: dovecot@procontrol.fi
@@ -1004,7 +1004,7 @@ Received: from carpa.ciagri.usp.br (carpa.ciagri.usp.br [143.107.209.25])
 	for <dovecot@procontrol.fi>; Fri,  9 Aug 2002 22:03:46 +0300 (EEST)
 Received: (qmail 27100 invoked by uid 1000); 9 Aug 2002 19:03:39 -0000
 From: marcelo@carpa.ciagri.usp.br
-Date: Fri, 9 Aug 2002 16:03:39 -0300
+Date: Sat, 10 Aug 2002 16:03:39 -0300
 To: dovecot@procontrol.fi
 Subject: [dovecot] Re: Disk quotas
 Message-ID: <20020809190339.GA2063@carpa.ciagri.usp.br>

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -228,23 +228,23 @@ func TestMessageSeenUpdate(t *testing.T) {
 		c.C("A001 SELECT mbox").OK("A001")
 
 		c.C("A002 FETCH 1 (FLAGS)")
-		c.S(`* 1 FETCH (FLAGS (\Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent))`)
 		c.OK("A002")
 
 		s.messageSeen("user", messageID, true)
 
 		c.C("A003 FETCH 1 (FLAGS)")
-		c.S(`* 1 FETCH (FLAGS (\Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent))`)
 		// Unilateral update arrives after fetch.
-		c.S(`* 1 FETCH (FLAGS (\Recent \Seen)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)
 		c.OK("A003")
 
 		s.messageSeen("user", messageID, false)
 
 		c.C("A004 FETCH 1 (FLAGS)")
-		c.S(`* 1 FETCH (FLAGS (\Recent \Seen)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent \Seen))`)
 		// Unilateral update arrives after fetch.
-		c.S(`* 1 FETCH (FLAGS (\Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent))`)
 		c.OK("A004")
 	})
 }
@@ -258,14 +258,14 @@ func TestMessageFlaggedUpdate(t *testing.T) {
 
 		s.messageFlagged("user", messageID, true)
 		c.C("A003 FETCH 1 (FLAGS)")
-		c.S(`* 1 FETCH (FLAGS (\Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent))`)
 		c.OK("A003")
 
 		s.messageFlagged("user", messageID, false)
 		c.C("A004 FETCH 1 (FLAGS)")
-		c.S(`* 1 FETCH (FLAGS (\Flagged \Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Flagged \Recent))`)
 		// Unilateral updates arrive afterwards.
-		c.S(`* 1 FETCH (FLAGS (\Recent)`)
+		c.S(`* 1 FETCH (FLAGS (\Recent))`)
 		c.OK("A004")
 	})
 }


### PR DESCRIPTION

* fix(godt-1599): make sure search before uses internal date.
* fix: more strict `testConnection.S` and `.Se` matching.
* fix(godt-1599): make sure search since/on uses internal date.


N.B. Dependency `emersion/go-mbox` was forked, added `GetMessageDelimiter` function and replaced in go.mod