### PR TITLE
refactor(GODT-1730): Refactor HeaderType

### DIFF
--- a/internal/ids/header.go
+++ b/internal/ids/header.go
@@ -2,7 +2,7 @@ package ids
 
 // InternalIDKey is the key of the header entry we add to messages in the mailserver system.
 // This allows us to detect when clients try to create a duplicate of a message, which we treat instead as a copy.
-const InternalIDKey = `X-PM-GLUON-ID`
+const InternalIDKey = `X-Pm-Gluon-Id`
 
 // InternalIDHeaderLength is the expected length of the full header entry, excluding the new line character.
 const InternalIDHeaderLength = 51

--- a/rfc822/encrypt.go
+++ b/rfc822/encrypt.go
@@ -25,7 +25,7 @@ func Encrypt(kr *crypto.KeyRing, r io.Reader) ([]byte, error) {
 
 	buf := new(bytes.Buffer)
 
-	headerParsed, err := ParseHeader(header)
+	headerParsed, err := NewHeader(header)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func writeEncryptedMultiPart(kr *crypto.KeyRing, w io.Writer, header *Header, r 
 	for _, part := range parts {
 		header, body := Split(part.Data)
 
-		headerParsed, err := ParseHeader(header)
+		headerParsed, err := NewHeader(header)
 		if err != nil {
 			return err
 		}

--- a/rfc822/parser.go
+++ b/rfc822/parser.go
@@ -38,7 +38,7 @@ func (section *Section) Header() []byte {
 
 func (section *Section) ParseHeader() (*Header, error) {
 	if section.parsedHeader == nil {
-		h, err := ParseHeader(section.Header())
+		h, err := NewHeader(section.Header())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
To improve lookup after the header has been parsed all the entries are stored in a map.

Every single line of the header is stored as a linked list so we can perform order dependent queries or modify the header while preserving the original order. The result of mergedLine requests are cached to avoid this computation in the future.

The SetHeaderValue function has been updated so that it does not parse the full header, but rather sets the new value as the first value of the new header. This avoids having to parse the whole header to set our internal ID-Key

Finally our internal ID key was case-corrected according to the standard.