### PR TITLE
fix: Header parser (naive)

### DIFF
--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -1,0 +1,27 @@
+package imap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedRFC822WithoutHeader(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
+	require.NoError(t, err)
+
+	parsed, err := NewParsedMessage(b)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+}
+
+func TestHeaderOutOfBounds(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
+	require.NoError(t, err)
+
+	parsed, err := NewParsedMessage(b)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+}

--- a/imap/testdata/bounds.eml
+++ b/imap/testdata/bounds.eml
@@ -1,0 +1,32 @@
+Content-Type: multipart/mixed;
+ boundary=eccb619eb8cb1994c1375b3b013a7c995dcc7ab05f9cfec486ffeb18d6f8ca65
+To: <someone@pm.me>
+From: <someone@gmail.com>
+Subject: empty header test
+Date: Tue, 17 Aug 2021 07:33:19 -0700 (PDT)
+Mime-Version: 1.0
+
+--eccb619eb8cb1994c1375b3b013a7c995dcc7ab05f9cfec486ffeb18d6f8ca65
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=utf-8
+
+No valid message body or attachments were found in this email. Please check=
+ with the sender to ensure that they are sending valid emails. The raw mess=
+age is attached.\n\n
+--eccb619eb8cb1994c1375b3b013a7c995dcc7ab05f9cfec486ffeb18d6f8ca65
+Content-Disposition: attachment; filename=message.eml
+Content-Type: message/rfc822; name=message.eml
+
+Return-Path: <someone@gmail.com>
+X-Original-To: someone@pm.me
+Date: Tue, 17 Aug 2021 07:33:19 -0700 (PDT)
+To: someone@pm.me
+From: someone@gmail.com
+Subject: empty header test
+Content-type: multipart/mixed; boundary=whatever
+
+--whatever
+Body
+--whatever
+
+--eccb619eb8cb1994c1375b3b013a7c995dcc7ab05f9cfec486ffeb18d6f8ca65--

--- a/imap/testdata/rfc822.eml
+++ b/imap/testdata/rfc822.eml
@@ -1,0 +1,20 @@
+Content-Type: multipart/mixed;
+ boundary=b55536263d91d87d90bcd1f3249becaa7fc9105ddfbd96d7c058e1589725
+Date: Thu, 21 Nov 2013 16:33:01 +0100
+From: "Some Body" <someone@pm.me>
+Subject: Empty header again
+To: "Some Body Else" <someoneelse@pm.me>
+Mime-Version: 1.0
+
+--b55536263d91d87d90bcd1f3249becaa7fc9105ddfbd96d7c058e1589725
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=utf-8
+
+<html><head></head><body><p>Test</p></body></html>
+--b55536263d91d87d90bcd1f3249becaa7fc9105ddfbd96d7c058e1589725
+Content-Disposition: attachment; filename=filename.mail
+Content-Type: message/rfc822; name=filename.mail
+
+# The command is:
+rm -rf /
+--b55536263d91d87d90bcd1f3249becaa7fc9105ddfbd96d7c058e1589725--

--- a/rfc822/header.go
+++ b/rfc822/header.go
@@ -410,12 +410,6 @@ func mergeMultiline(line []byte) string {
 	return builder.String()
 }
 
-func isHeader(b []byte) bool {
-	_, err := NewHeader(b)
-
-	return err == nil
-}
-
 func splitLine(line []byte) [][]byte {
 	result := bytes.SplitN(line, []byte(`:`), 2)
 

--- a/rfc822/header.go
+++ b/rfc822/header.go
@@ -10,7 +10,8 @@ import (
 )
 
 type headerEntry struct {
-	ParsedHeaderEntry
+	parsedHeaderEntry
+
 	mapKey string
 	merged string
 	prev   *headerEntry
@@ -19,7 +20,7 @@ type headerEntry struct {
 
 func (he *headerEntry) getMerged(data []byte) string {
 	if len(he.merged) == 0 {
-		he.merged = mergeMultiline(he.GetValue(data))
+		he.merged = mergeMultiline(he.getValue(data))
 	}
 
 	return he.merged
@@ -41,7 +42,7 @@ func NewHeader(data []byte) (*Header, error) {
 	parser := newHeaderParser(data)
 
 	for {
-		entry, err := parser.Next()
+		entry, err := parser.next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -51,13 +52,13 @@ func NewHeader(data []byte) (*Header, error) {
 		}
 
 		hentry := &headerEntry{
-			ParsedHeaderEntry: entry,
+			parsedHeaderEntry: entry,
 			merged:            "",
 			next:              nil,
 		}
 
-		if entry.HasKey() {
-			hashKey := strings.ToLower(string(entry.GetKey(data)))
+		if entry.hasKey() {
+			hashKey := strings.ToLower(string(entry.getKey(data)))
 			hentry.mapKey = hashKey
 
 			if v, ok := h.keys[hashKey]; !ok {
@@ -114,7 +115,7 @@ func (h *Header) GetLine(key string) []byte {
 		return nil
 	}
 
-	return v[0].GetAll(h.data)
+	return v[0].getAll(h.data)
 }
 
 func (h *Header) getLines() [][]byte {
@@ -132,7 +133,7 @@ func (h *Header) GetRaw(key string) []byte {
 		return nil
 	}
 
-	return v[0].GetValue(h.data)
+	return v[0].getValue(h.data)
 }
 
 func (h *Header) Set(key, val string) {
@@ -144,7 +145,7 @@ func (h *Header) Set(key, val string) {
 
 	entryBytes := joinLine([]byte(key), []byte(val))
 	newHeaderEntry := &headerEntry{
-		ParsedHeaderEntry: ParsedHeaderEntry{
+		parsedHeaderEntry: parsedHeaderEntry{
 			keyStart:   0,
 			keyEnd:     len(keyBytes),
 			valueStart: len(keyBytes) + 2,
@@ -168,7 +169,8 @@ func (h *Header) Set(key, val string) {
 		h.firstEntry.prev = newHeaderEntry
 		h.firstEntry = newHeaderEntry
 
-		buffer := bytes.Buffer{}
+		var buffer bytes.Buffer
+
 		if insertOffset != 0 {
 			if _, err := buffer.Write(h.data[0:insertOffset]); err != nil {
 				panic("failed to write to byte buffer")
@@ -229,12 +231,12 @@ func (h *Header) Fields(fields []string) []byte {
 	var res []byte
 
 	for e := h.firstEntry; e != nil; e = e.next {
-		if len(bytes.TrimSpace(e.GetAll(h.data))) == 0 {
-			res = append(res, e.GetAll(h.data)...)
+		if len(bytes.TrimSpace(e.getAll(h.data))) == 0 {
+			res = append(res, e.getAll(h.data)...)
 			continue
 		}
 
-		if !e.HasKey() {
+		if !e.hasKey() {
 			continue
 		}
 
@@ -243,7 +245,7 @@ func (h *Header) Fields(fields []string) []byte {
 			continue
 		}
 
-		res = append(res, e.GetAll(h.data)...)
+		res = append(res, e.getAll(h.data)...)
 	}
 
 	return res
@@ -259,12 +261,12 @@ func (h *Header) FieldsNot(fields []string) []byte {
 	var res []byte
 
 	for e := h.firstEntry; e != nil; e = e.next {
-		if len(bytes.TrimSpace(e.GetAll(h.data))) == 0 {
-			res = append(res, e.GetAll(h.data)...)
+		if len(bytes.TrimSpace(e.getAll(h.data))) == 0 {
+			res = append(res, e.getAll(h.data)...)
 			continue
 		}
 
-		if !e.HasKey() {
+		if !e.hasKey() {
 			continue
 		}
 
@@ -273,20 +275,19 @@ func (h *Header) FieldsNot(fields []string) []byte {
 			continue
 		}
 
-		res = append(res, e.GetAll(h.data)...)
+		res = append(res, e.getAll(h.data)...)
 	}
 
-	// Since we are only applying the entries that have a key, we need to add a new line at the end.
 	return res
 }
 
 func (h *Header) Entries(fn func(key, val string)) {
 	for e := h.firstEntry; e != nil; e = e.next {
-		if !e.HasKey() {
+		if !e.hasKey() {
 			continue
 		}
 
-		fn(string(e.GetKey(h.data)), e.getMerged(h.data))
+		fn(string(e.getKey(h.data)), e.getMerged(h.data))
 	}
 }
 
@@ -303,13 +304,14 @@ func SetHeaderValue(literal []byte, key, val string) ([]byte, error) {
 
 	parser := newHeaderParser(rawHeader)
 
-	var foundFirstEntry bool
-
-	var parsedHeaderEntry ParsedHeaderEntry
+	var (
+		foundFirstEntry   bool
+		parsedHeaderEntry parsedHeaderEntry
+	)
 
 	// find first header entry.
 	for {
-		entry, err := parser.Next()
+		entry, err := parser.next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -318,7 +320,7 @@ func SetHeaderValue(literal []byte, key, val string) ([]byte, error) {
 			}
 		}
 
-		if entry.HasKey() {
+		if entry.hasKey() {
 			foundFirstEntry = true
 			parsedHeaderEntry = entry
 
@@ -332,7 +334,10 @@ func SetHeaderValue(literal []byte, key, val string) ([]byte, error) {
 	if !foundFirstEntry {
 		return append(rawHeader, append(data, body...)...), nil
 	} else {
-		return append(literal[0:parsedHeaderEntry.keyStart], append(data, literal[parsedHeaderEntry.keyStart:]...)...), nil
+		return append(
+			literal[0:parsedHeaderEntry.keyStart],
+			append(data, literal[parsedHeaderEntry.keyStart:]...)...,
+		), nil
 	}
 }
 
@@ -343,7 +348,7 @@ func GetHeaderValue(literal []byte, key string) (string, error) {
 	parser := newHeaderParser(rawHeader)
 
 	for {
-		entry, err := parser.Next()
+		entry, err := parser.next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -352,161 +357,39 @@ func GetHeaderValue(literal []byte, key string) (string, error) {
 			}
 		}
 
-		if !entry.HasKey() {
+		if !entry.hasKey() {
 			continue
 		}
 
-		if !strings.EqualFold(key, string(entry.GetKey(rawHeader))) {
+		if !strings.EqualFold(key, string(entry.getKey(rawHeader))) {
 			continue
 		}
 
-		return mergeMultiline(entry.GetValue(rawHeader)), nil
+		return mergeMultiline(entry.getValue(rawHeader)), nil
 	}
 
 	return "", nil
 }
 
 var (
-	errNonASCIIHeaderKey = fmt.Errorf("header key contains invalid characters")
-	errKeyNotFound       = fmt.Errorf("invalid header key")
+	ErrNonASCIIHeaderKey = fmt.Errorf("header key contains invalid characters")
+	ErrKeyNotFound       = fmt.Errorf("invalid header key")
 )
-
-type ParsedHeaderEntry struct {
-	keyStart   int
-	keyEnd     int
-	valueStart int
-	valueEnd   int
-}
-
-func (p ParsedHeaderEntry) HasKey() bool {
-	return p.keyStart != p.keyEnd
-}
-
-func (p ParsedHeaderEntry) GetKey(header []byte) []byte {
-	return header[p.keyStart:p.keyEnd]
-}
-
-func (p ParsedHeaderEntry) GetValue(header []byte) []byte {
-	return header[p.valueStart:p.valueEnd]
-}
-
-func (p ParsedHeaderEntry) GetAll(header []byte) []byte {
-	return header[p.keyStart:p.valueEnd]
-}
-
-func (p *ParsedHeaderEntry) applyOffset(offset int) {
-	p.keyStart += offset
-	p.keyEnd += offset
-	p.valueStart += offset
-	p.valueEnd += offset
-}
-
-type headerParser struct {
-	header []byte
-	offset int
-}
-
-// Next will keep parsing until it collects a new entry. io.EOF is returned when there is nothing left to parse.
-func (hp *headerParser) Next() (ParsedHeaderEntry, error) {
-	headerLen := len(hp.header)
-
-	if hp.offset >= headerLen {
-		return ParsedHeaderEntry{}, io.EOF
-	}
-
-	result := ParsedHeaderEntry{
-		keyStart:   hp.offset,
-		keyEnd:     -1,
-		valueStart: -1,
-		valueEnd:   -1,
-	}
-
-	// Detect key, have to handle prelude case where there is no header information or last empty new line.
-	{
-		for hp.offset < headerLen {
-			if hp.header[hp.offset] == ':' {
-				prevOffset := hp.offset
-				hp.offset++
-				if hp.offset < headerLen && (hp.header[hp.offset] == ' ' || hp.header[hp.offset] == '\r' || hp.header[hp.offset] == '\n') {
-					result.keyEnd = prevOffset
-
-					// Validate the header key.
-					for i := result.keyStart; i < result.keyEnd; i++ {
-						v := hp.header[i]
-						if v < 33 || v > 126 {
-							return ParsedHeaderEntry{}, errNonASCIIHeaderKey
-						}
-					}
-
-					break
-				}
-			} else if hp.header[hp.offset] == '\n' {
-				hp.offset++
-				result.keyEnd = result.keyStart
-				result.valueStart = result.keyStart
-				result.valueEnd = hp.offset
-				return result, nil
-			} else {
-				hp.offset++
-			}
-		}
-
-	}
-
-	// collect value.
-	searchOffset := result.keyEnd + 2
-	result.valueStart = searchOffset
-
-	for searchOffset < headerLen {
-		// consume all content in between two quotes.
-		if hp.header[searchOffset] == '"' {
-			searchOffset++
-			for searchOffset < headerLen && hp.header[searchOffset] != '"' {
-				searchOffset++
-			}
-			searchOffset++
-
-			continue
-		} else if hp.header[searchOffset] == '\n' {
-			searchOffset++
-			// if folding the next line has to start with space or tab.
-			if searchOffset < headerLen && (hp.header[searchOffset] != ' ' && hp.header[searchOffset] != '\t') {
-				result.valueEnd = searchOffset
-				break
-			}
-		} else {
-			searchOffset++
-		}
-	}
-
-	hp.offset = searchOffset
-
-	// handle case where we may have reached EOF without concluding any previous processing.
-	if result.valueEnd == -1 && searchOffset >= headerLen {
-		result.valueEnd = headerLen
-	}
-
-	return result, nil
-}
-
-func newHeaderParser(header []byte) headerParser {
-	return headerParser{header: header}
-}
 
 func mergeMultiline(line []byte) string {
 	remaining := line
 
-	builder := strings.Builder{}
-	separator := []byte{'\n'}
+	var builder strings.Builder
 
 	for len(remaining) != 0 {
-		index := bytes.Index(remaining, separator)
+		index := bytes.Index(remaining, []byte{'\n'})
 		if index < 0 {
 			builder.Write(bytes.TrimSpace(remaining))
 			break
 		}
 
 		var section []byte
+
 		if index >= 1 && remaining[index-1] == '\r' {
 			section = remaining[0 : index-1]
 		} else {
@@ -525,6 +408,12 @@ func mergeMultiline(line []byte) string {
 	}
 
 	return builder.String()
+}
+
+func isHeader(b []byte) bool {
+	_, err := NewHeader(b)
+
+	return err == nil
 }
 
 func splitLine(line []byte) [][]byte {

--- a/rfc822/header_parser.go
+++ b/rfc822/header_parser.go
@@ -1,0 +1,129 @@
+package rfc822
+
+import "io"
+
+type headerParser struct {
+	header []byte
+	offset int
+}
+
+func newHeaderParser(header []byte) headerParser {
+	return headerParser{header: header}
+}
+
+// next will keep parsing until it collects a new entry. io.EOF is returned when there is nothing left to parse.
+func (hp *headerParser) next() (parsedHeaderEntry, error) {
+	headerLen := len(hp.header)
+
+	if hp.offset >= headerLen {
+		return parsedHeaderEntry{}, io.EOF
+	}
+
+	result := parsedHeaderEntry{
+		keyStart:   hp.offset,
+		keyEnd:     -1,
+		valueStart: -1,
+		valueEnd:   -1,
+	}
+
+	// Detect key, have to handle prelude case where there is no header information or last empty new line.
+	{
+		for hp.offset < headerLen {
+			if hp.header[hp.offset] == ':' {
+				prevOffset := hp.offset
+				hp.offset++
+				if hp.offset < headerLen && (hp.header[hp.offset] == ' ' || hp.header[hp.offset] == '\r' || hp.header[hp.offset] == '\n') {
+					result.keyEnd = prevOffset
+
+					// Validate the header key.
+					for i := result.keyStart; i < result.keyEnd; i++ {
+						if v := hp.header[i]; v < 33 || v > 126 {
+							return parsedHeaderEntry{}, ErrNonASCIIHeaderKey
+						}
+					}
+
+					break
+				}
+			} else if hp.header[hp.offset] == '\n' {
+				hp.offset++
+
+				result.keyEnd = result.keyStart
+				result.valueStart = result.keyStart
+				result.valueEnd = hp.offset
+
+				return result, nil
+			} else {
+				hp.offset++
+			}
+		}
+
+		if result.keyEnd == -1 {
+			return parsedHeaderEntry{}, ErrKeyNotFound
+		}
+	}
+
+	// collect value.
+	searchOffset := result.keyEnd + 2
+	result.valueStart = searchOffset
+
+	for searchOffset < headerLen {
+		// consume all content in between two quotes.
+		if hp.header[searchOffset] == '"' {
+			searchOffset++
+			for searchOffset < headerLen && hp.header[searchOffset] != '"' {
+				searchOffset++
+			}
+			searchOffset++
+
+			continue
+		} else if hp.header[searchOffset] == '\n' {
+			searchOffset++
+			// if folding the next line has to start with space or tab.
+			if searchOffset < headerLen && (hp.header[searchOffset] != ' ' && hp.header[searchOffset] != '\t') {
+				result.valueEnd = searchOffset
+				break
+			}
+		} else {
+			searchOffset++
+		}
+	}
+
+	hp.offset = searchOffset
+
+	// handle case where we may have reached EOF without concluding any previous processing.
+	if result.valueEnd == -1 && searchOffset >= headerLen {
+		result.valueEnd = headerLen
+	}
+
+	return result, nil
+}
+
+type parsedHeaderEntry struct {
+	keyStart   int
+	keyEnd     int
+	valueStart int
+	valueEnd   int
+}
+
+func (p parsedHeaderEntry) hasKey() bool {
+	return p.keyStart != p.keyEnd
+}
+
+func (p parsedHeaderEntry) getKey(header []byte) []byte {
+	return header[p.keyStart:p.keyEnd]
+}
+
+func (p parsedHeaderEntry) getValue(header []byte) []byte {
+	return header[p.valueStart:p.valueEnd]
+}
+
+func (p parsedHeaderEntry) getAll(header []byte) []byte {
+	return header[p.keyStart:p.valueEnd]
+}
+
+func (p *parsedHeaderEntry) applyOffset(offset int) {
+	p.keyStart += offset
+	p.keyEnd += offset
+	p.valueStart += offset
+	p.valueEnd += offset
+}

--- a/rfc822/parser.go
+++ b/rfc822/parser.go
@@ -155,6 +155,10 @@ func Split(b []byte) ([]byte, []byte) {
 func parse(literal []byte, identifier []int, begin, end int) *Section {
 	header, _ := Split(literal[begin:end])
 
+	if !isHeader(header) {
+		header = nil
+	}
+
 	return &Section{
 		identifier: identifier,
 		literal:    literal,

--- a/rfc822/parser.go
+++ b/rfc822/parser.go
@@ -155,15 +155,18 @@ func Split(b []byte) ([]byte, []byte) {
 func parse(literal []byte, identifier []int, begin, end int) *Section {
 	header, _ := Split(literal[begin:end])
 
-	if !isHeader(header) {
+	parsedHeader, err := NewHeader(header)
+	if err != nil {
 		header = nil
+		parsedHeader = nil
 	}
 
 	return &Section{
-		identifier: identifier,
-		literal:    literal,
-		header:     begin,
-		body:       begin + len(header),
-		end:        end,
+		identifier:   identifier,
+		literal:      literal,
+		parsedHeader: parsedHeader,
+		header:       begin,
+		body:         begin + len(header),
+		end:          end,
 	}
 }


### PR DESCRIPTION
The new header parser did not correctly deal with two edge cases:
1. The message contains an embedded RFC822 message with no header
2. Parsing something (not necessarily a header) with a key but no value

This fix checks that what we think is a header actually is one in a naive way by trying to parse it and seeing if it returns an error. It also handles the case that a header key was not finished being read by returning an error, indicating this wasn't a valid header).