### PR TITLE
refactor(GODT-1570): Do less work with Flag modification

### DIFF
--- a/imap/flags.go
+++ b/imap/flags.go
@@ -40,6 +40,10 @@ func NewFlagSet(flags ...string) FlagSet {
 	return fs
 }
 
+func NewFlagSetWithCapacity(capacity int) FlagSet {
+	return make(FlagSet, capacity)
+}
+
 // NewFlagSetFromSlice creates a flag set containing the flags from a slice.
 func NewFlagSetFromSlice(flags []string) FlagSet {
 	return NewFlagSet(flags...)
@@ -106,6 +110,10 @@ func (fs FlagSet) Equals(otherFs FlagSet) bool {
 // The case of existing elements is preserved.
 func (fs FlagSet) Add(flags ...string) FlagSet {
 	return fs.clone().add(flags...)
+}
+
+func (fs FlagSet) AddToSelf(flags ...string) FlagSet {
+	return fs.add(flags...)
 }
 
 func (fs FlagSet) AddFlagSet(set FlagSet) FlagSet {

--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -391,21 +391,23 @@ func (user *user) setMessageFlags(ctx context.Context, tx *ent.Tx, messageID ima
 		return err
 	}
 
-	if seen && !curFlags[messageID].ContainsUnchecked(imap.FlagSeenLowerCase) {
+	flagSet := curFlags[0].FlagSet
+
+	if seen && !flagSet.ContainsUnchecked(imap.FlagSeenLowerCase) {
 		if err := user.addMessageFlags(ctx, tx, messageID, imap.FlagSeen); err != nil {
 			return err
 		}
-	} else if !seen && curFlags[messageID].ContainsUnchecked(imap.FlagSeenLowerCase) {
+	} else if !seen && flagSet.ContainsUnchecked(imap.FlagSeenLowerCase) {
 		if err := user.removeMessageFlags(ctx, tx, messageID, imap.FlagSeen); err != nil {
 			return err
 		}
 	}
 
-	if flagged && !curFlags[messageID].ContainsUnchecked(imap.FlagFlaggedLowerCase) {
+	if flagged && !flagSet.ContainsUnchecked(imap.FlagFlaggedLowerCase) {
 		if err := user.addMessageFlags(ctx, tx, messageID, imap.FlagFlagged); err != nil {
 			return err
 		}
-	} else if !flagged && curFlags[messageID].ContainsUnchecked(imap.FlagFlaggedLowerCase) {
+	} else if !flagged && flagSet.ContainsUnchecked(imap.FlagFlaggedLowerCase) {
 		if err := user.removeMessageFlags(ctx, tx, messageID, imap.FlagFlagged); err != nil {
 			return err
 		}


### PR DESCRIPTION
Cost of retrieving deleted messages and filtering them and then updating the ones that were not set was about the same as just setting the value for every message in the list.

Return the flags as an array as there's no need to perform mapping operations.