### PR TITLE
refactor(GODT-1570): Track expunge status on sanpshot messages

### DIFF
--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -98,6 +98,8 @@ func (snap *snapshot) setMessageFlags(messageID imap.InternalMessageID, flags im
 		flags = flags.Add(imap.FlagRecent)
 	}
 
+	msg.toExpunge = flags.ContainsUnchecked(imap.FlagDeletedLowerCase)
+
 	msg.flags = flags
 
 	return nil
@@ -121,6 +123,18 @@ func (snap *snapshot) getAllMessageIDs() []ids.MessageIDPair {
 	return xslices.Map(snap.messages.all(), func(msg *snapMsg) ids.MessageIDPair {
 		return msg.ID
 	})
+}
+
+func (snap *snapshot) getAllMessagesIDsMarkedDelete() []ids.MessageIDPair {
+	var msgs []ids.MessageIDPair
+
+	for _, v := range snap.messages.all() {
+		if v.toExpunge {
+			msgs = append(msgs, v.ID)
+		}
+	}
+
+	return msgs
 }
 
 func (snap *snapshot) getMessagesInRange(ctx context.Context, seq *proto.SequenceSet) ([]snapMsgWithSeq, error) {

--- a/internal/state/snapshot_messages.go
+++ b/internal/state/snapshot_messages.go
@@ -8,9 +8,10 @@ import (
 
 // snapMsg is a single message inside a snapshot.
 type snapMsg struct {
-	ID    ids.MessageIDPair
-	UID   imap.UID
-	flags imap.FlagSet
+	ID        ids.MessageIDPair
+	UID       imap.UID
+	flags     imap.FlagSet
+	toExpunge bool
 }
 
 type snapMsgWithSeq struct {
@@ -27,7 +28,7 @@ type snapMsgList struct {
 func newMsgList(capacity int) *snapMsgList {
 	return &snapMsgList{
 		msg: make([]*snapMsg, 0, capacity),
-		idx: make(map[imap.InternalMessageID]*snapMsg),
+		idx: make(map[imap.InternalMessageID]*snapMsg, capacity),
 	}
 }
 
@@ -47,9 +48,10 @@ func (list *snapMsgList) insert(msgID ids.MessageIDPair, msgUID imap.UID, flags 
 	}
 
 	snapMsg := &snapMsg{
-		ID:    msgID,
-		UID:   msgUID,
-		flags: flags,
+		ID:        msgID,
+		UID:       msgUID,
+		flags:     flags,
+		toExpunge: flags.ContainsUnchecked(imap.FlagDeletedLowerCase),
 	}
 
 	list.msg = append(list.msg, snapMsg)


### PR DESCRIPTION
Speed up collection of all messages that need to be expunged by tracking this in their state rather than checking the flags.