### PR TITLE
fix: Don't close connector

### DIFF
--- a/benchmarks/gluon_bench/utils/connector_factory.go
+++ b/benchmarks/gluon_bench/utils/connector_factory.go
@@ -13,6 +13,7 @@ import (
 type ConnectorImpl interface {
 	Connector() connector.Connector
 	Sync(ctx context.Context) error
+	Close()
 }
 
 type ConnectorBuilder interface {
@@ -72,6 +73,10 @@ func (d *DummyConnectorImpl) Sync(ctx context.Context) error {
 	d.dummy.ClearUpdates()
 
 	return d.dummy.Sync(ctx)
+}
+
+func (d *DummyConnectorImpl) Close() {
+	d.dummy.Close()
 }
 
 func (*DummyConnectorBuilder) New() (ConnectorImpl, error) {

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -54,7 +54,4 @@ type Connector interface {
 
 	// SetUIDValidity sets the default UID validity for this user.
 	SetUIDValidity(uidValidity imap.UID) error
-
-	// Close the connector will no longer be used and all resources should be closed/released.
-	Close(ctx context.Context) error
 }

--- a/connector/dummy.go
+++ b/connector/dummy.go
@@ -281,12 +281,10 @@ func (conn *Dummy) Sync(ctx context.Context) error {
 	return nil
 }
 
-func (conn *Dummy) Close(ctx context.Context) error {
+func (conn *Dummy) Close() {
 	close(conn.updateQuitCh)
 	close(conn.updateCh)
 	conn.ticker.Stop()
-
-	return nil
 }
 
 func (conn *Dummy) GetLastRecordedIMAPID() imap.IMAPID {

--- a/internal/backend/user.go
+++ b/internal/backend/user.go
@@ -128,10 +128,6 @@ func (user *user) close(ctx context.Context) error {
 		return err
 	}
 
-	if err := user.connector.Close(ctx); err != nil {
-		return err
-	}
-
 	user.closeStates()
 
 	// Ensure we wait until all states have been removed/closed by any active sessions otherwise we run  into issues

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -166,6 +166,7 @@ func runServer(tb testing.TB, options *serverOptions, tests func(session *testSe
 			defaultPermanentFlags,
 			defaultAttributes,
 		)
+		defer conn.Close()
 
 		// Force USER ID to be consistent.
 		userID := hex.EncodeToString(hash.SHA256([]byte(creds.usernames[0])))


### PR DESCRIPTION
This change stops the gluon backend from closing its connectors. It shouldn't be gluon's responsibility to close the connectors; rather, they should be closed by the surrounding parent code that passes them in to gluon. This enables, for example, a single connector to survive across gluon restarts.