### PR TITLE
fix: Revert "mailbox name matching and Noselect estimation."

### DIFF
--- a/internal/state/match.go
+++ b/internal/state/match.go
@@ -21,18 +21,17 @@ type Match struct {
 func getMatches(
 	ctx context.Context,
 	client *ent.Client,
-	allMailboxes []*ent.Mailbox,
+	mailboxes []*ent.Mailbox,
 	ref, pattern, delimiter string,
 	subscribed bool,
 ) (map[string]Match, error) {
 	matches := make(map[string]Match)
 
-	mailboxes := make(map[string]*ent.Mailbox)
-	for _, mbox := range allMailboxes {
-		mailboxes[mbox.Name] = mbox
-	}
+	for _, mailbox := range mailboxes {
+		if subscribed && !mailbox.Subscribed {
+			continue
+		}
 
-	for mboxName := range mailboxes {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -40,84 +39,39 @@ func getMatches(
 		default: // fallthrough
 		}
 
-		for _, superior := range append(listSuperiors(mboxName, delimiter), mboxName) {
-			matchedName, isMatched := match(ref, pattern, delimiter, superior)
-			if !isMatched {
-				continue
-			}
+		if name, ok := match(ref, pattern, delimiter, mailbox.Name); ok {
+			if mailbox.Name == name {
+				atts := imap.NewFlagSetFromSlice(xslices.Map(mailbox.Edges.Attributes, func(flag *ent.MailboxAttr) string {
+					return flag.Value
+				}))
 
-			if _, alreadyMatched := matches[matchedName]; alreadyMatched {
-				continue
-			}
+				recent, err := db.GetMailboxRecentCount(ctx, client, mailbox)
+				if err != nil {
+					return nil, err
+				}
 
-			mbox, mailboxExists := mailboxes[matchedName]
+				if recent > 0 {
+					atts.AddToSelf(imap.AttrMarked)
+				} else {
+					atts.AddToSelf(imap.AttrUnmarked)
+				}
 
-			match, isMatch, err := prepareMatch(
-				ctx, client, matchedName, mbox,
-				pattern, delimiter,
-				mboxName == matchedName, mailboxExists, subscribed,
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			if isMatch {
-				matches[match.Name] = match
+				matches[mailbox.Name] = Match{
+					Name:      mailbox.Name,
+					Delimiter: delimiter,
+					Atts:      atts,
+				}
+			} else {
+				matches[name] = Match{
+					Name:      name,
+					Delimiter: delimiter,
+					Atts:      imap.NewFlagSet(imap.AttrNoSelect),
+				}
 			}
 		}
 	}
 
 	return matches, nil
-}
-
-func prepareMatch(
-	ctx context.Context,
-	client *ent.Client,
-	matchedName string,
-	mbox *ent.Mailbox,
-	pattern, delimiter string,
-	isNotSuperior, mailboxExists, onlySubscribed bool,
-) (Match, bool, error) {
-	// not match when:
-	if onlySubscribed && !mbox.Subscribed && // should be subscribed and it's not
-		(isNotSuperior || !strings.HasSuffix(pattern, "%")) { // is not superior or percent wildcard not used
-		return Match{}, false, nil
-	}
-
-	// add match as NoSelect when:
-	if !mailboxExists || // is deleted superior
-		matchedName == "" || // is empty request for delimiter response
-		onlySubscribed && !mbox.Subscribed { // is unsubscribed superior
-		return Match{
-			Name:      matchedName,
-			Delimiter: delimiter,
-			Atts:      imap.NewFlagSet(imap.AttrNoSelect),
-		}, true, nil
-	}
-
-	atts := imap.NewFlagSetFromSlice(xslices.Map(
-		mbox.Edges.Attributes,
-		func(flag *ent.MailboxAttr) string {
-			return flag.Value
-		},
-	))
-
-	recent, err := db.GetMailboxRecentCount(ctx, client, mbox)
-	if err != nil {
-		return Match{}, false, err
-	}
-
-	if recent > 0 {
-		atts.AddToSelf(imap.AttrMarked)
-	} else {
-		atts.AddToSelf(imap.AttrUnmarked)
-	}
-
-	return Match{
-		Name:      mbox.Name,
-		Delimiter: delimiter,
-		Atts:      atts,
-	}, true, nil
 }
 
 // GOMSRV-100: validate this implementation.

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -14,80 +14,40 @@ func TestDelete(t *testing.T) {
 		require.NoError(t, client.Create("blurdybloop"))
 		require.NoError(t, client.Create("foo"))
 		require.NoError(t, client.Create("foo.bar"))
-
-		checkMailboxesMatchNamesAndAttributes(
-			t, client, "", "*",
-			map[string][]string{
-				"INBOX":       {goimap.UnmarkedAttr},
-				"blurdybloop": {goimap.UnmarkedAttr},
-				"foo":         {goimap.UnmarkedAttr},
-				"foo.bar":     {goimap.UnmarkedAttr},
-			},
-		)
-
+		{
+			expectedMailboxNames := []string{
+				"INBOX",
+				"blurdybloop",
+				"foo",
+				"foo.bar",
+			}
+			expectedAttributes := []string{goimap.UnmarkedAttr}
+			checkMailboxesMatchNamesAndAttributes(t, client, "", "*", expectedMailboxNames, expectedAttributes)
+		}
 		require.NoError(t, client.Delete("blurdybloop"))
 		require.NoError(t, client.Delete("foo"))
-
-		checkMailboxesMatchNamesAndAttributes(
-			t, client, "", "*",
-			map[string][]string{
-				"INBOX":   {goimap.UnmarkedAttr},
-				"foo":     {goimap.NoSelectAttr},
-				"foo.bar": {goimap.UnmarkedAttr},
-			},
-		)
-
-		checkMailboxesMatchNamesAndAttributes(
-			t, client, "", "%",
-			map[string][]string{
-				"INBOX": {goimap.UnmarkedAttr},
-				"foo":   {goimap.NoSelectAttr},
-			},
-		)
-
+		{
+			expectedMailboxNames := []string{
+				"INBOX",
+				"foo.bar",
+			}
+			expectedAttributes := []string{goimap.UnmarkedAttr}
+			checkMailboxesMatchNamesAndAttributes(t, client, "", "*", expectedMailboxNames, expectedAttributes)
+		}
+		{
+			mailboxes := listMailboxesClient(t, client, "", "%")
+			for _, mailbox := range mailboxes {
+				if mailbox.Name == "INBOX" {
+					require.ElementsMatch(t, mailbox.Attributes, []string{goimap.UnmarkedAttr})
+				} else if mailbox.Name == "foo" {
+					require.ElementsMatch(t, mailbox.Attributes, []string{goimap.NoSelectAttr})
+				} else {
+					require.Fail(t, "Unexpected mailbox name")
+				}
+			}
+		}
 		// deleting mailboxes with \Noselect Attribute is an error
 		require.Error(t, client.Delete("foo"))
-	})
-}
-
-func TestDeleteMailboxHasChildren(t *testing.T) {
-	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
-		c.C(`A001 CREATE "blurdybloop"`).OK(`A001`)
-		c.C(`A002 CREATE "foo"`).OK(`A002`)
-		c.C(`A003 CREATE "foo/bar"`).OK(`A003`)
-
-		c.doAppend(`foo`, `To: 1@pm.me`).expect("OK")
-		c.doAppend(`foo/bar`, `To: 2@pm.me`).expect("OK")
-
-		c.C(`A004 SELECT "INBOX"`).OK(`A004`)
-		c.C(`A005 LIST "" *`)
-		c.S(
-			`* LIST (\Unmarked) "/" "INBOX"`,
-			`* LIST (\Unmarked) "/" "blurdybloop"`,
-			`* LIST (\Marked) "/" "foo"`,
-			`* LIST (\Marked) "/" "foo/bar"`,
-		)
-		c.OK(`A005`)
-
-		c.C(`A006 STATUS "foo/bar" (UIDNEXT MESSAGES)`)
-		c.S(`* STATUS "foo/bar" (UIDNEXT 2 MESSAGES 1)`)
-		c.OK(`A006`)
-
-		c.C(`A007 DELETE "foo"`).OK(`A007`)
-
-		c.C(`A008 STATUS "foo/bar" (UIDNEXT MESSAGES)`)
-		c.S(`* STATUS "foo/bar" (UIDNEXT 2 MESSAGES 1)`)
-		c.OK(`A008`)
-
-		c.C(`A009 LIST "" *`)
-		c.S(
-			`* LIST (\Unmarked) "/" "INBOX"`,
-			`* LIST (\Unmarked) "/" "blurdybloop"`,
-			`* LIST (\Noselect) "/" "foo"`,
-			`* LIST (\Marked) "/" "foo/bar"`,
-		)
-		c.OK(`A009`)
-
 	})
 }
 
@@ -103,7 +63,7 @@ func TestDeleteCannotDeleteMissingMailbox(t *testing.T) {
 	})
 }
 
-func TestDeleteSelectedMailboxCausesDisconnect(t *testing.T) {
+func TestDeleteMailboxCausesDisconnect(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
 		c.C("b001 CREATE mbox1")
 		c.S("b001 OK CREATE")
@@ -114,18 +74,7 @@ func TestDeleteSelectedMailboxCausesDisconnect(t *testing.T) {
 	})
 }
 
-func TestDeleteExaminedMailboxCausesDisconnect(t *testing.T) {
-	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
-		c.C("b001 CREATE mbox1")
-		c.S("b001 OK CREATE")
-
-		c.C("b002 EXAMINE mbox1").OK("b002")
-		c.C("b003 DELETE mbox1").OK("b003")
-		c.S(response.Bye().WithMailboxDeleted().String())
-	})
-}
-
-func TestDeleteSelectedMailboxCausesDisconnectOnOtherClients(t *testing.T) {
+func TestDeleteMailboxCausesDisconnectOnOtherClients(t *testing.T) {
 	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		c[1].C("b001 CREATE mbox1")
 		c[1].S("b001 OK CREATE")
@@ -136,26 +85,6 @@ func TestDeleteSelectedMailboxCausesDisconnectOnOtherClients(t *testing.T) {
 
 		// Delete mailbox
 		c[1].C("b002 SELECT mbox1").OK("b002")
-		c[1].C("b003 DELETE mbox1").OK("b003")
-		c[1].S(response.Bye().WithMailboxDeleted().String())
-
-		// Other client should get kicked out on next command
-		c[2].C("c002 NOOP")
-		c[2].S(response.Bye().WithInconsistentState().String())
-	})
-}
-
-func TestDeleteExaminedMailboxCausesDisconnectOnOtherClients(t *testing.T) {
-	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
-		c[1].C("b001 CREATE mbox1")
-		c[1].S("b001 OK CREATE")
-
-		s.flush("user")
-
-		c[2].C("c001 EXAMINE mbox1").OK("c001")
-
-		// Delete mailbox
-		c[1].C("b002 EXAMINE mbox1").OK("b002")
 		c[1].C("b003 DELETE mbox1").OK("b003")
 		c[1].S(response.Bye().WithMailboxDeleted().String())
 

--- a/tests/full_state_test.go
+++ b/tests/full_state_test.go
@@ -33,16 +33,15 @@ func TestSimpleMailCopy(t *testing.T) {
 
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
 		require.NoError(t, client.Create("Archive"))
-
 		// list mailbox
-		checkMailboxesMatchNamesAndAttributes(
-			t, client, "", "*",
-			map[string][]string{
-				"INBOX":     {goimap.UnmarkedAttr},
-				mailboxName: {goimap.UnmarkedAttr},
-			},
-		)
-
+		{
+			expectedMailboxNames := []string{
+				"INBOX",
+				mailboxName,
+			}
+			expectedAttributes := []string{goimap.UnmarkedAttr}
+			checkMailboxesMatchNamesAndAttributes(t, client, "", "*", expectedMailboxNames, expectedAttributes)
+		}
 		// select Archive
 		status, err := client.Select(mailboxName, false)
 		require.NoError(t, err)
@@ -89,13 +88,13 @@ func TestReceptionOnIdle(t *testing.T) {
 
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(c *client.Client, sess *testSession) {
 		// list mailbox
-		checkMailboxesMatchNamesAndAttributes(
-			t, c, "", "*",
-			map[string][]string{
-				mailboxName: {goimap.UnmarkedAttr},
-			},
-		)
-
+		{
+			expectedMailboxNames := []string{
+				mailboxName,
+			}
+			expectedAttributes := []string{goimap.UnmarkedAttr}
+			checkMailboxesMatchNamesAndAttributes(t, c, "", "*", expectedMailboxNames, expectedAttributes)
+		}
 		status, err := c.Select(mailboxName, false)
 		require.NoError(t, err)
 		require.Equal(t, uint32(0), status.Messages, "Expected message count does not match")
@@ -187,16 +186,16 @@ func TestMorningFiltering(t *testing.T) {
 		require.NoError(t, client.Create("Archive"))
 
 		// list mailbox
-		checkMailboxesMatchNamesAndAttributes(
-			t, client, "", "*",
-			map[string][]string{
-				"INBOX":     {goimap.UnmarkedAttr},
-				"Archive":   {goimap.UnmarkedAttr},
-				"ReadLater": {goimap.UnmarkedAttr},
-				mbox:        {goimap.UnmarkedAttr},
-			},
-		)
-
+		{
+			expectedMailboxNames := []string{
+				"ReadLater",
+				"Archive",
+				"INBOX",
+				mbox,
+			}
+			expectedAttributes := []string{goimap.UnmarkedAttr}
+			checkMailboxesMatchNamesAndAttributes(t, client, "", "*", expectedMailboxNames, expectedAttributes)
+		}
 		{
 			// There are 100 messages in the origin and no messages in the destination.
 			mailboxStatus, err := client.Status(mbox, []goimap.StatusItem{goimap.StatusMessages})

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -81,22 +81,17 @@ func listMailboxesClient(t testing.TB, client *client.Client, reference string, 
 	return iterator.Collect(iterator.Chan(mailboxesChannel))
 }
 
-func checkMailboxesMatchNamesAndAttributes(t *testing.T, client *client.Client, reference string, expression string, expectedNamesAndAttributes map[string][]string) {
-	haveNames := []string{}
-	for _, mbox := range listMailboxesClient(t, client, reference, expression) {
-		haveNames = append(haveNames, mbox.Name)
+func checkMailboxesMatchNamesAndAttributes(t *testing.T, client *client.Client, reference string, expression string, expectedNames []string, expectedAttributes []string) {
+	mailboxes := listMailboxesClient(t, client, "", "*")
 
-		wantAttributes, ok := expectedNamesAndAttributes[mbox.Name]
-		require.True(t, ok, "not expected to have mailbox %q", mbox.Name)
-		require.ElementsMatch(t, wantAttributes, mbox.Attributes, "for mailbox %q", mbox.Name)
+	var actualMailboxNames []string
+
+	for _, mailbox := range mailboxes {
+		actualMailboxNames = append(actualMailboxNames, mailbox.Name)
+		require.ElementsMatch(t, mailbox.Attributes, expectedAttributes)
 	}
 
-	wantNames := []string{}
-	for name := range expectedNamesAndAttributes {
-		wantNames = append(wantNames, name)
-	}
-
-	require.ElementsMatch(t, haveNames, wantNames)
+	require.ElementsMatch(t, actualMailboxNames, expectedNames)
 }
 
 func getMailboxNamesClient(t testing.TB, client *client.Client, reference string, expression string) []string {

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -25,7 +25,6 @@ func TestList(t *testing.T) {
 		c.C("A005 DELETE ~/Mail/foo")
 		c.OK("A005")
 
-		// Test
 		c.C(`A101 LIST "" ""`)
 		c.S(`* LIST (\Noselect) "/" ""`)
 		c.OK("A101")
@@ -39,8 +38,7 @@ func TestList(t *testing.T) {
 		c.OK("A103")
 
 		c.C(`A202 LIST ~/Mail/ %`)
-		c.S(
-			`* LIST (\Noselect) "/" "~/Mail/foo"`,
+		c.S(`* LIST (\Noselect) "/" "~/Mail/foo"`,
 			`* LIST (\Unmarked) "/" "~/Mail/meetings"`)
 		c.OK("A202")
 	})
@@ -72,6 +70,9 @@ func TestListFlagsAndAttributes(t *testing.T) {
 
 func TestListRef(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, s *testSession) {
+		c.C(`tag create some`).OK(`tag`)
+		c.C(`tag create some.thing`).OK(`tag`)
+		c.C(`tag create some.thing.else`).OK(`tag`)
 		c.C(`tag create some.thing.else.entirely`).OK(`tag`)
 
 		// No ref - names interpreted like SELECT
@@ -155,8 +156,9 @@ func TestListRemoved(t *testing.T) {
 		c.C(`tag delete blurdybloop`).OK(`tag`)
 		c.C(`tag delete foo`).OK(`tag`)
 
+		// TODO(GODT-1612): Should also return foo here!
 		c.C(`tag list "" "*"`).S(
-			`* LIST (\Noselect) "." "foo"`,
+			// `* LIST (\Noselect) "." "foo"`,
 			`* LIST (\Unmarked) "." "foo.bar"`,
 			`* LIST (\Unmarked) "." "INBOX"`,
 		).OK(`tag`)
@@ -168,50 +170,17 @@ func TestListRemoved(t *testing.T) {
 	})
 }
 
-func TestListWildcards(t *testing.T) {
+func TestListPercent(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, s *testSession) {
+		c.C(`tag create some`).OK(`tag`)
+		c.C(`tag create some.thing`).OK(`tag`)
+		c.C(`tag create some.thing.else`).OK(`tag`)
 		c.C(`tag create some.thing.else.entirely`).OK(`tag`)
-		c.C(`tag delete some`).OK(`tag`)
 
-		c.C(`tag list "" "*"`)
-		c.S(
+		// TODO(GODT-1612): "some" should be selectable!
+		c.C(`tag list "" "%"`).S(
 			`* LIST (\Unmarked) "." "INBOX"`,
 			`* LIST (\Noselect) "." "some"`,
-			`* LIST (\Unmarked) "." "some.thing"`,
-			`* LIST (\Unmarked) "." "some.thing.else"`,
-			`* LIST (\Unmarked) "." "some.thing.else.entirely"`,
-		)
-		c.OK(`tag`)
-
-		c.C(`tag list "" "%"`)
-		c.S(
-			`* LIST (\Unmarked) "." "INBOX"`,
-			`* LIST (\Noselect) "." "some"`,
-		)
-		c.OK(`tag`)
-
-		c.C(`tag list "some.thing" "*"`)
-		c.S(
-			`* LIST (\Unmarked) "." "some.thing"`,
-			`* LIST (\Unmarked) "." "some.thing.else"`,
-			`* LIST (\Unmarked) "." "some.thing.else.entirely"`,
-		)
-		c.OK(`tag`)
-
-		c.C(`tag list "some.thing" "%"`)
-		c.S(`* LIST (\Unmarked) "." "some.thing"`)
-		c.OK(`tag`)
-
-		c.C(`tag list "some.thing." "*"`)
-		c.S(
-			`* LIST (\Unmarked) "." "some.thing.else"`,
-			`* LIST (\Unmarked) "." "some.thing.else.entirely"`,
-		)
-		c.OK(`tag`)
-
-		c.C(`tag list "some.thing." "%"`)
-		c.S(`* LIST (\Unmarked) "." "some.thing.else"`)
-		c.OK(`tag`)
-
+		).OK(`tag`)
 	})
 }

--- a/tests/lsub_test.go
+++ b/tests/lsub_test.go
@@ -6,93 +6,38 @@ import (
 
 func TestLsub(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
-		c.C("tag CREATE foo.bar").OK(`tag`)
-		c.C(`tag UNSUBSCRIBE foo`).OK(`tag`)
+		c.C("B002 CREATE #news.comp.mail.mime")
+		c.OK("B002")
 
-		c.C(`S001 LSUB "" "*"`)
-		c.S(
-			`* LSUB (\Unmarked) "." "INBOX"`,
-			`* LSUB (\Unmarked) "." "foo.bar"`,
-		)
-		c.S("S001 OK LSUB")
+		c.C(`A003 UNSUBSCRIBE "#news.comp.mail.mime"`)
+		c.OK("A003")
 
-		c.C(`P001 LSUB "" "%"`)
-		c.S(
-			`* LSUB (\Unmarked) "." "INBOX"`,
-			`* LSUB (\Noselect) "." "foo"`,
-		)
-		c.S("P001 OK LSUB")
+		c.C("B003 CREATE #news.comp.mail.misc")
+		c.OK("B003")
 
-		c.C("tag CREATE #news.comp.mail.mime").OK("tag")
+		c.C(`A003 UNSUBSCRIBE "#news.comp.mail.misc"`)
+		c.OK("A003")
 
-		c.C(`tag UNSUBSCRIBE "#news.comp.mail.mime"`).OK("tag")
+		c.C(`A002 LSUB "#news." "comp.mail.*"`)
+		c.OK("A002")
 
-		c.C("tag CREATE #news.comp.mail.misc").OK("tag")
+		c.C(`A003 SUBSCRIBE "#news.comp.mail.mime"`)
+		c.OK("A003")
 
-		c.C(`tag UNSUBSCRIBE "#news.comp.mail.misc"`).OK("tag")
-
-		c.C(`S002 LSUB "#news." "comp.mail.*"`)
-		c.S("S002 OK LSUB")
-
-		c.C(`P002 LSUB "#news." "comp.mail.%"`)
-		c.S("P002 OK LSUB")
-
-		c.C(`tag SUBSCRIBE "#news.comp.mail.mime"`).OK("tag")
-
-		c.C(`S003 LSUB "#news." "comp.mail.*"`)
+		c.C(`A004 LSUB "#news." "comp.mail.*"`)
 		c.S(`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`)
-		c.S("S003 OK LSUB")
+		c.OK("A004")
 
-		c.C(`P003 LSUB "#news." "comp.mail.%"`)
-		c.S(`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`)
-		c.S("P003 OK LSUB")
+		c.C(`A005 SUBSCRIBE "#news.comp.mail.misc"`)
+		c.OK("A005")
 
-		c.C(`tag SUBSCRIBE "#news.comp.mail.misc"`).OK("tag")
+		c.C(`A006 LSUB "#news." "comp.mail.*"`)
+		c.S(`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`,
+			`* LSUB (\Unmarked) "." "#news.comp.mail.misc"`)
+		c.OK(`A006`)
 
-		c.C(`S004 LSUB "#news." "comp.mail.*"`)
-		c.S(
-			`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`,
-			`* LSUB (\Unmarked) "." "#news.comp.mail.misc"`,
-		)
-		c.OK(`S004`)
-
-		c.C(`P004 LSUB "#news." "comp.mail.%"`)
-		c.S(
-			`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`,
-			`* LSUB (\Unmarked) "." "#news.comp.mail.misc"`,
-		)
-		c.OK(`P004`)
-
-		c.C(`S005 LSUB "#news." "comp.*"`)
-		c.S(
-			`* LSUB (\Unmarked) "." "#news.comp.mail"`,
-			`* LSUB (\Unmarked) "." "#news.comp.mail.mime"`,
-			`* LSUB (\Unmarked) "." "#news.comp.mail.misc"`,
-		)
-		c.OK(`S005`)
-
-		c.C(`P005 LSUB "#news." "comp.%"`)
-		c.S(`* LSUB (\Unmarked) "." "#news.comp.mail"`)
-		c.OK(`P005`)
-	})
-}
-
-func TestLsubSubscribedNotExisting(t *testing.T) {
-	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, _ *testSession) {
-		c.C("tag CREATE foo").OK(`tag`)
-
-		c.C(`A001 LSUB "" "foo"`)
-		c.S(`* LSUB (\Unmarked) "." "foo"`)
-		c.OK(`A001`)
-
-		c.C(`tag DELETE foo`).OK(`tag`)
-
-		c.C(`A002 LSUB "" "foo"`)
-		// TODO GODT-1896: The server MUST NOT unilaterally remove an existing mailbox name
-		// from the subscription list even if a mailbox by that name no
-		// longer exists.
-		//
-		// c.S(`* LSUB (\Noselect) "." "foo"`)
-		c.OK(`A002`)
+		c.C(`A007 LSUB "#news." "comp.%"`)
+		c.S(`* LSUB (\Noselect) "." "#news.comp.mail"`)
+		c.OK(`A007`)
 	})
 }


### PR DESCRIPTION
This reverts commit 0a92d3383db708348ed3fd07765e1bcd8b05c9a8.