### PR TITLE
fix: User "Folder/" prefix for bench mailboxes

### DIFF
--- a/benchmarks/gluon_bench/imap_benchmarks/state_tracker.go
+++ b/benchmarks/gluon_bench/imap_benchmarks/state_tracker.go
@@ -16,7 +16,7 @@ func newStateTracker() *stateTracker {
 }
 
 func (s *stateTracker) createRandomMBox(cl *client.Client) (string, error) {
-	mbox := uuid.NewString()
+	mbox := "Folders/" + uuid.NewString()
 
 	if err := cl.Create(mbox); err != nil {
 		return "", err


### PR DESCRIPTION
Ensure they work with the proton connector.