### PR TITLE
fix(GODT-1650): Handle existing remote ID returned after CreateMessage

### DIFF
--- a/tests/append_test.go
+++ b/tests/append_test.go
@@ -2,7 +2,11 @@ package tests
 
 import (
 	"bytes"
+	"context"
+	"github.com/ProtonMail/gluon/connector"
+	"github.com/ProtonMail/gluon/imap"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -172,5 +176,88 @@ func TestAppendHeaderWithSpaceLine(t *testing.T) {
 					r.Equal(wantHeader, haveHeader)
 				})
 			}).check()
+	})
+}
+
+type returnSameRemoteIDConnector struct {
+	*connector.Dummy
+	lock           sync.Mutex
+	messageCreated bool
+	createdMessage imap.Message
+	messageLiteral []byte
+}
+
+func (r *returnSameRemoteIDConnector) CreateMessage(ctx context.Context, mboxID imap.LabelID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if !r.messageCreated {
+		msg, l, err := r.Dummy.CreateMessage(ctx, mboxID, literal, flags, date)
+		if err != nil {
+			return imap.Message{}, nil, err
+		}
+
+		r.createdMessage = msg
+		r.messageLiteral = l
+		r.messageCreated = true
+	}
+
+	return r.createdMessage, r.messageLiteral, nil
+}
+
+type returnSameRemoteIDConnectorBuilder struct{}
+
+func (returnSameRemoteIDConnectorBuilder) New(usernames []string, password []byte, period time.Duration, flags, permFlags, attrs imap.FlagSet) Connector {
+	return &returnSameRemoteIDConnector{
+		Dummy: connector.NewDummy(usernames, password, period, flags, permFlags, attrs),
+	}
+}
+
+func TestAppendConnectorReturnsSameRemoteIDSameMBox(t *testing.T) {
+	const (
+		mailboxName = "INBOX"
+		messagePath = "testdata/afternoon-meeting.eml"
+	)
+
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&returnSameRemoteIDConnectorBuilder{})), func(client *client.Client, _ *testSession) {
+		{
+			require.NoError(t, doAppendWithClientFromFile(t, client, mailboxName, messagePath, time.Now(), goimap.SeenFlag))
+			require.NoError(t, doAppendWithClientFromFile(t, client, mailboxName, messagePath, time.Now(), goimap.SeenFlag))
+			require.NoError(t, doAppendWithClientFromFile(t, client, mailboxName, messagePath, time.Now(), goimap.SeenFlag))
+		}
+		{
+			// second check, there should be  1 message
+			status, err := client.Status(mailboxName, []goimap.StatusItem{goimap.StatusMessages})
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), status.Messages, "Expected message count does not match")
+		}
+	})
+}
+
+func TestAppendConnectorReturnsSameRemoteIDDifferentMBox(t *testing.T) {
+	const (
+		mailboxName      = "INBOX"
+		mailboxNameOther = "saved-messages"
+		messagePath      = "testdata/afternoon-meeting.eml"
+	)
+
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&returnSameRemoteIDConnectorBuilder{})), func(client *client.Client, _ *testSession) {
+		require.NoError(t, client.Create(mailboxNameOther))
+		{
+			require.NoError(t, doAppendWithClientFromFile(t, client, mailboxName, messagePath, time.Now(), goimap.SeenFlag))
+			require.NoError(t, doAppendWithClientFromFile(t, client, mailboxNameOther, messagePath, time.Now(), goimap.SeenFlag))
+		}
+		{
+			// there should be  1 message in mailboxName
+			status, err := client.Status(mailboxName, []goimap.StatusItem{goimap.StatusMessages})
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), status.Messages, "Expected message count does not match")
+		}
+		{
+			// there should be 1 message in mailboxNameOther
+			status, err := client.Status(mailboxNameOther, []goimap.StatusItem{goimap.StatusMessages})
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), status.Messages, "Expected message count does not match")
+		}
 	})
 }


### PR DESCRIPTION
It is possible that some connector implementation will return the same RemoteID for a message if they perform some header analysis.

In that case we check if the message already exist and if so add it to the destination mailbox.