### PR TITLE
feat: Expose ParseMediaType

### DIFF
--- a/imap/structure.go
+++ b/imap/structure.go
@@ -2,7 +2,6 @@ package imap
 
 import (
 	"bytes"
-	"mime"
 	"strings"
 
 	"github.com/ProtonMail/gluon/rfc822"
@@ -147,7 +146,7 @@ func getMIMEInfo(section *rfc822.Section) (string, string, map[string]string, er
 }
 
 func addDispInfo(c *paramList, writer parListWriter, header *rfc822.Header) {
-	if contentDisp, contentDispParams, err := mime.ParseMediaType(header.Get("Content-Disposition")); err == nil {
+	if contentDisp, contentDispParams, err := rfc822.ParseMediaType(header.Get("Content-Disposition")); err == nil {
 		writer.writeByte(' ')
 		fields := c.newChildList(writer)
 		fields.addString(writer, contentDisp).addMap(writer, contentDispParams)

--- a/rfc822/mime.go
+++ b/rfc822/mime.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// ParseMediaType parses a MIME media type.
+var ParseMediaType = mime.ParseMediaType
+
 type MIMEType string
 
 const (
@@ -40,7 +43,7 @@ func ParseMIMEType(val string) (MIMEType, map[string]string, error) {
 		val = string(TextPlain)
 	}
 
-	mimeType, mimeParams, err := mime.ParseMediaType(val)
+	mimeType, mimeParams, err := ParseMediaType(val)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
The standard library mime.ParseMediaType does not handle some edge cases. This commit exposes a package-level ParseMediaType function, allowing the standard library calls to be replaced with a custom function.