### PR TITLE
fix(GODT-1760): Fix out of order UID panics

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,7 +86,7 @@ jobs:
           skip-cache: true
 
       - name: Run tests
-        run: go test -v ./...
+        run: go test -timeout 15m -v ./...
 
       - name: Run tests with race check
         if: runner.os != 'Windows'

--- a/builder.go
+++ b/builder.go
@@ -28,6 +28,7 @@ type serverBuilder struct {
 	cmdExecProfBuilder profiling.CmdProfilerBuilder
 	storeBuilder       store.Builder
 	reporter           reporter.Reporter
+	disableParallelism bool
 }
 
 func newBuilder() (*serverBuilder, error) {
@@ -78,5 +79,6 @@ func (builder *serverBuilder) build() (*Server, error) {
 		cmdExecProfBuilder: builder.cmdExecProfBuilder,
 		versionInfo:        builder.versionInfo,
 		reporter:           builder.reporter,
+		disableParallelism: builder.disableParallelism,
 	}, nil
 }

--- a/internal/contexts/context.go
+++ b/internal/contexts/context.go
@@ -57,3 +57,19 @@ func IsRemoteUpdateCtx(ctx context.Context) bool {
 func NewRemoteUpdateCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, handleRemoteUpdateCtxKey, struct{}{})
 }
+
+type disableParallelismCtxType struct{}
+
+var disableParallelismCtxKey disableParallelismCtxType
+
+func IsParallelismDisabledCtx(ctx context.Context) bool {
+	return ctx.Value(disableParallelismCtxKey) != nil
+}
+
+func NewDisableParallelismCtx(ctx context.Context, disabled bool) context.Context {
+	if !disabled {
+		return ctx
+	}
+
+	return context.WithValue(ctx, disableParallelismCtxKey, struct{}{})
+}

--- a/internal/state/mailbox_fetch.go
+++ b/internal/state/mailbox_fetch.go
@@ -80,7 +80,7 @@ func (m *Mailbox) Fetch(ctx context.Context, seq *proto.SequenceSet, attributes 
 
 	// Only run in parallel if we have to fetch more than minCountForParallelism messages or if we have more than one
 	// message and we need to access the literal.
-	if len(snapMessages) > minCountForParallelism || (len(snapMessages) > 1 && needsLiteral) {
+	if !contexts.IsParallelismDisabledCtx(ctx) && (len(snapMessages) > minCountForParallelism || (len(snapMessages) > 1 && needsLiteral)) {
 		// If multiple fetch request are happening in parallel, reduce the number of goroutines in proportion to that
 		// to avoid overloading the user's machine.
 		parallelism = runtime.NumCPU() / int(activeFetchRequests)

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -386,6 +386,16 @@ func (snap *snapshot) appendMessage(messageID ids.MessageIDPair, uid imap.UID, f
 	return nil
 }
 
+func (snap *snapshot) appendMessageFromOtherState(messageID ids.MessageIDPair, uid imap.UID, flags imap.FlagSet) error {
+	snap.messages.insertOutOfOrder(
+		messageID,
+		uid,
+		flags,
+	)
+
+	return nil
+}
+
 func (snap *snapshot) expungeMessage(messageID imap.InternalMessageID) error {
 	if ok := snap.messages.remove(messageID); !ok {
 		return ErrNoSuchMessage

--- a/option.go
+++ b/option.go
@@ -167,3 +167,13 @@ func (w *withReporter) config(builder *serverBuilder) {
 func WithReporter(reporter reporter.Reporter) Option {
 	return &withReporter{reporter: reporter}
 }
+
+type withDisableParallelism struct{}
+
+func (withDisableParallelism) config(builder *serverBuilder) {
+	builder.disableParallelism = true
+}
+
+func WithDisableParallelism() Option {
+	return &withDisableParallelism{}
+}


### PR DESCRIPTION
Extendend snapshot with `appendMessageFromOtherState` to enable out of order UID insertion. Please check the comments in
`TestAppendCanHandleOutOfOrderUIDUpdates` for why this is necessary.