### PR TITLE
feat(GODT-1742): Add `IsMailboxVisible` to `Connector`

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -18,6 +18,9 @@ type Connector interface {
 	// CreateLabel creates a label with the given name.
 	CreateLabel(ctx context.Context, name []string) (imap.Mailbox, error)
 
+	// IsLabelVisible can be used to hide mailboxes from connected clients.
+	IsLabelVisible(ctx context.Context, labelID imap.LabelID) bool
+
 	// UpdateLabel sets the name of the label with the given ID.
 	UpdateLabel(ctx context.Context, labelID imap.LabelID, newName []string) error
 

--- a/internal/backend/state_connector_impl.go
+++ b/internal/backend/state_connector_impl.go
@@ -142,6 +142,10 @@ func (sc *stateConnectorImpl) SetUIDValidity(uidValidity imap.UID) error {
 	return sc.connector.SetUIDValidity(uidValidity)
 }
 
+func (sc *stateConnectorImpl) IsMailboxVisible(ctx context.Context, id imap.LabelID) bool {
+	return sc.connector.IsLabelVisible(ctx, id)
+}
+
 func (sc *stateConnectorImpl) getMetadataValue(key string) any {
 	v, ok := sc.metadata[key]
 	if !ok {

--- a/internal/state/connector.go
+++ b/internal/state/connector.go
@@ -71,4 +71,7 @@ type Connector interface {
 
 	// SetUIDValidity sets the UID Validity for the user.
 	SetUIDValidity(imap.UID) error
+
+	// IsMailboxVisible checks whether a mailbox is visible to a client.
+	IsMailboxVisible(ctx context.Context, id imap.LabelID) bool
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -79,6 +79,10 @@ func (state *State) List(ctx context.Context, ref, pattern string, subscribed bo
 			return err
 		}
 
+		mailboxes = xslices.Filter(mailboxes, func(mailbox *ent.Mailbox) bool {
+			return state.user.GetRemote().IsMailboxVisible(ctx, mailbox.RemoteID)
+		})
+
 		matches, err := getMatches(ctx, client, mailboxes, ref, pattern, state.delimiter, subscribed)
 		if err != nil {
 			return err

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -43,6 +43,8 @@ type Connector interface {
 	Flush()
 
 	GetLastRecordedIMAPID() imap.IMAPID
+
+	SetMailboxVisible(imap.LabelID, bool)
 }
 
 type testSession struct {


### PR DESCRIPTION
Allow connector implementations to hide mailboxes from clients if necessary.