### PR TITLE
test: Use a top-level test main for leak detection

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,14 +1,11 @@
 package tests
 
 import (
-	"os"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	os.Setenv("GLUON_TEST_HOST", "127.0.0.1:2143")
-	os.Setenv("GLUON_TEST_USER", "dummy@proton.ch")
-	os.Setenv("GLUON_TEST_PASS", "password")
-
-	os.Exit(m.Run())
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
 const defaultPeriod = time.Second
@@ -190,10 +189,10 @@ func defaultServerOptions(tb testing.TB, modifiers ...serverOption) *serverOptio
 // runServer initializes and starts the mailserver.
 func runServer(tb testing.TB, options *serverOptions, tests func(session *testSession)) {
 	loggerIn := logrus.StandardLogger().WriterLevel(logrus.TraceLevel)
-	loggerOut := logrus.StandardLogger().WriterLevel(logrus.TraceLevel)
+	defer loggerIn.Close()
 
-	// Setup goroutine leak detector here so that it doesn't report the goroutines created by logrus.
-	defer goleak.VerifyNone(tb, goleak.IgnoreCurrent())
+	loggerOut := logrus.StandardLogger().WriterLevel(logrus.TraceLevel)
+	defer loggerOut.Close()
 
 	// Log the (temporary?) directory to store gluon data.
 	logrus.Tracef("Gluon Data Dir: %v", options.dataDir)


### PR DESCRIPTION
By using a top-level test main, we can check for leaks that occur in the test fixture as well.

This commit also removes some old environment variables that are no longer used.