### PR TITLE
test: Remove extra INBOX creation call in test

### DIFF
--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -262,7 +262,6 @@ func TestListSpecialUseAttributes(t *testing.T) {
 
 func TestListNilDelimiter(t *testing.T) {
 	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter("")), func(c *testConnection, s *testSession) {
-		s.mailboxCreated("user", []string{"INBOX"})
 		s.mailboxCreated("user", []string{"Folders/Custom"})
 
 		c.C(`a list "" "*"`)


### PR DESCRIPTION
INBOX is created by default in the dummy connector, no need to create it again.