### PR TITLE
fix: Fix state connector deadlock

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -12,9 +12,6 @@ type Connector interface {
 	// Authorize returns whether the given username/password combination are valid for this connector.
 	Authorize(username string, password []byte) bool
 
-	// GetMailbox returns information about the mailbox with the given ID.
-	GetMailbox(ctx context.Context, mboxID imap.MailboxID) (imap.Mailbox, error)
-
 	// CreateMailbox creates a mailbox with the given name.
 	CreateMailbox(ctx context.Context, name []string) (imap.Mailbox, error)
 
@@ -26,9 +23,6 @@ type Connector interface {
 
 	// DeleteMailbox deletes the mailbox with the given ID.
 	DeleteMailbox(ctx context.Context, mboxID imap.MailboxID) error
-
-	// GetMessage returns the message with the given ID.
-	GetMessage(ctx context.Context, messageID imap.MessageID) (imap.Message, []imap.MailboxID, error)
 
 	// CreateMessage creates a new message on the remote.
 	CreateMessage(ctx context.Context, mboxID imap.MailboxID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error)

--- a/connector/dummy.go
+++ b/connector/dummy.go
@@ -99,10 +99,6 @@ func (conn *Dummy) GetUpdates() <-chan imap.Update {
 	return conn.updateCh
 }
 
-func (conn *Dummy) GetMailbox(ctx context.Context, mboxID imap.MailboxID) (imap.Mailbox, error) {
-	return conn.state.getMailbox(mboxID)
-}
-
 func (conn *Dummy) CreateMailbox(ctx context.Context, name []string) (imap.Mailbox, error) {
 	exclusive, err := conn.validateName(name)
 	if err != nil {
@@ -139,15 +135,6 @@ func (conn *Dummy) DeleteMailbox(ctx context.Context, mboxID imap.MailboxID) err
 	conn.pushUpdate(imap.NewMailboxDeleted(mboxID))
 
 	return nil
-}
-
-func (conn *Dummy) GetMessage(ctx context.Context, messageID imap.MessageID) (imap.Message, []imap.MailboxID, error) {
-	message, err := conn.state.getMessage(messageID)
-	if err != nil {
-		return imap.Message{}, nil, err
-	}
-
-	return message, conn.state.getMailboxIDs(messageID), nil
 }
 
 func (conn *Dummy) CreateMessage(ctx context.Context, mboxID imap.MailboxID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error) {

--- a/connector/mock_connector/connector.go
+++ b/connector/mock_connector/connector.go
@@ -123,37 +123,6 @@ func (mr *MockConnectorMockRecorder) DeleteMailbox(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMailbox", reflect.TypeOf((*MockConnector)(nil).DeleteMailbox), arg0, arg1)
 }
 
-// GetMailbox mocks base method.
-func (m *MockConnector) GetMailbox(arg0 context.Context, arg1 imap.MailboxID) (imap.Mailbox, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMailbox", arg0, arg1)
-	ret0, _ := ret[0].(imap.Mailbox)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMailbox indicates an expected call of GetMailbox.
-func (mr *MockConnectorMockRecorder) GetMailbox(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMailbox", reflect.TypeOf((*MockConnector)(nil).GetMailbox), arg0, arg1)
-}
-
-// GetMessage mocks base method.
-func (m *MockConnector) GetMessage(arg0 context.Context, arg1 imap.MessageID) (imap.Message, []imap.MailboxID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMessage", arg0, arg1)
-	ret0, _ := ret[0].(imap.Message)
-	ret1, _ := ret[1].([]imap.MailboxID)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetMessage indicates an expected call of GetMessage.
-func (mr *MockConnectorMockRecorder) GetMessage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessage", reflect.TypeOf((*MockConnector)(nil).GetMessage), arg0, arg1)
-}
-
 // GetUIDValidity mocks base method.
 func (m *MockConnector) GetUIDValidity() imap.UID {
 	m.ctrl.T.Helper()

--- a/internal/state/actions.go
+++ b/internal/state/actions.go
@@ -74,11 +74,10 @@ func (state *State) actionDeleteMailbox(ctx context.Context, tx *ent.Tx, mboxID 
 	return state.user.QueueOrApplyStateUpdate(ctx, tx, NewMailboxDeletedStateUpdate(mboxID.InternalID))
 }
 
-func (state *State) actionUpdateMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.MailboxID, oldName, newName string) error {
+func (state *State) actionUpdateMailbox(ctx context.Context, tx *ent.Tx, mboxID imap.MailboxID, newName string) error {
 	if err := state.user.GetRemote().UpdateMailbox(
 		ctx,
 		mboxID,
-		strings.Split(oldName, state.delimiter),
 		strings.Split(newName, state.delimiter),
 	); err != nil {
 		return err

--- a/internal/state/connector.go
+++ b/internal/state/connector.go
@@ -27,7 +27,7 @@ type Connector interface {
 	CreateMailbox(ctx context.Context, name []string) (imap.Mailbox, error)
 
 	// UpdateMailbox sets the name of the mailbox with the given ID to the given new name.
-	UpdateMailbox(ctx context.Context, mboxID imap.MailboxID, oldName, newName []string) error
+	UpdateMailbox(ctx context.Context, mboxID imap.MailboxID, newName []string) error
 
 	// DeleteMailbox deletes the mailbox with the given ID and name.
 	DeleteMailbox(ctx context.Context, mboxID imap.MailboxID) error

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -298,12 +298,12 @@ func (state *State) Rename(ctx context.Context, oldName, newName string) error {
 
 			newInferior := newName + strings.TrimPrefix(inferior, oldName)
 
-			if err := state.actionUpdateMailbox(ctx, tx, mbox.RemoteID, inferior, newInferior); err != nil {
+			if err := state.actionUpdateMailbox(ctx, tx, mbox.RemoteID, newInferior); err != nil {
 				return err
 			}
 		}
 
-		return state.actionUpdateMailbox(ctx, tx, result.MBox.RemoteID, oldName, newName)
+		return state.actionUpdateMailbox(ctx, tx, result.MBox.RemoteID, newName)
 	})
 }
 


### PR DESCRIPTION
Remove `refresh` function as it is no longer required since we removed the operation queue. Additionally this function was causing a deadlock on error since the update it was waiting on could not be executed as the current operation has acquired the database lock.