### PR TITLE
Fix connector update issues related to deletion of mailboxes and messages

### DIFF
--- a/internal/db/mailbox.go
+++ b/internal/db/mailbox.go
@@ -70,6 +70,15 @@ func MailboxExistsWithRemoteID(ctx context.Context, client *ent.Client, mboxID i
 	return client.Mailbox.Query().Where(mailbox.RemoteID(mboxID)).Exist(ctx)
 }
 
+func GetMailboxIDFromRemoteID(ctx context.Context, client *ent.Client, mboxID imap.MailboxID) (imap.InternalMailboxID, error) {
+	mbox, err := client.Mailbox.Query().Where(mailbox.RemoteID(mboxID)).Select(mailbox.FieldID).Only(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return mbox.ID, nil
+}
+
 func MailboxExistsWithName(ctx context.Context, client *ent.Client, name string) (bool, error) {
 	return client.Mailbox.Query().Where(mailbox.Name(name)).Exist(ctx)
 }

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -164,3 +164,18 @@ func TestDeleteExaminedMailboxCausesDisconnectOnOtherClients(t *testing.T) {
 		c[2].S(response.Bye().WithInconsistentState().String())
 	})
 }
+
+func TestDeleteSelectedMailboxWithRemoteUpdateCausesDisconnect(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		s.flush("user")
+
+		c.C("b002 SELECT mbox1").OK("b002")
+
+		s.mailboxDeleted("user", mailboxID)
+		s.flush("user")
+
+		c.C("b003 NOOP")
+		c.S(response.Bye().WithInconsistentState().String())
+	})
+}

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -120,6 +120,10 @@ func (s *testSession) mailboxCreated(user string, name []string, withData ...str
 	return s.mailboxCreatedWithAttributes(user, name, defaultAttributes, withData...)
 }
 
+func (s *testSession) mailboxDeleted(user string, id imap.MailboxID) {
+	require.NoError(s.tb, s.conns[s.userIDs[user]].MailboxDeleted(id))
+}
+
 func (s *testSession) mailboxCreatedWithAttributes(user string, name []string, attributes imap.FlagSet, withData ...string) imap.MailboxID {
 	mboxID := imap.MailboxID(utils.NewRandomMailboxID())
 


### PR DESCRIPTION
- Ensure messages are removed from mailboxes if no state is selected.
- Ensure states are updated if the mailbox has been removed from remote.