### PR TITLE
fix: Ensure delete followed by create with same ID works

### DIFF
--- a/internal/db/message.go
+++ b/internal/db/message.go
@@ -585,6 +585,15 @@ func GetMessageIDFromRemoteID(ctx context.Context, client *ent.Client, id imap.M
 	return message.ID, nil
 }
 
+func GetMessageFromRemoteIDWithDeletedFlag(ctx context.Context, client *ent.Client, id imap.MessageID) (*ent.Message, error) {
+	message, err := client.Message.Query().Where(message.RemoteID(id)).Select(message.FieldID, message.FieldDeleted).Only(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return message, nil
+}
+
 func GetMessageRemoteIDFromID(ctx context.Context, client *ent.Client, id imap.InternalMessageID) (imap.MessageID, error) {
 	message, err := client.Message.Query().Where(message.ID(id)).Select(message.FieldRemoteID).Only(ctx)
 	if err != nil {

--- a/tests/deleted_test.go
+++ b/tests/deleted_test.go
@@ -177,3 +177,29 @@ func TestRemoteDeleteOnNonSelectedMailboxRemoveMessageFromMailbox(t *testing.T) 
 		c.S(`A002 OK STATUS`)
 	})
 }
+
+func TestRemoteMessageUpdate(t *testing.T) {
+	// Test that a sequence of delete followed by create with the same message ID  results in an updated message.
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		messageID := s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"), time.Now())
+
+		s.flush("user")
+		c.C(`A002 STATUS mbox1 (MESSAGES)`)
+		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
+		c.S(`A002 OK STATUS`)
+
+		s.messageDeleted("user", messageID)
+		s.messageCreatedWithID("user", messageID, mailboxID, []byte("To: 4@4.pm"), time.Now())
+		s.flush("user")
+
+		c.C(`A002 STATUS mbox1 (MESSAGES)`)
+		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
+		c.S(`A002 OK STATUS`)
+
+		c.C(`A00X SELECT mbox1`).OK(`A00X`)
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm FLAGS (\\Recent \\Seen))")
+		c.OK("A005")
+	})
+}


### PR DESCRIPTION
If the Connector sends a delete message update followed by a create message update we need to delete the existing message from the database on the spot so that it can be replaced with the updated value.