### PR TITLE
feat: MessageUpdated Update

### DIFF
--- a/imap/update_message_updated.go
+++ b/imap/update_message_updated.go
@@ -1,0 +1,38 @@
+package imap
+
+import (
+	"fmt"
+	"github.com/bradenaw/juniper/xslices"
+)
+
+// MessageUpdated replaces the previous behavior of MessageDelete followed by MessageCreate. Furthermore, it guarantees
+// that the operation is executed atomically.
+type MessageUpdated struct {
+	updateBase
+	*updateWaiter
+
+	Message       Message
+	Literal       []byte
+	MailboxIDs    []MailboxID
+	ParsedMessage *ParsedMessage
+}
+
+func NewMessageUpdated(message Message, literal []byte, mailboxIDs []MailboxID, parsedMessage *ParsedMessage) *MessageUpdated {
+	return &MessageUpdated{
+		updateWaiter:  newUpdateWaiter(),
+		Message:       message,
+		Literal:       literal,
+		MailboxIDs:    mailboxIDs,
+		ParsedMessage: parsedMessage,
+	}
+}
+
+func (u *MessageUpdated) String() string {
+	return fmt.Sprintf("MessageUpdate: ID:%v Mailboxes:%v Flags:%s",
+		u.Message.ID.ShortID(),
+		xslices.Map(u.MailboxIDs, func(mboxID MailboxID) string {
+			return mboxID.ShortID()
+		}),
+		u.Message.Flags.ToSlice(),
+	)
+}

--- a/internal/backend/user.go
+++ b/internal/backend/user.go
@@ -182,11 +182,14 @@ func (user *user) deleteAllMessagesMarkedDeleted(ctx context.Context) error {
 	return user.store.Delete(ids...)
 }
 
-func (user *user) queueStateUpdate(update state.Update) {
+func (user *user) queueStateUpdate(updates ...state.Update) {
 	if err := user.forState(func(state *state.State) error {
-		if !state.QueueUpdates(update) {
-			logrus.Errorf("Failed to push update to state %v", state.StateID)
+		for _, update := range updates {
+			if !state.QueueUpdates(update) {
+				logrus.Errorf("Failed to push update to state %v", state.StateID)
+			}
 		}
+
 		return nil
 	}); err != nil {
 		panic("unexpected, should not happen")

--- a/tests/deleted_test.go
+++ b/tests/deleted_test.go
@@ -189,8 +189,7 @@ func TestRemoteMessageUpdate(t *testing.T) {
 		c.S(`* STATUS "mbox1" (MESSAGES 1)`)
 		c.S(`A002 OK STATUS`)
 
-		s.messageDeleted("user", messageID)
-		s.messageCreatedWithID("user", messageID, mailboxID, []byte("To: 4@4.pm"), time.Now())
+		s.messageUpdatedWithID("user", messageID, mailboxID, []byte("To: 4@4.pm"), time.Now())
 		s.flush("user")
 
 		c.C(`A002 STATUS mbox1 (MESSAGES)`)

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -33,6 +33,7 @@ type Connector interface {
 
 	MessageCreated(imap.Message, []byte, []imap.MailboxID) error
 	MessagesCreated([]imap.Message, [][]byte, [][]imap.MailboxID) error
+	MessageUpdated(imap.Message, []byte, []imap.MailboxID) error
 	MessageAdded(imap.MessageID, imap.MailboxID) error
 	MessageRemoved(imap.MessageID, imap.MailboxID) error
 	MessageSeen(imap.MessageID, bool) error
@@ -192,6 +193,20 @@ func (s *testSession) messageCreated(user string, mailboxID imap.MailboxID, lite
 
 func (s *testSession) messageCreatedWithID(user string, messageID imap.MessageID, mailboxID imap.MailboxID, literal []byte, internalDate time.Time, flags ...string) {
 	require.NoError(s.tb, s.conns[s.userIDs[user]].MessageCreated(
+		imap.Message{
+			ID:    messageID,
+			Flags: imap.NewFlagSetFromSlice(flags),
+			Date:  internalDate,
+		},
+		literal,
+		[]imap.MailboxID{mailboxID},
+	))
+
+	s.conns[s.userIDs[user]].Flush()
+}
+
+func (s *testSession) messageUpdatedWithID(user string, messageID imap.MessageID, mailboxID imap.MailboxID, literal []byte, internalDate time.Time, flags ...string) {
+	require.NoError(s.tb, s.conns[s.userIDs[user]].MessageUpdated(
 		imap.Message{
 			ID:    messageID,
 			Flags: imap.NewFlagSetFromSlice(flags),


### PR DESCRIPTION
To be used in cases where one needs to atomically replace a message (e.g: Drafts) in one go. This was previously possible with a combination of Delete + Create update, but these were not guaranteed to be atomic and could cause undefined behaviors if something else happened in between.

The old logic to handle the replacement of delete messages on create has been reverted. It is now expected that this type of behavior uses the newly introduced update.