### PR TITLE
feat(GODT-1989): Recovery Mailbox

### DIFF
--- a/internal/backend/state_user_interface_impl.go
+++ b/internal/backend/state_user_interface_impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/db"
 	"github.com/ProtonMail/gluon/internal/db/ent"
+	"github.com/ProtonMail/gluon/internal/ids"
 	"github.com/ProtonMail/gluon/internal/state"
 	"github.com/ProtonMail/gluon/store"
 )
@@ -41,28 +42,34 @@ func (s *StateUserInterfaceImpl) GetStore() store.Store {
 	return s.u.store
 }
 
-func (s *StateUserInterfaceImpl) QueueOrApplyStateUpdate(ctx context.Context, tx *ent.Tx, update state.Update) error {
+func (s *StateUserInterfaceImpl) QueueOrApplyStateUpdate(ctx context.Context, tx *ent.Tx, updates ...state.Update) error {
 	// If we detect a state id in the context, it means this function call is a result of a User interaction.
 	// When that happens the update needs to be applied to the state matching the state ID immediately. If no such
 	// stateID exists or the context information is not present, all updates are queued for later execution.
 	stateID, ok := state.GetStateIDFromContext(ctx)
 	if !ok {
 		return s.u.forState(func(state *state.State) error {
-			state.QueueUpdates(update)
+			state.QueueUpdates(updates...)
 			return nil
 		})
 	} else {
 		return s.u.forState(func(state *state.State) error {
 			if state.StateID != stateID {
-				state.QueueUpdates(update)
+				state.QueueUpdates(updates...)
 
 				return nil
 			} else {
-				if !update.Filter(state) {
-					return nil
+				for _, update := range updates {
+					if !update.Filter(state) {
+						continue
+					}
+
+					if err := update.Apply(ctx, tx, state); err != nil {
+						return err
+					}
 				}
 
-				return update.Apply(ctx, tx, state)
+				return nil
 			}
 		})
 	}
@@ -78,4 +85,15 @@ func (s *StateUserInterfaceImpl) GetGlobalUIDValidity() imap.UID {
 
 func (s *StateUserInterfaceImpl) SetGlobalUIDValidity(uid imap.UID) {
 	s.u.globalUIDValidity = uid
+}
+
+func (s *StateUserInterfaceImpl) GetRecoveryMailboxID() ids.MailboxIDPair {
+	return ids.MailboxIDPair{
+		InternalID: s.u.recoveryMailboxID,
+		RemoteID:   ids.GluonInternalRecoveryMailboxRemoteID,
+	}
+}
+
+func (s *StateUserInterfaceImpl) NextRecoveryMessageID() imap.InternalMessageID {
+	return s.u.nextMessageID()
 }

--- a/internal/db/message.go
+++ b/internal/db/message.go
@@ -235,6 +235,10 @@ func GetMessage(ctx context.Context, client *ent.Client, messageID imap.Internal
 	return client.Message.Query().Where(message.ID(messageID)).Only(ctx)
 }
 
+func GetImportedMessageData(ctx context.Context, client *ent.Client, messageID imap.InternalMessageID) (*ent.Message, error) {
+	return client.Message.Query().Where(message.ID(messageID)).WithFlags().Select(message.FieldDate).Only(ctx)
+}
+
 func GetMessageDateAndSize(ctx context.Context, client *ent.Client, messageID imap.InternalMessageID) (*ent.Message, error) {
 	return client.Message.Query().Where(message.ID(messageID)).Select(message.FieldSize, message.FieldDate).Only(ctx)
 }
@@ -532,6 +536,14 @@ func UpdateRemoteMessageID(ctx context.Context, tx *ent.Tx, internalID imap.Inte
 		Where(message.ID(internalID)).
 		SetRemoteID(remoteID).
 		Save(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MarkMessageAsDeleted(ctx context.Context, tx *ent.Tx, messageID imap.InternalMessageID) error {
+	if _, err := tx.Message.Update().Where(message.ID(messageID)).SetDeleted(true).Save(ctx); err != nil {
 		return err
 	}
 

--- a/internal/ids/ids.go
+++ b/internal/ids/ids.go
@@ -73,3 +73,7 @@ func SplitMailboxIDPairSlice(s []MailboxIDPair) ([]imap.InternalMailboxID, []ima
 
 	return internalMailboxIDs, mailboxIDs
 }
+
+const GluonRecoveryMailboxName = "Recovered Messages"
+const GluonRecoveryMailboxNameLowerCase = "recovered messages"
+const GluonInternalRecoveryMailboxRemoteID = imap.MailboxID("GLUON-INTERNAL-RECOVERY-MBOX")

--- a/internal/state/user_interface.go
+++ b/internal/state/user_interface.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/db"
 	"github.com/ProtonMail/gluon/internal/db/ent"
+	"github.com/ProtonMail/gluon/internal/ids"
 	"github.com/ProtonMail/gluon/store"
 )
 
@@ -23,11 +24,15 @@ type UserInterface interface {
 
 	GetStore() store.Store
 
-	QueueOrApplyStateUpdate(ctx context.Context, tx *ent.Tx, update Update) error
+	QueueOrApplyStateUpdate(ctx context.Context, tx *ent.Tx, update ...Update) error
 
 	ReleaseState(ctx context.Context, st *State) error
 
 	GetGlobalUIDValidity() imap.UID
 
 	SetGlobalUIDValidity(imap.UID)
+
+	GetRecoveryMailboxID() ids.MailboxIDPair
+
+	NextRecoveryMessageID() imap.InternalMessageID
 }

--- a/tests/counts_test.go
+++ b/tests/counts_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/ProtonMail/gluon/internal/ids"
 	"testing"
 	"time"
 
@@ -24,8 +25,12 @@ func TestCounts(t *testing.T) {
 	})
 
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withDataDir(dir)), func(_ *client.Client, s *testSession) {
-		for _, count := range getEvent[events.UserAdded](s.eventCh).Counts {
-			require.Equal(t, 10, count)
+		for mbox, count := range getEvent[events.UserAdded](s.eventCh).Counts {
+			if mbox == ids.GluonInternalRecoveryMailboxRemoteID {
+				require.Equal(t, 0, count)
+			} else {
+				require.Equal(t, 10, count)
+			}
 		}
 	})
 }

--- a/tests/recovery_mailbox_test.go
+++ b/tests/recovery_mailbox_test.go
@@ -1,0 +1,451 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/ProtonMail/gluon/connector"
+	"github.com/ProtonMail/gluon/imap"
+	"github.com/ProtonMail/gluon/internal/ids"
+	goimap "github.com/emersion/go-imap"
+	"github.com/emersion/go-imap/client"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestRecoveryMBoxNotVisibleWhenEmpty(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		c.C(`A103 LIST "" *`)
+		c.S(`* LIST (\Unmarked) "/" "INBOX"`)
+		c.OK(`A103`)
+	})
+}
+
+func TestRecoveryMBoxVisibleWhenNotEmpty(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&failAppendLabelConnectorBuilder{})), func(c *testConnection, s *testSession) {
+		c.doAppend("INBOX", "INBOX", "To: Test@test.com").expect("NO")
+		c.C(`A103 LIST "" *`)
+		c.S(`* LIST (\Unmarked) "/" "INBOX"`,
+			fmt.Sprintf(`* LIST (\Marked \Noinferiors) "/" "%v"`, ids.GluonRecoveryMailboxName),
+		)
+		c.OK(`A103`)
+	})
+}
+
+func TestRecoveryMBoxCanNotBeCreated(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
+		require.Error(t, client.Create(ids.GluonRecoveryMailboxNameLowerCase))
+		require.Error(t, client.Create(ids.GluonRecoveryMailboxName))
+		require.Error(t, client.Create(fmt.Sprintf("%v/sub", ids.GluonRecoveryMailboxName)))
+	})
+}
+
+func TestRecoveryMBoxCanNotBeRenamed(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
+		require.Error(t, client.Rename(ids.GluonRecoveryMailboxName, "SomethingElse"))
+		require.Error(t, client.Rename("INBOX", ids.GluonRecoveryMailboxName))
+	})
+}
+
+func TestRecoveryMBoxCanNotBeAppended(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
+		require.Error(t, client.Append(ids.GluonRecoveryMailboxName, nil, time.Now(), bytes.NewReader([]byte("RandomGibberish"))))
+	})
+}
+
+func TestRecoveryMBoxCanNotBeMovedOrCopiedInto(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, s *testSession) {
+		const mboxName = "Foo"
+		mboxID := s.mailboxCreated("user", []string{mboxName})
+		s.messageCreated("user", mboxID, []byte("To: Test@test.com"), time.Now())
+		s.flush("user")
+		status, err := client.Select(mboxName, false)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+
+		require.Error(t, client.Move(createSeqSet("1"), ids.GluonRecoveryMailboxName))
+		require.Error(t, client.Copy(createSeqSet("1"), ids.GluonRecoveryMailboxName))
+	})
+}
+
+func TestRecoveryMBoxCanBeMovedOutOf(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&disableRemoveFromMailboxBuilder{})), func(client *client.Client, s *testSession) {
+		// Insert first message, fails.
+		require.Error(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+		status, err := client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		{
+			_, err := client.Select(ids.GluonRecoveryMailboxName, false)
+			require.NoError(t, err)
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+
+		// Move message.
+		require.NoError(t, client.Move(createSeqSet("1"), "INBOX"))
+
+		// Check state.
+		status, err = client.Status("INBOX", []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		status, err = client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), status.Messages)
+
+		{
+			_, err := client.Select("INBOX", false)
+			require.NoError(t, err)
+			// Check that message has the new internal ID header.
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", fmt.Sprintf("%v: 2", ids.InternalIDKey), "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+	})
+}
+
+func TestRecoveryMBoxCanBeCopiedOutOf(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&disableRemoveFromMailboxBuilder{})), func(client *client.Client, s *testSession) {
+		// Insert first message, fails.
+		require.Error(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+		status, err := client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		{
+			_, err := client.Select(ids.GluonRecoveryMailboxName, false)
+			require.NoError(t, err)
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+
+		// Copy message.
+		require.NoError(t, client.Copy(createSeqSet("1"), "INBOX"))
+
+		// Validate state.
+		status, err = client.Status("INBOX", []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		status, err = client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+
+		{
+			_, err := client.Select("INBOX", false)
+			require.NoError(t, err)
+			// Check that message has the new internal ID header.
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", fmt.Sprintf("%v: 2", ids.InternalIDKey), "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+	})
+}
+
+func TestRecoveryMBoxCanBeExpunged(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&disableRemoveFromMailboxBuilder{})), func(client *client.Client, s *testSession) {
+		// Insert first message, fails.
+		require.Error(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+		// Execute expunge
+		status, err := client.Select(ids.GluonRecoveryMailboxName, false)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		require.NoError(t, client.Store(createSeqSet("1"), goimap.AddFlags, []interface{}{goimap.DeletedFlag}, nil))
+		require.NoError(t, client.Expunge(nil))
+		status, err = client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), status.Messages)
+	})
+}
+
+func TestFailedAppendEndsInRecovery(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&failAppendLabelConnectorBuilder{})), func(client *client.Client, s *testSession) {
+		{
+			status, err := client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+			require.NoError(t, err)
+			require.Equal(t, uint32(0), status.Messages)
+		}
+
+		status, err := client.Select("INBOX", false)
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), status.Messages)
+		require.Error(t, doAppendWithClient(client, "INBOX", "To: Foo@bar.com", time.Now()))
+
+		{
+			status, err := client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), status.Messages)
+		}
+		{
+			status, err := client.Status("INBOX", []goimap.StatusItem{goimap.StatusMessages})
+			require.NoError(t, err)
+			require.Equal(t, uint32(0), status.Messages)
+		}
+
+		{
+			_, err := client.Select(ids.GluonRecoveryMailboxName, false)
+			require.NoError(t, err)
+			// Check that no custom headers are appended to the message.
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", "To: Foo@bar.com")
+			}).checkAndRequireMessageCount(1)
+		}
+	})
+}
+
+func TestRecoveryMBoxCanBeCopiedOutOfDedup(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&recoveryDedupConnectorConnectorBuilder{})), func(client *client.Client, s *testSession) {
+		// Insert first message, fails.
+		require.Error(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+		{
+			_, err := client.Select(ids.GluonRecoveryMailboxName, false)
+			require.NoError(t, err)
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+
+		// Insert same message, succeeds.
+		require.NoError(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+
+		{
+			_, err := client.Select("INBOX", false)
+			require.NoError(t, err)
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", fmt.Sprintf("%v: 2", ids.InternalIDKey), "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+
+		// Copy message out of recovery, triggers insert will return the same ID.
+		status, err := client.Select(ids.GluonRecoveryMailboxName, false)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		require.NoError(t, client.Copy(createSeqSet("1"), "INBOX"))
+		status, err = client.Status("INBOX", []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		status, err = client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+
+		// Check that no new message was created in INBOX as we already have this message available there.
+		{
+			_, err := client.Select("INBOX", false)
+			require.NoError(t, err)
+			// Check that message has the new internal ID header.
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", fmt.Sprintf("%v: 2", ids.InternalIDKey), "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+	})
+}
+
+func TestRecoveryMBoxCanBeMovedOutOfDedup(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withConnectorBuilder(&recoveryDedupConnectorConnectorBuilder{})), func(client *client.Client, s *testSession) {
+		// Insert first message, fails.
+		require.Error(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+		{
+			_, err := client.Select(ids.GluonRecoveryMailboxName, false)
+			require.NoError(t, err)
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+
+		// Insert same message, succeeds.
+		require.NoError(t, doAppendWithClient(client, "INBOX", "To: Test@test.com", time.Now()))
+
+		{
+			_, err := client.Select("INBOX", false)
+			require.NoError(t, err)
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", fmt.Sprintf("%v: 2", ids.InternalIDKey), "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+
+		// Copy message out of recovery, triggers insert will return the same ID.
+		status, err := client.Select(ids.GluonRecoveryMailboxName, false)
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		require.NoError(t, client.Move(createSeqSet("1"), "INBOX"))
+		status, err = client.Status("INBOX", []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(1), status.Messages)
+		status, err = client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), status.Messages)
+
+		// Check that no new message was created in INBOX as we already have this message available there.
+		{
+			_, err := client.Select("INBOX", false)
+			require.NoError(t, err)
+			// Check that message has the new internal ID header.
+			newFetchCommand(t, client).withItems("BODY[]").fetch("1").forSeqNum(1, func(builder *validatorBuilder) {
+				builder.ignoreFlags()
+				builder.wantSection("BODY[]", fmt.Sprintf("%v: 2", ids.InternalIDKey), "To: Test@test.com")
+			}).checkAndRequireMessageCount(1)
+		}
+	})
+}
+
+// disableRemoveFromMailboxConnector fails the first append and panics if move or remove takes place on the
+// connector.
+type disableRemoveFromMailboxConnector struct {
+	*connector.Dummy
+	createFailed bool
+}
+
+func (r *disableRemoveFromMailboxConnector) CreateMessage(
+	ctx context.Context,
+	mboxID imap.MailboxID,
+	literal []byte,
+	flags imap.FlagSet,
+	date time.Time) (imap.Message, []byte, error) {
+	if !r.createFailed {
+		r.createFailed = true
+		return imap.Message{}, nil, fmt.Errorf("failed")
+	}
+
+	return r.Dummy.CreateMessage(ctx, mboxID, literal, flags, date)
+}
+
+func (r *disableRemoveFromMailboxConnector) RemoveMessagesFromMailbox(
+	_ context.Context,
+	_ []imap.MessageID,
+	_ imap.MailboxID,
+) error {
+	panic("Should not be called")
+}
+
+func (r *disableRemoveFromMailboxConnector) MoveMessages(
+	_ context.Context,
+	_ []imap.MessageID,
+	_ imap.MailboxID,
+	_ imap.MailboxID,
+) error {
+	panic("Should not be called")
+}
+
+type disableRemoveFromMailboxBuilder struct{}
+
+func (disableRemoveFromMailboxBuilder) New(usernames []string, password []byte, period time.Duration, flags, permFlags, attrs imap.FlagSet) Connector {
+	return &disableRemoveFromMailboxConnector{
+		Dummy: connector.NewDummy(usernames, password, period, flags, permFlags, attrs),
+	}
+}
+
+// recoveryDedupConnector fails the first CreateMessage call and then returns the same remote id for all
+// the next messages which are created to simulated de-duplication.
+type recoveryDedupConnector struct {
+	*connector.Dummy
+
+	firstMessage   bool
+	messageCreated bool
+	createdMessage imap.Message
+	messageLiteral []byte
+}
+
+func (r *recoveryDedupConnector) CreateMessage(
+	ctx context.Context,
+	mboxID imap.MailboxID,
+	literal []byte,
+	flags imap.FlagSet,
+	date time.Time) (imap.Message, []byte, error) {
+	if r.firstMessage {
+		r.firstMessage = false
+		return imap.Message{}, nil, fmt.Errorf("failed")
+	}
+
+	if !r.messageCreated {
+		msg, l, err := r.Dummy.CreateMessage(ctx, mboxID, literal, flags, date)
+		if err != nil {
+			return imap.Message{}, nil, err
+		}
+
+		r.createdMessage = msg
+		r.messageLiteral = l
+		r.messageCreated = true
+	}
+
+	return r.createdMessage, r.messageLiteral, nil
+}
+
+func (r *recoveryDedupConnector) AddMessagesToMailbox(
+	ctx context.Context,
+	ids []imap.MessageID,
+	mboxID imap.MailboxID,
+) error {
+	if r.firstMessage {
+		return fmt.Errorf("failed")
+	}
+
+	return r.Dummy.AddMessagesToMailbox(ctx, ids, mboxID)
+}
+
+func (r *recoveryDedupConnector) MoveMessagesFromMailbox(
+	_ context.Context,
+	_ []imap.MessageID,
+	_ imap.MailboxID,
+	_ imap.MailboxID,
+) error {
+	return fmt.Errorf("failed")
+}
+
+type recoveryDedupConnectorConnectorBuilder struct{}
+
+func (recoveryDedupConnectorConnectorBuilder) New(usernames []string, password []byte, period time.Duration, flags, permFlags, attrs imap.FlagSet) Connector {
+	return &recoveryDedupConnector{
+		Dummy:        connector.NewDummy(usernames, password, period, flags, permFlags, attrs),
+		firstMessage: true,
+	}
+}
+
+// failAppendLabelConnector simulate Create Message failures and also ensures that no calls to Add or Move can take place.
+type failAppendLabelConnector struct {
+	*connector.Dummy
+}
+
+func (r *failAppendLabelConnector) CreateMessage(
+	_ context.Context,
+	_ imap.MailboxID,
+	_ []byte,
+	_ imap.FlagSet,
+	_ time.Time) (imap.Message, []byte, error) {
+	return imap.Message{}, nil, fmt.Errorf("failed")
+}
+
+func (r *failAppendLabelConnector) AddMessagesToMailbox(
+	_ context.Context,
+	_ []imap.MessageID,
+	_ imap.MailboxID,
+) error {
+	return fmt.Errorf("failed")
+}
+
+func (r *failAppendLabelConnector) MoveMessagesFromMailbox(
+	_ context.Context,
+	_ []imap.MessageID,
+	_ imap.MailboxID,
+	_ imap.MailboxID,
+) error {
+	return fmt.Errorf("failed")
+}
+
+type failAppendLabelConnectorBuilder struct{}
+
+func (failAppendLabelConnectorBuilder) New(usernames []string, password []byte, period time.Duration, flags, permFlags, attrs imap.FlagSet) Connector {
+	return &failAppendLabelConnector{
+		Dummy: connector.NewDummy(usernames, password, period, flags, permFlags, attrs),
+	}
+}

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -91,6 +91,7 @@ func TestMessageCreatedIDLEUpdate(t *testing.T) {
 		// Create two messages externally.
 		s.messageCreatedFromFile("user", other, "testdata/multipart-mixed.eml")
 		s.messageCreatedFromFile("user", other, "testdata/afternoon-meeting.eml")
+		s.flush("user")
 
 		// Expect that we receive IDLE updates.
 		c.S(`* 2 EXISTS`, `* 2 RECENT`)
@@ -98,6 +99,7 @@ func TestMessageCreatedIDLEUpdate(t *testing.T) {
 		// Create two more messages externally.
 		s.messageCreatedFromFile("user", other, "testdata/multipart-mixed.eml")
 		s.messageCreatedFromFile("user", other, "testdata/afternoon-meeting.eml")
+		s.flush("user")
 
 		// Expect that we receive IDLE updates.
 		c.S(`* 4 EXISTS`, `* 4 RECENT`)
@@ -111,6 +113,7 @@ func TestMessageCreatedIDLEUpdate(t *testing.T) {
 		// Create two more messages externally.
 		s.messageCreatedFromFile("user", other, "testdata/multipart-mixed.eml")
 		s.messageCreatedFromFile("user", other, "testdata/afternoon-meeting.eml")
+		s.flush("user")
 
 		// Expect that we receive IDLE updates.
 		c.S(`* 6 EXISTS`, `* 2 RECENT`)


### PR DESCRIPTION
Add a Gluon managed mailbox which stores messages which failed to be appended. This is required to handle clients such as Outlook which do not check Append failures when moving message and can result in data loss.

When an Append fails, we insert it into a special mailbox called "RecoveredMessages". Messages in this mailbox support:
* Being copied out
* Being moved out
* Flag modifications
* Being deleted

Any other operation is not allowed.

When messages are moved/copied out of this mailbox they are first created as new messages on the Connector before being added to the target mailbox.