### PR TITLE
fix: RemoveMessagesFromMailbox should only remove from remote if need be

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -82,7 +82,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
-          args: --timeout=180s
+          args: --timeout=250s
           skip-cache: true
 
       - name: Run tests

--- a/internal/db/mailbox.go
+++ b/internal/db/mailbox.go
@@ -366,3 +366,36 @@ func FilterMailboxContains(ctx context.Context, client *ent.Client, mboxID imap.
 		return r.InternalID
 	}), nil
 }
+
+func GetMailboxFlags(ctx context.Context, client *ent.Client, mboxID imap.InternalMailboxID) (imap.FlagSet, error) {
+	mbox, err := client.Mailbox.Query().Where(mailbox.ID(mboxID)).WithFlags().Only(ctx)
+	if err != nil {
+		return imap.FlagSet{}, err
+	}
+
+	return imap.NewFlagSetFromSlice(xslices.Map(mbox.Edges.Flags, func(flag *ent.MailboxFlag) string {
+		return flag.Value
+	})), nil
+}
+
+func GetMailboxPermanentFlags(ctx context.Context, client *ent.Client, mboxID imap.InternalMailboxID) (imap.FlagSet, error) {
+	mbox, err := client.Mailbox.Query().Where(mailbox.ID(mboxID)).WithPermanentFlags().Only(ctx)
+	if err != nil {
+		return imap.FlagSet{}, err
+	}
+
+	return imap.NewFlagSetFromSlice(xslices.Map(mbox.Edges.PermanentFlags, func(flag *ent.MailboxPermFlag) string {
+		return flag.Value
+	})), nil
+}
+
+func GetMailboxAttributes(ctx context.Context, client *ent.Client, mboxID imap.InternalMailboxID) (imap.FlagSet, error) {
+	mbox, err := client.Mailbox.Query().Where(mailbox.ID(mboxID)).WithAttributes().Only(ctx)
+	if err != nil {
+		return imap.FlagSet{}, err
+	}
+
+	return imap.NewFlagSetFromSlice(xslices.Map(mbox.Edges.Attributes, func(flag *ent.MailboxAttr) string {
+		return flag.Value
+	})), nil
+}

--- a/internal/state/mailbox.go
+++ b/internal/state/mailbox.go
@@ -147,8 +147,14 @@ func (m *Mailbox) GetMessagesWithoutFlagCount(flag string) int {
 
 func (m *Mailbox) AppendRegular(ctx context.Context, literal []byte, flags imap.FlagSet, date time.Time) (imap.UID, error) {
 	var appendIntoDrafts bool
+
+	attr, err := m.Attributes(ctx)
+	if err != nil {
+		return 0, err
+	}
+
 	// Force create message when appending to drafts so that IMAP clients can create new draft messages.
-	if !strings.EqualFold(m.name, "Drafts") {
+	if !attr.Contains(imap.AttrDrafts) {
 		internalIDString, err := rfc822.GetHeaderValue(literal, ids.InternalIDKey)
 		if err != nil {
 			return 0, err

--- a/rfc822/header_test.go
+++ b/rfc822/header_test.go
@@ -324,3 +324,31 @@ func TestSetHeaderValueWithPrelude(t *testing.T) {
 	// Ensure the original data wasn't modified.
 	assert.Equal(t, literalBytes, []byte(literal))
 }
+
+func TestHeader_Erase(t *testing.T) {
+	literal := []byte("Subject: this is\r\n\ta multiline field\r\nFrom: duplicate entry\r\nReferences:\r\n\t <foo@bar.com>\r\n\r\n")
+	literalWithoutSubject := []byte("From: duplicate entry\r\nReferences:\r\n\t <foo@bar.com>\r\n\r\n")
+	literalWithoutFrom := []byte("Subject: this is\r\n\ta multiline field\r\nReferences:\r\n\t <foo@bar.com>\r\n\r\n")
+	literalWithoutReferences := []byte("Subject: this is\r\n\ta multiline field\r\nFrom: duplicate entry\r\n\r\n")
+
+	{
+		newLiteral, err := EraseHeaderValue(literal, "Subject")
+		require.NoError(t, err)
+		assert.Equal(t, literalWithoutSubject, newLiteral)
+	}
+	{
+		newLiteral, err := EraseHeaderValue(literal, "From")
+		require.NoError(t, err)
+		assert.Equal(t, literalWithoutFrom, newLiteral)
+	}
+	{
+		newLiteral, err := EraseHeaderValue(literal, "References")
+		require.NoError(t, err)
+		assert.Equal(t, literalWithoutReferences, newLiteral)
+	}
+	{
+		newLiteral, err := EraseHeaderValue(literal, "ThisKeyDoesNotExist")
+		require.NoError(t, err)
+		assert.Equal(t, literal, newLiteral)
+	}
+}

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -1,8 +1,11 @@
 package tests
 
 import (
+	"regexp"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDraftScenario(t *testing.T) {
@@ -37,5 +40,108 @@ func TestDraftScenario(t *testing.T) {
 		c.C("A005 FETCH 1 (BODY.PEEK[HEADER.FIELDS (To)])")
 		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm)")
 		c.OK("A005")
+	})
+}
+
+func TestDraftSavedAgain(t *testing.T) {
+	// Email client can save same message i.e.: it will delete old draft
+	// and append one with same content.
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"Drafts"})
+
+		c.C("A002 SELECT Drafts").OK("A002")
+
+		_ = s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"), time.Now())
+
+		c.C("A002 NOOP")
+		c.S("* 1 EXISTS")
+		c.S("* 1 RECENT")
+		c.OK("A002")
+
+		c.C("A003 FETCH 1 (BODY.PEEK[])")
+		raw := c.read()
+
+		fetch := regexp.MustCompile(
+			regexp.QuoteMeta("* 1 FETCH (BODY[] {63}\r\nX-Pm-Gluon-Id: ") +
+				".*" +
+				regexp.QuoteMeta("\r\nTo: 3@3.pm)\r\n"),
+		)
+
+		require.Regexp(t, fetch, string(raw))
+		c.OK("A003")
+
+		// Expunge+Append same message
+		{
+			c.C(`A004 STORE 1 +FLAGS (\Deleted)`).OK("A004")
+			c.C(`A005 EXPUNGE`).OK("A005")
+
+			c.doAppend(
+				"Drafts",
+				string(raw[24:len(raw)-3]),
+			).expect("OK")
+
+			c.C("A004 FETCH 1 (BODY.PEEK[])")
+			raw := c.read()
+			require.Regexp(t, fetch, string(raw))
+			c.OK("A004")
+		}
+
+		newBody2 := string(raw[24:]) + "\r\nThis is body\r\n"
+		fetchUpdated2 := regexp.MustCompile(
+			regexp.QuoteMeta("* 1 FETCH (BODY[] {82}\r\nX-Pm-Gluon-Id: ") +
+				".*" +
+				regexp.QuoteMeta("\r\nTo: 3@3.pm)\r\n\r\nThis is body\r\n)"),
+		)
+		// Expunge+Append different message
+		{
+			c.C(`A004 STORE 1 +FLAGS (\Deleted)`).OK("A004")
+			c.C(`A005 EXPUNGE`).OK("A005")
+
+			c.doAppend(
+				"Drafts",
+				newBody2,
+			).expect("OK")
+
+			c.C("A004 FETCH 1 (BODY.PEEK[])")
+			raw := c.read()
+			require.Regexp(t, fetchUpdated2, string(raw))
+			c.OK("A004")
+		}
+
+		// Append + Expunge different message
+		newBody3 := newBody2 + "hello\r\n"
+		fetchUpdated3 := regexp.MustCompile(
+			regexp.QuoteMeta("* ") +
+				"\\d" +
+				regexp.QuoteMeta(" FETCH (BODY[] {89}\r\nX-Pm-Gluon-Id: ") +
+				".*" +
+				regexp.QuoteMeta("\r\nTo: 3@3.pm)\r\n\r\nThis is body\r\nhello\r\n)"),
+		)
+		{
+
+			c.doAppend(
+				"Drafts",
+				newBody3,
+			).expect("OK")
+
+			c.C("A004 FETCH 1 (BODY.PEEK[])")
+			raw := c.read()
+			require.Regexp(t, fetchUpdated2, string(raw))
+			c.OK("A004")
+
+			c.C("A005 FETCH 2 (BODY.PEEK[])")
+			raw = c.read()
+			require.Regexp(t, fetchUpdated3, string(raw))
+			c.OK("A005")
+
+			c.C(`A004 STORE 1 +FLAGS (\Deleted)`).OK("A004")
+			c.C(`A005 EXPUNGE`).OK("A005")
+
+			c.C("A006 FETCH 1 (BODY.PEEK[])")
+			raw = c.read()
+			require.Regexp(t, fetchUpdated3, string(raw))
+			c.OK("A006")
+
+		}
 	})
 }

--- a/tests/draft_test.go
+++ b/tests/draft_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/ProtonMail/gluon/imap"
 	"regexp"
 	"testing"
 	"time"
@@ -47,7 +48,7 @@ func TestDraftSavedAgain(t *testing.T) {
 	// Email client can save same message i.e.: it will delete old draft
 	// and append one with same content.
 	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
-		mailboxID := s.mailboxCreated("user", []string{"Drafts"})
+		mailboxID := s.mailboxCreatedWithAttributes("user", []string{"Drafts"}, imap.NewFlagSet(imap.AttrDrafts))
 
 		c.C("A002 SELECT Drafts").OK("A002")
 


### PR DESCRIPTION
When adding a message to a mailbox, it can happen that the message is already there. In that case, we remove it and re-add it. However, that change only needs to be done locally; it's useless to do it on the remote. Further, it can even be dangerous to do on the remote, as the remote might handle this as a permanent deletion.