### PR TITLE
fix(GODT-1967): Fix Seq ID too high

### DIFF
--- a/internal/state/responders.go
+++ b/internal/state/responders.go
@@ -115,12 +115,7 @@ func (u *targetedExists) handle(_ context.Context, snap *snapshot, stateID State
 		}
 	}
 
-	seq, err := snap.getMessageSeq(u.resp.messageID.InternalID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	res := []response.Response{response.Exists().WithCount(seq)}
+	res := []response.Response{response.Exists().WithCount(imap.SeqID(snap.messages.len()))}
 
 	var dbUpdate responderDBUpdate
 


### PR DESCRIPTION
Always return the total number of messages in the exists unilateral update. We were previous returning the SeqID of the inserted message, but this was not guaranteed to be the last message in the mailbox when the updated arrived from other sessions.