### PR TITLE
fix(GODT-2207): Fix missing utf7 encoding for responses

### DIFF
--- a/internal/response/list.go
+++ b/internal/response/list.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/ProtonMail/gluon/imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 type list struct {
@@ -43,10 +42,5 @@ func (r *list) String() string {
 		del = strconv.Quote(r.del)
 	}
 
-	enc, err := utf7.Encoding.NewEncoder().String(r.name)
-	if err != nil {
-		panic(err)
-	}
-
-	return fmt.Sprintf(`* LIST (%v) %v %v`, join(r.att.ToSlice()), del, strconv.Quote(enc))
+	return fmt.Sprintf(`* LIST (%v) %v %v`, join(r.att.ToSlice()), del, strconv.Quote(r.name))
 }

--- a/internal/session/handle_list.go
+++ b/internal/session/handle_list.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ProtonMail/gluon/internal/parser/proto"
 	"github.com/ProtonMail/gluon/internal/response"
@@ -21,9 +22,13 @@ func (s *Session) handleList(ctx context.Context, tag string, cmd *proto.List, c
 
 	return s.state.List(ctx, cmd.GetReference(), nameUTF8, false, func(matches map[string]state.Match) error {
 		for _, match := range matches {
+			nameUtf7, err := utf7.Encoding.NewEncoder().String(match.Name)
+			if err != nil {
+				return fmt.Errorf("failed to convert name to utf7")
+			}
 			select {
 			case ch <- response.List().
-				WithName(match.Name).
+				WithName(nameUtf7).
 				WithDelimiter(match.Delimiter).
 				WithAttributes(match.Atts):
 

--- a/internal/session/handle_lsub.go
+++ b/internal/session/handle_lsub.go
@@ -21,9 +21,13 @@ func (s *Session) handleLsub(ctx context.Context, tag string, cmd *proto.Lsub, c
 
 	return s.state.List(ctx, cmd.GetReference(), nameUTF8, true, func(matches map[string]state.Match) error {
 		for _, match := range matches {
+			nameUtf7, err := utf7.Encoding.NewEncoder().String(match.Name)
+			if err != nil {
+				panic(err)
+			}
 			select {
 			case ch <- response.Lsub().
-				WithName(match.Name).
+				WithName(nameUtf7).
 				WithDelimiter(match.Delimiter).
 				WithAttributes(match.Atts):
 

--- a/internal/session/handle_status.go
+++ b/internal/session/handle_status.go
@@ -49,7 +49,7 @@ func (s *Session) handleStatus(ctx context.Context, tag string, cmd *proto.Statu
 			}
 		}
 
-		ch <- response.Status().WithMailbox(nameUTF8).WithItems(items...)
+		ch <- response.Status().WithMailbox(cmd.GetMailbox()).WithItems(items...)
 
 		return nil
 	}); err != nil {

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -301,3 +301,16 @@ func TestListHiddenMailbox(t *testing.T) {
 		c.OK(`a`)
 	})
 }
+
+func TestListWithUtf8MailboxNames(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, s *testSession) {
+		s.mailboxCreated("user", []string{"mbox-öüäëæøå"})
+		s.flush("user")
+		c.C(`a list "" "*"`)
+		c.S(
+			`* LIST (\Unmarked) "." "INBOX"`,
+			`* LIST (\Unmarked) "." "mbox-&APYA,ADkAOsA5gD4AOU-"`,
+		)
+		c.OK(`a`)
+	})
+}

--- a/tests/lsub_test.go
+++ b/tests/lsub_test.go
@@ -164,3 +164,16 @@ func TestLsubWithHiddenMailbox(t *testing.T) {
 		c.OK(`a`)
 	})
 }
+
+func TestLSubWithUtf8MailboxNames(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, s *testSession) {
+		s.mailboxCreated("user", []string{"mbox-öüäëæøå"})
+		s.flush("user")
+		c.C(`a LSUB "" "*"`)
+		c.S(
+			`* LSUB (\Unmarked) "." "INBOX"`,
+			`* LSUB (\Unmarked) "." "mbox-&APYA,ADkAOsA5gD4AOU-"`,
+		)
+		c.OK(`a`)
+	})
+}

--- a/tests/status_test.go
+++ b/tests/status_test.go
@@ -18,3 +18,14 @@ func TestStatus(t *testing.T) {
 		c.S("A042 OK STATUS")
 	})
 }
+
+func TestStatusWithUtf8MailboxNames(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDelimiter(".")), func(c *testConnection, s *testSession) {
+		s.mailboxCreated("user", []string{"mbox-öüäëæøå"})
+		s.flush("user")
+		c.doAppend(`mbox-&APYA,ADkAOsA5gD4AOU-`, `To: 1@pm.me`).expect("OK")
+		c.C(`a STATUS mbox-&APYA,ADkAOsA5gD4AOU- (MESSAGES)`)
+		c.S(`* STATUS "mbox-&APYA,ADkAOsA5gD4AOU-" (MESSAGES 1)`)
+		c.OK(`a`)
+	})
+}


### PR DESCRIPTION
Some responses which contain mailbox names were not encoded into utf7. This can lead to duplicate subscription folders and IMAP clients being unable to list the contents of a mailbox.