### PR TITLE
fix(GODT-2188): Do not fail APPEND  with invalid MIME types

### DIFF
--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -73,3 +73,91 @@ hey there bro
 	expected := "((\"text\" \"plain\" (\"charset\" \"utf-8\") NIL NIL \"quoted-printable\" 6 2)(\"message\" \"rfc822\" (\"name\" \"ISO-8859-1.eml\") NIL NIL NIL 127 (NIL \"ISO-8859-1\" ((NIL NIL \"random-mail\" \"pm.me\")) ((NIL NIL \"random-mail\" \"pm.me\")) ((NIL NIL \"random-mail\" \"pm.me\")) ((NIL NIL \"random-mail2\" \"pm.me\")) NIL NIL NIL NIL)(\"text\" \"plain\" (\"charset\" \"iso-8859-1\") NIL NIL NIL 14 1) 6) \"mixed\")"
 	require.Equal(t, expected, parsed.Body)
 }
+
+func TestParseInvalidCharsInContenType(t* testing.T) {
+	const literal = `From: Nathaniel Borenstein <nsb@bellcore.com> 
+To:  Ned Freed <ned@innosoft.com> 
+Subject: Sample message 
+MIME-Version: 1.0 
+Content-type: multipart/mixed; boundary="simple boundary" 
+
+This is the preamble.  It is to be ignored, though it 
+is a handy place for mail composers to include an 
+explanatory note to non-MIME compliant readers. 
+--simple boundary
+Content-type: text/plain; charset=us-ascii
+
+This part does not end with a linebreak.
+--simple boundary
+Content-Disposition: attachment; filename=test.eml
+Content-Type: message/rfc822; name=test.eml
+X-Pm-Content-Encryption: on-import
+
+To: someone
+Subject: Fwd: embedded
+Content-type: multipart/mixed; boundary="embedded-boundary" 
+
+--embedded-boundary
+Content-Type: GIF �ɮ�;
+Content-Transfer-Encoding: base64
+Content-Location: file:///C:/ABWhiz41/images/itinlogo1.gif
+
+Ym9keQ==
+
+--embedded-boundary
+Content-type: text/plain; charset=us-ascii
+
+This part is also embedded
+--embedded-boundary--
+--simple boundary--
+This is the epilogue.  It is also to be ignored.
+`
+
+	parsed, err := NewParsedMessage([]byte(literal))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+}
+
+func TestParseInvalidMimeType(t* testing.T) {
+	const literal = `From: Nathaniel Borenstein <nsb@bellcore.com> 
+To:  Ned Freed <ned@innosoft.com> 
+Subject: Sample message 
+MIME-Version: 1.0 
+Content-type: multipart/mixed; boundary="simple boundary" 
+
+This is the preamble.  It is to be ignored, though it 
+is a handy place for mail composers to include an 
+explanatory note to non-MIME compliant readers. 
+--simple boundary
+Content-type: text/plain; charset=us-ascii
+
+This part does not end with a linebreak.
+--simple boundary
+Content-Disposition: attachment; filename=test.eml
+Content-Type: message/rfc822; name=test.eml
+X-Pm-Content-Encryption: on-import
+
+To: someone
+Subject: Fwd: embedded
+Content-type: multipart/mixed; boundary="embedded-boundary" 
+
+--embedded-boundary
+Content-Type: application/;
+Content-Transfer-Encoding: base64
+Content-Location: file:///C:/ABWhiz41/images/itinlogo1.gif
+
+Ym9keQ==
+
+--embedded-boundary
+Content-type: text/plain; charset=us-ascii
+
+This part is also embedded
+--embedded-boundary--
+--simple boundary--
+This is the epilogue.  It is also to be ignored.
+`
+
+	parsed, err := NewParsedMessage([]byte(literal))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+}

--- a/rfc822/mime.go
+++ b/rfc822/mime.go
@@ -3,6 +3,7 @@ package rfc822
 import (
 	"mime"
 	"strings"
+	"unicode"
 )
 
 // ParseMediaType parses a MIME media type.
@@ -43,7 +44,14 @@ func ParseMIMEType(val string) (MIMEType, map[string]string, error) {
 		val = string(TextPlain)
 	}
 
-	mimeType, mimeParams, err := ParseMediaType(val)
+	sanitized := strings.Map(func(r rune) rune {
+		if r > unicode.MaxASCII {
+			return -1
+		}
+		return r
+	}, val)
+
+	mimeType, mimeParams, err := ParseMediaType(sanitized)
 	if err != nil {
 		return "", nil, err
 	}

--- a/rfc822/parser.go
+++ b/rfc822/parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io"
 	"mime/quotedprintable"
 )
@@ -32,7 +33,16 @@ func (section *Section) ContentType() (MIMEType, map[string]string, error) {
 		return "", nil, err
 	}
 
-	return ParseMIMEType(header.Get("Content-Type"))
+	contentType := header.Get("Content-Type")
+
+	mimeType, values, err := ParseMIMEType(contentType)
+	if err != nil {
+		logrus.Warnf("Message contains invalid mime type: %v", contentType)
+
+		return "", nil, nil //nolint:nilerr
+	}
+
+	return mimeType, values, nil
 }
 
 func (section *Section) Header() []byte {


### PR DESCRIPTION
If we run into an invalid mime type do not block parsing and upload of the message. When this happen we simply report nothing as MIME type. This works as we only use this information internally to reply to FETCH BODY and BODYSTRUCTURE requests.

Finally we also ensure that the Content-Type value only contains valid ASCII characters before being processed.