### PR TITLE
fix(GODT-2218): Fix invalid UID/Seq ID Sequence range

### DIFF
--- a/benchmarks/gluon_bench/imap_benchmarks/append.go
+++ b/benchmarks/gluon_bench/imap_benchmarks/append.go
@@ -39,7 +39,8 @@ func (a *Append) Setup(ctx context.Context, addr net.Addr) error {
 }
 
 func (a *Append) TearDown(ctx context.Context, addr net.Addr) error {
-	return a.cleanupWithAddr(addr)
+	//return a.cleanupWithAddr(addr)
+	return nil
 }
 
 func (a *Append) Run(ctx context.Context, addr net.Addr) error {


### PR DESCRIPTION
Ensure that sequence set intervals with request interval "N:*" in a mailbox with N-1 messages behaves correctly.

Refactor some of the Snapshot to make it easier to test.