### PR TITLE
Test: Check for delete falg removal on duplication

### DIFF
--- a/internal/state/actions.go
+++ b/internal/state/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/ProtonMail/gluon/reporter"
+	"github.com/sirupsen/logrus"
 	"strings"
 	"time"
 
@@ -117,6 +118,8 @@ func (state *State) actionCreateMessage(
 				reporter.ExceptionWithContext(ctx, "Append to drafts must not return an existing RemoteID", nil)
 				return 0, fmt.Errorf("append to drafts returned an existing remote ID")
 			}
+
+			logrus.Debugf("Deduped message detected, adding existing %v message to mailbox instead.", internalID.ShortID())
 
 			result, err := state.actionAddMessagesToMailbox(ctx,
 				tx,

--- a/internal/state/mailbox.go
+++ b/internal/state/mailbox.go
@@ -197,6 +197,7 @@ func (m *Mailbox) AppendRegular(ctx context.Context, literal []byte, flags imap.
 			}); err != nil || message == nil {
 				logrus.WithError(err).Warn("The message has an unknown internal ID")
 			} else if !message.Deleted {
+				logrus.Debugf("Appending duplicate message with Internal ID:%v", msgID.ShortID())
 				// Only shuffle around messages that haven't been marked for deletion.
 				if res, err := db.WriteResult(ctx, m.state.db(), func(ctx context.Context, tx *ent.Tx) ([]db.UIDWithFlags, error) {
 					remoteID, err := db.GetMessageRemoteIDFromID(ctx, tx.Client(), msgID)


### PR DESCRIPTION
When receiving the same remote message ID or appending a message with a known internal ID, we should remote the delete flag from the original original message when it gets moved. This was working in Gluon but never tested for. This patch contains 2 tests that verify this behavior.