### PR TITLE
fix: Do not crash on out of order UID

### DIFF
--- a/internal/state/responders.go
+++ b/internal/state/responders.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+	"github.com/ProtonMail/gluon/reporter"
 	"sync"
 
 	"github.com/ProtonMail/gluon/imap"
@@ -93,7 +94,7 @@ type targetedExists struct {
 	originStateSet bool
 }
 
-func (u *targetedExists) handle(_ context.Context, snap *snapshot, stateID StateID) ([]response.Response, responderDBUpdate, error) {
+func (u *targetedExists) handle(ctx context.Context, snap *snapshot, stateID StateID) ([]response.Response, responderDBUpdate, error) {
 	if snap.hasMessage(u.resp.messageID.InternalID) {
 		return nil, nil, nil
 	}
@@ -107,6 +108,7 @@ func (u *targetedExists) handle(_ context.Context, snap *snapshot, stateID State
 
 	if u.originStateSet && u.originStateID == stateID {
 		if err := snap.appendMessage(u.resp.messageID, u.resp.messageUID, flags); err != nil {
+			reporter.ExceptionWithContext(ctx, "Failed to append message to snap via targetedExists", reporter.Context{"error": err})
 			return nil, nil, err
 		}
 	} else {

--- a/internal/state/snapshot_messages.go
+++ b/internal/state/snapshot_messages.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 )
 
+var ErrOutOfOrderUIDInsertion = fmt.Errorf("UIDs must be strictly ascending")
+
 // snapMsg is a single message inside a snapshot.
 type snapMsg struct {
 	ID        ids.MessageIDPair
@@ -45,9 +47,9 @@ func (list *snapMsgList) binarySearchByUID(uid imap.UID) (int, bool) {
 	return index, ok
 }
 
-func (list *snapMsgList) insert(msgID ids.MessageIDPair, msgUID imap.UID, flags imap.FlagSet) {
+func (list *snapMsgList) insert(msgID ids.MessageIDPair, msgUID imap.UID, flags imap.FlagSet) error {
 	if len(list.msg) > 0 && list.msg[len(list.msg)-1].UID >= msgUID {
-		panic("UIDs must be strictly ascending")
+		return ErrOutOfOrderUIDInsertion
 	}
 
 	snapMsg := &snapMsg{
@@ -60,6 +62,8 @@ func (list *snapMsgList) insert(msgID ids.MessageIDPair, msgUID imap.UID, flags 
 	list.msg = append(list.msg, snapMsg)
 
 	list.idx[msgID.InternalID] = snapMsg
+
+	return nil
 }
 
 func (list *snapMsgList) insertOutOfOrder(msgID ids.MessageIDPair, msgUID imap.UID, flags imap.FlagSet) {

--- a/internal/state/snapshot_messages_test.go
+++ b/internal/state/snapshot_messages_test.go
@@ -19,12 +19,12 @@ func TestMessages(t *testing.T) {
 	id5 := imap.NewInternalMessageID()
 	id6 := imap.NewInternalMessageID()
 
-	msg.insert(messageIDPair(id1, "1"), 10, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id2, "2"), 20, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id3, "3"), 30, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id4, "4"), 40, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id5, "5"), 50, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id6, "6"), 60, imap.NewFlagSet(imap.FlagSeen))
+	require.NoError(t, msg.insert(messageIDPair(id1, "1"), 10, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id2, "2"), 20, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id3, "3"), 30, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id4, "4"), 40, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id5, "5"), 50, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id6, "6"), 60, imap.NewFlagSet(imap.FlagSeen)))
 
 	msg.remove(id2)
 	msg.remove(id4)
@@ -85,12 +85,12 @@ func TestMessageUIDRange(t *testing.T) {
 	id5 := imap.NewInternalMessageID()
 	id6 := imap.NewInternalMessageID()
 
-	msg.insert(messageIDPair(id1, "1"), 10, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id2, "2"), 20, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id3, "3"), 30, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id4, "4"), 40, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id5, "5"), 50, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id6, "6"), 60, imap.NewFlagSet(imap.FlagSeen))
+	require.NoError(t, msg.insert(messageIDPair(id1, "1"), 10, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id2, "2"), 20, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id3, "3"), 30, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id4, "4"), 40, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id5, "5"), 50, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id6, "6"), 60, imap.NewFlagSet(imap.FlagSeen)))
 
 	// UIDRange Higher than maximum
 	{
@@ -141,8 +141,8 @@ func TestMessageRange1HigherThanMax(t *testing.T) {
 	id1 := imap.NewInternalMessageID()
 	id2 := imap.NewInternalMessageID()
 
-	msg.insert(messageIDPair(id1, "1"), 1, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id2, "2"), 2, imap.NewFlagSet(imap.FlagSeen))
+	require.NoError(t, msg.insert(messageIDPair(id1, "1"), 1, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id2, "2"), 2, imap.NewFlagSet(imap.FlagSeen)))
 
 	seqSetInterval := [][]string{{"3", "*"}}
 
@@ -173,8 +173,8 @@ func TestSnapListGetMessages(t *testing.T) {
 	id1 := imap.NewInternalMessageID()
 	id2 := imap.NewInternalMessageID()
 
-	msg.insert(messageIDPair(id1, "1"), 1, imap.NewFlagSet(imap.FlagSeen))
-	msg.insert(messageIDPair(id2, "2"), 2, imap.NewFlagSet(imap.FlagSeen))
+	require.NoError(t, msg.insert(messageIDPair(id1, "1"), 1, imap.NewFlagSet(imap.FlagSeen)))
+	require.NoError(t, msg.insert(messageIDPair(id2, "2"), 2, imap.NewFlagSet(imap.FlagSeen)))
 
 	{
 		seqSetInterval := [][]string{{"3", "*"}}


### PR DESCRIPTION
Gracefully handle the rare case that an out of order UID insertion can occur. Make a report in the two possible cases where this could take place.