### PR TITLE
fix(GODT-2202): Report update errors to connector

### DIFF
--- a/connector/dummy_test.go
+++ b/connector/dummy_test.go
@@ -28,7 +28,7 @@ func TestDummyConnector_validateUpdate(t *testing.T) {
 
 	go func() {
 		for update := range conn.GetUpdates() {
-			update.Done()
+			update.Done(nil)
 		}
 	}()
 

--- a/internal/backend/update_injector.go
+++ b/internal/backend/update_injector.go
@@ -62,6 +62,8 @@ func (u *updateInjector) forward(ctx context.Context, updateCh <-chan imap.Updat
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case update, ok := <-updateCh:
 			if !ok {
 				return
@@ -76,14 +78,14 @@ func (u *updateInjector) forward(ctx context.Context, updateCh <-chan imap.Updat
 }
 
 // send the update on the updates channel, optionally blocking until it has been processed.
-func (u *updateInjector) send(ctx context.Context, update imap.Update, withBlock ...bool) {
+func (u *updateInjector) send(ctx context.Context, update imap.Update) {
 	select {
 	case <-u.forwardQuitCh:
 		return
 
 	case u.updatesCh <- update:
-		if len(withBlock) > 0 && withBlock[0] {
-			update.WaitContext(ctx)
-		}
+
+	case <-ctx.Done():
+		return
 	}
 }

--- a/tests/imap_limits_test.go
+++ b/tests/imap_limits_test.go
@@ -46,6 +46,7 @@ func TestMaxUIDLimitRespected_Append(t *testing.T) {
 
 func TestMaxMessageLimitRespected_Copy(t *testing.T) {
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withIMAPLimits(testIMAPLimits())), func(client *client.Client, session *testSession) {
+		session.setUpdatesAllowedToFail("user", true)
 		require.NoError(t, client.Create("mbox1"))
 		require.NoError(t, doAppendWithClient(client, "mbox1", "To: Foo@bar.com", time.Now()))
 		require.NoError(t, doAppendWithClient(client, "INBOX", "To: Bar@bar.com", time.Now()))
@@ -57,6 +58,7 @@ func TestMaxMessageLimitRespected_Copy(t *testing.T) {
 
 func TestMaxUIDLimitRespected_Copy(t *testing.T) {
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withIMAPLimits(testIMAPLimits())), func(client *client.Client, session *testSession) {
+		session.setUpdatesAllowedToFail("user", true)
 		require.NoError(t, client.Create("mbox1"))
 		require.NoError(t, doAppendWithClient(client, "mbox1", "To: Foo@bar.com", time.Now()))
 		require.NoError(t, doAppendWithClient(client, "INBOX", "To: Bar@bar.com", time.Now()))
@@ -76,6 +78,7 @@ func TestMaxUIDLimitRespected_Copy(t *testing.T) {
 
 func TestMaxMessageLimitRespected_Move(t *testing.T) {
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withIMAPLimits(testIMAPLimits())), func(client *client.Client, session *testSession) {
+		session.setUpdatesAllowedToFail("user", true)
 		require.NoError(t, client.Create("mbox1"))
 		require.NoError(t, doAppendWithClient(client, "mbox1", "To: Foo@bar.com", time.Now()))
 		require.NoError(t, doAppendWithClient(client, "INBOX", "To: Bar@bar.com", time.Now()))
@@ -87,6 +90,7 @@ func TestMaxMessageLimitRespected_Move(t *testing.T) {
 
 func TestMaxUIDLimitRespected_Move(t *testing.T) {
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withIMAPLimits(testIMAPLimits())), func(client *client.Client, session *testSession) {
+		session.setUpdatesAllowedToFail("user", true)
 		require.NoError(t, client.Create("mbox1"))
 		require.NoError(t, doAppendWithClient(client, "mbox1", "To: Foo@bar.com", time.Now()))
 		require.NoError(t, doAppendWithClient(client, "INBOX", "To: Bar@bar.com", time.Now()))
@@ -106,6 +110,7 @@ func TestMaxUIDLimitRespected_Move(t *testing.T) {
 
 func TestMaxUIDValidityLimitRespected(t *testing.T) {
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t, withIMAPLimits(testIMAPLimits())), func(client *client.Client, session *testSession) {
+		session.setUpdatesAllowedToFail("user", true)
 		require.NoError(t, client.Create("mbox1"))
 		require.NoError(t, client.Delete("mbox1"))
 		require.Error(t, client.Create("mbox2"))

--- a/tests/recent_test.go
+++ b/tests/recent_test.go
@@ -80,9 +80,12 @@ func TestRecentAppend(t *testing.T) {
 }
 
 func TestRecentStore(t *testing.T) {
-	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, _ *testSession) {
+	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		mbox, done := c[1].doCreateTempDir()
-		defer done()
+		defer func() {
+			s.flush("user")
+			done()
+		}()
 
 		// Create a message in mbox.
 		c[1].doAppend(mbox, `To: 1@pm.me`).expect(`OK`)

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -51,6 +51,8 @@ type Connector interface {
 	Sync(context.Context) error
 
 	Flush()
+
+	SetUpdatesAllowedToFail(bool)
 }
 
 type testSession struct {
@@ -359,6 +361,10 @@ func (s *testSession) uidValidityBumped(user string) {
 
 func (s *testSession) flush(user string) {
 	s.conns[s.userIDs[user]].Flush()
+}
+
+func (s *testSession) setUpdatesAllowedToFail(user string, value bool) {
+	s.conns[s.userIDs[user]].SetUpdatesAllowedToFail(value)
 }
 
 func forMessageInMBox(rr io.Reader, fn func(messageDelimiter, literal []byte)) error {

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -313,6 +313,7 @@ func TestBatchMessageAddedWithMultipleFlags(t *testing.T) {
 func TestMessageCreatedWithIgnoreMissingMailbox(t *testing.T) {
 	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(c *client.Client, s *testSession) {
 		mailboxID := s.mailboxCreated("user", []string{"mbox"})
+		s.setUpdatesAllowedToFail("user", true)
 		{
 			// First round fails as a missing mailbox is not allowed.
 			s.messageCreatedWithMailboxes("user", []imap.MailboxID{mailboxID, "THIS MAILBOX DOES NOT EXISTS"}, []byte("To: Test"), time.Now())


### PR DESCRIPTION
When applying updates from the connector report the error, if any, via the channel the connector is using to wait for the update to complete its execution.

Extend the dummy connector with an option to allow updates to fail as it is impossible to avoid these under certain circumstances.