### PR TITLE
fix(GODT-2311): Add missing header to downloaded message.

### DIFF
--- a/tests/cache_reset_test.go
+++ b/tests/cache_reset_test.go
@@ -30,7 +30,7 @@ func TestFetchWhenFileDeletedFromCache(t *testing.T) {
 		newFetchCommand(t, client).withItems(goimap.FetchRFC822).fetch("1").forSeqNum(1, func(validator *validatorBuilder) {
 			validator.ignoreFlags()
 			validator.wantSectionString(goimap.FetchRFC822, func(t testing.TB, literal string) {
-				messageFromSection := skipGLUONHeader(literal)
+				messageFromSection := skipGLUONHeaderOrPanic(literal)
 				require.Equal(t, fullMessage, messageFromSection)
 			})
 		}).checkAndRequireMessageCount(1)


### PR DESCRIPTION
Gluon's internal ID header was not being applied to messages which are re-downloaded from the connector if they are not available in the local cache.