### PR TITLE
feat(GODT-2295): publish event when IMAP login fails.

### DIFF
--- a/events/login_failed.go
+++ b/events/login_failed.go
@@ -1,0 +1,8 @@
+package events
+
+type LoginFailed struct {
+	eventBase
+
+	SessionID int
+	Username  string
+}

--- a/internal/session/handle_login.go
+++ b/internal/session/handle_login.go
@@ -28,6 +28,11 @@ func (s *Session) handleLogin(ctx context.Context, tag string, cmd *proto.Login,
 
 	state, err := s.backend.GetState(ctx, cmd.GetUsername(), cmd.GetPassword(), s.sessionID)
 	if err != nil {
+		s.eventCh <- events.LoginFailed{
+			SessionID: s.sessionID,
+			Username:  cmd.GetUsername(),
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Whenever an IMAP login fails, a `LoginFailed` event will be published.