### PR TITLE
fix: Use os.Remove instead of os.RemoveAll for store files

### DIFF
--- a/store/disk.go
+++ b/store/disk.go
@@ -221,7 +221,7 @@ func (c *onDiskStore) Delete(messageIDs ...imap.InternalMessageID) error {
 	}
 
 	for _, messageID := range messageIDs {
-		if err := os.RemoveAll(filepath.Join(c.path, messageID.String())); err != nil {
+		if err := os.Remove(filepath.Join(c.path, messageID.String())); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
We don't need to pay the extra cost of directory clean up when we are only dealing with full file paths.