### PR TITLE
feat(GODT-1264): adds 'Hidden if empty' options for mailboxes.

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -19,8 +19,8 @@ type Connector interface {
 	// Note: this can get called from different go routines.
 	GetMessageLiteral(ctx context.Context, id imap.MessageID) ([]byte, error)
 
-	// IsMailboxVisible can be used to hide mailboxes from connected clients.
-	IsMailboxVisible(ctx context.Context, mboxID imap.MailboxID) bool
+	// GetMailboxVisibility can be used to retrieve the visibility of mailboxes for connected clients.
+	GetMailboxVisibility(ctx context.Context, mboxID imap.MailboxID) imap.MailboxVisibility
 
 	// UpdateMailboxName sets the name of the mailbox with the given ID.
 	UpdateMailboxName(ctx context.Context, mboxID imap.MailboxID, newName []string) error

--- a/imap/mailbox.go
+++ b/imap/mailbox.go
@@ -9,3 +9,11 @@ type Mailbox struct {
 }
 
 const Inbox = "INBOX"
+
+type MailboxVisibility int
+
+const (
+	Hidden MailboxVisibility = iota
+	Visible
+	HiddenIfEmpty
+)

--- a/internal/backend/state_connector_impl.go
+++ b/internal/backend/state_connector_impl.go
@@ -124,8 +124,8 @@ func (sc *stateConnectorImpl) SetMessagesFlagged(ctx context.Context, messageIDs
 	return sc.connector.MarkMessagesFlagged(ctx, messageIDs, flagged)
 }
 
-func (sc *stateConnectorImpl) IsMailboxVisible(ctx context.Context, id imap.MailboxID) bool {
-	return sc.connector.IsMailboxVisible(ctx, id)
+func (sc *stateConnectorImpl) GetMailboxVisibility(ctx context.Context, id imap.MailboxID) imap.MailboxVisibility {
+	return sc.connector.GetMailboxVisibility(ctx, id)
 }
 
 func (sc *stateConnectorImpl) getMetadataValue(key string) any {

--- a/internal/state/connector.go
+++ b/internal/state/connector.go
@@ -73,6 +73,6 @@ type Connector interface {
 	// SetMessagesFlagged marks the message with the given ID as seen or unseen.
 	SetMessagesFlagged(ctx context.Context, messageIDs []imap.MessageID, flagged bool) error
 
-	// IsMailboxVisible checks whether a mailbox is visible to a client.
-	IsMailboxVisible(ctx context.Context, id imap.MailboxID) bool
+	// GetMailboxVisibility retrieves the visibility status of a mailbox for a client.
+	GetMailboxVisibility(ctx context.Context, id imap.MailboxID) imap.MailboxVisibility
 }

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ProtonMail/gluon/imap"
 )
@@ -282,13 +283,18 @@ func TestListHiddenMailbox(t *testing.T) {
 		m3 := s.mailboxCreatedWithAttributes("user", []string{"Spam"}, imap.NewFlagSet())
 		s.mailboxCreatedWithAttributes("user", []string{"Kos"}, imap.NewFlagSet())
 		m4 := s.mailboxCreatedWithAttributes("user", []string{"Vsechny zpravy"}, imap.NewFlagSet())
+		m5 := s.mailboxCreatedWithAttributes("user", []string{"HiddenIfEmpty1"}, imap.NewFlagSet())
+		m6 := s.mailboxCreatedWithAttributes("user", []string{"HiddenIfEmpty2"}, imap.NewFlagSet())
+		msg1 := s.messageCreatedWithMailboxes("user", []imap.MailboxID{m5}, []byte("To: no-reply@pm.me"), time.Now())
 
 		{
 			connector := s.conns[s.userIDs["user"]]
-			connector.SetMailboxVisible(m1, false)
-			connector.SetMailboxVisible(m2, false)
-			connector.SetMailboxVisible(m3, false)
-			connector.SetMailboxVisible(m4, false)
+			connector.SetMailboxVisibility(m1, imap.Hidden)
+			connector.SetMailboxVisibility(m2, imap.Hidden)
+			connector.SetMailboxVisibility(m3, imap.Hidden)
+			connector.SetMailboxVisibility(m4, imap.Hidden)
+			connector.SetMailboxVisibility(m5, imap.HiddenIfEmpty)
+			connector.SetMailboxVisibility(m6, imap.HiddenIfEmpty)
 		}
 
 		c.C(`a list "" "*"`)
@@ -297,6 +303,20 @@ func TestListHiddenMailbox(t *testing.T) {
 			`* LIST (\Unmarked) "." "Odeslane"`,
 			`* LIST (\Unmarked) "." "Archiv"`,
 			`* LIST (\Unmarked) "." "Kos"`,
+			`* LIST (\Marked) "." "HiddenIfEmpty1"`,
+		)
+		c.OK(`a`)
+
+		s.messageRemoved("user", msg1, m5)
+		s.messageAdded("user", msg1, m6)
+
+		c.C(`a list "" "*"`)
+		c.S(
+			`* LIST (\Unmarked) "." "INBOX"`,
+			`* LIST (\Unmarked) "." "Odeslane"`,
+			`* LIST (\Unmarked) "." "Archiv"`,
+			`* LIST (\Unmarked) "." "Kos"`,
+			`* LIST (\Marked) "." "HiddenIfEmpty2"`,
 		)
 		c.OK(`a`)
 	})

--- a/tests/lsub_test.go
+++ b/tests/lsub_test.go
@@ -143,10 +143,10 @@ func TestLsubWithHiddenMailbox(t *testing.T) {
 
 		{
 			connector := s.conns[s.userIDs["user"]]
-			connector.SetMailboxVisible(m1, false)
-			connector.SetMailboxVisible(m2, false)
-			connector.SetMailboxVisible(m3, false)
-			connector.SetMailboxVisible(m4, false)
+			connector.SetMailboxVisibility(m1, imap.Hidden)
+			connector.SetMailboxVisibility(m2, imap.Hidden)
+			connector.SetMailboxVisibility(m3, imap.Hidden)
+			connector.SetMailboxVisibility(m4, imap.HiddenIfEmpty)
 		}
 
 		{

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -31,7 +31,7 @@ type Connector interface {
 
 	MailboxCreated(imap.Mailbox) error
 	MailboxDeleted(imap.MailboxID) error
-	SetMailboxVisible(imap.MailboxID, bool)
+	SetMailboxVisibility(imap.MailboxID, imap.MailboxVisibility)
 
 	SetAllowMessageCreateWithUnknownMailboxID(value bool)
 


### PR DESCRIPTION
The Connector 
`IsMailboxVisible(ctx context.Context, mboxID imap.MailboxID) bool`
has been changed to 
`GetMailboxVisibility(ctx context.Context, mboxID imap.MailboxID) imap.MailboxVisibility`
to allow to specify that a mailbox is to be hidden if empty.