### PR TITLE
feat(GODT-2201): Native GO IMAP Parser Foundations

### DIFF
--- a/imap/command/append.go
+++ b/imap/command/append.go
@@ -1,0 +1,92 @@
+package command
+
+import (
+	"fmt"
+	"github.com/ProtonMail/gluon/imap/parser"
+	"time"
+)
+
+type AppendCommand struct {
+	Mailbox  string
+	Flags    []string
+	DateTime time.Time
+	Literal  []byte
+}
+
+func (l AppendCommand) String() string {
+	return fmt.Sprintf("APPEND '%v' Flags='%v' DateTime='%v' Literal=%v",
+		l.Mailbox,
+		l.Flags,
+		l.DateTime,
+		l.Literal,
+	)
+}
+
+func (l AppendCommand) SanitizedString() string {
+	return fmt.Sprintf("APPEND '%v' Flags='%v' DateTime='%v'",
+		sanitizeString(l.Mailbox),
+		l.Flags,
+		l.DateTime,
+	)
+}
+
+func (l AppendCommand) HasDateTime() bool {
+	return l.DateTime != time.Time{}
+}
+
+type AppendCommandParser struct{}
+
+func (AppendCommandParser) FromParser(p *parser.Parser) (Payload, error) {
+	mailbox, err := p.ParseMailbox()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.Consume(parser.TokenTypeSP, "expected space after mailbox"); err != nil {
+		return nil, err
+	}
+
+	var appendFlags []string
+
+	// check if we have flags.
+	flagList, hasFlagList, err := p.TryParseFlagList()
+	if err != nil {
+		return nil, err
+	} else if hasFlagList {
+		appendFlags = flagList
+	}
+
+	if hasFlagList {
+		if err := p.Consume(parser.TokenTypeSP, "expected space after flag list"); err != nil {
+			return nil, err
+		}
+	}
+
+	var dateTime time.Time
+	// check date time.
+	if !p.Check(parser.TokenTypeLCurly) {
+		dt, err := ParseDateTime(p)
+		if err != nil {
+			return nil, err
+		}
+
+		dateTime = dt
+
+		if err := p.Consume(parser.TokenTypeSP, "expected space after flag list"); err != nil {
+			return nil, err
+		}
+	}
+
+	// read literal.
+	literal, err := p.ParseLiteral()
+	if err != nil {
+		return nil, err
+	}
+
+	return &AppendCommand{
+		Mailbox:  mailbox,
+		Literal:  literal,
+		Flags:    appendFlags,
+		DateTime: dateTime,
+	}, nil
+}

--- a/imap/command/append_test.go
+++ b/imap/command/append_test.go
@@ -1,0 +1,138 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/ProtonMail/gluon/imap/parser"
+	cppParser "github.com/ProtonMail/gluon/internal/parser"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func buildAppendDateTime(year int, month time.Month, day int, hour int, min int, sec int, zoneHour int, zoneMinutes int, negativeZone bool) time.Time {
+	zoneMultiplier := 1
+	if negativeZone {
+		zoneMultiplier = -1
+	}
+
+	zone := (zoneHour*3600 + zoneMinutes*60) * zoneMultiplier
+
+	location := time.FixedZone("zone", zone)
+
+	return time.Date(year, month, day, hour, min, sec, 0, location)
+}
+
+func TestParser_AppendCommandWithAllFields(t *testing.T) {
+	input := toIMAPLine(`A003 APPEND saved-messages (\Seen) "15-Nov-1984 13:37:01 +0730" {23}`, `My message body is here`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "A003", Payload: &AppendCommand{
+		Mailbox:  "saved-messages",
+		Flags:    []string{`\Seen`},
+		Literal:  []byte("My message body is here"),
+		DateTime: buildAppendDateTime(1984, time.November, 15, 13, 37, 1, 07, 30, false),
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "append", p.LastParsedCommand())
+	require.Equal(t, "A003", p.LastParsedTag())
+}
+
+func TestParser_AppendCommandWithLiteralOnly(t *testing.T) {
+	input := toIMAPLine(`A003 APPEND saved-messages {23}`, `My message body is here`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "A003", Payload: &AppendCommand{
+		Mailbox: "saved-messages",
+		Literal: []byte("My message body is here"),
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "append", p.LastParsedCommand())
+	require.Equal(t, "A003", p.LastParsedTag())
+}
+
+func TestParser_AppendCommandWithFlagAndLiteral(t *testing.T) {
+	input := toIMAPLine(`A003 APPEND saved-messages (\Seen) {23}`, `My message body is here`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "A003", Payload: &AppendCommand{
+		Mailbox: "saved-messages",
+		Flags:   []string{`\Seen`},
+		Literal: []byte("My message body is here"),
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "append", p.LastParsedCommand())
+	require.Equal(t, "A003", p.LastParsedTag())
+}
+
+func TestParser_AppendCommandWithDateTimeAndLiteral(t *testing.T) {
+	input := toIMAPLine(`A003 APPEND saved-messages "15-Nov-1984 13:37:01 +0730" {23}`, `My message body is here`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "A003", Payload: &AppendCommand{
+		Mailbox:  "saved-messages",
+		Literal:  []byte("My message body is here"),
+		DateTime: buildAppendDateTime(1984, time.November, 15, 13, 37, 1, 07, 30, false),
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "append", p.LastParsedCommand())
+	require.Equal(t, "A003", p.LastParsedTag())
+}
+
+func TestParser_AppendWithUTF8Literal(t *testing.T) {
+	const literal = `割ゃちとた紀別チノホコ隠面ノネシ披畑つ筋型菊ラ済百チユネ報能げほべえ一王ユサ禁未シムカ学康ほル退今ずはぞゃ宿理古えべにあ。民さぱをだ意宇りう医6通海ヘクヲ点71丈2社つぴげわ中知多ッ場親られ見要クラ著喜栄潟ぼゆラけ。著災ンう三育府能に汁裁ラヤユ哉能ルサレ開30被ちゃ英死オイ教禁能ふてっせ社化選市へす。`
+	input := toIMAPLine(fmt.Sprintf("A003 APPEND saved-messages (\\Seen) {%v}", len(literal)), literal)
+
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "A003", Payload: &AppendCommand{
+		Mailbox: "saved-messages",
+		Flags:   []string{`\Seen`},
+		Literal: []byte(literal),
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+}
+
+func BenchmarkParser_Append(b *testing.B) {
+	input := toIMAPLine(`A003 APPEND saved-messages (\Seen) {23}`, `My message body is here`)
+
+	for i := 0; i < b.N; i++ {
+		s := parser.NewScanner(bytes.NewReader(input))
+		p := NewParser(s)
+
+		_, err := p.Parse()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkParser_AppendCPP(b *testing.B) {
+	input := string(toIMAPLine(`A003 APPEND saved-messages (\Seen) {23}`, `04269a34-ad29-472c-9d5d-042a02b7fc0d`))
+
+	literalMap := cppParser.NewStringMap()
+
+	literalMap.Set("04269a34-ad29-472c-9d5d-042a02b7fc0d", "My message body is here")
+
+	for i := 0; i < b.N; i++ {
+		cppParser.Parse(input, literalMap, "/")
+	}
+}

--- a/imap/command/command.go
+++ b/imap/command/command.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"encoding/base64"
+	"github.com/ProtonMail/gluon/internal/hash"
+)
+
+type Payload interface {
+	String() string
+
+	// SanitizedString should return the command payload with all the sensitive information stripped out.
+	SanitizedString() string
+}
+
+func sanitizeString(s string) string {
+	return base64.StdEncoding.EncodeToString(hash.SHA256([]byte(s)))
+}
+
+type Command struct {
+	Tag     string
+	Payload Payload
+}

--- a/imap/command/date_time.go
+++ b/imap/command/date_time.go
@@ -1,0 +1,171 @@
+package command
+
+import (
+	"fmt"
+	"github.com/ProtonMail/gluon/imap/parser"
+	"time"
+)
+
+func ParseDateTime(p *parser.Parser) (time.Time, error) {
+	//  date-time       = DQUOTE date-day-fixed "-" date-month "-" date-year SP time SP zone DQUOTE
+	if err := p.Consume(parser.TokenTypeDQuote, `Expected '"' at start of date time`); err != nil {
+		return time.Time{}, err
+	}
+
+	dateDay, err := ParseDateDayFixed(p)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if err := p.Consume(parser.TokenTypeMinus, `Expected '-' after date day`); err != nil {
+		return time.Time{}, err
+	}
+
+	dateMonth, err := ParseDateMonth(p)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if err := p.Consume(parser.TokenTypeMinus, `Expected '-' after date month`); err != nil {
+		return time.Time{}, err
+	}
+
+	dateYear, err := ParseDateYear(p)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if err := p.Consume(parser.TokenTypeSP, `Expected space after date year`); err != nil {
+		return time.Time{}, err
+	}
+
+	timeHour, timeMin, timeSec, err := ParseTime(p)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if err := p.Consume(parser.TokenTypeSP, `Expected space after date time`); err != nil {
+		return time.Time{}, err
+	}
+
+	timeZone, err := ParseZone(p)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if err := p.Consume(parser.TokenTypeDQuote, `Expected '"' at end of date time`); err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Date(dateYear, dateMonth, dateDay, timeHour, timeMin, timeSec, 0, timeZone), nil
+}
+
+func ParseDateDayFixed(p *parser.Parser) (int, error) {
+	// date-day-fixed  = (SP DIGIT) / 2DIGIT
+	if ok, err := p.Matches(parser.TokenTypeSP); err != nil {
+		return 0, err
+	} else if ok {
+		if err := p.Consume(parser.TokenTypeDigit, "expected digit after space separated date day"); err != nil {
+			return 0, err
+		}
+
+		return parser.ByteToInt(p.PreviousToken().Value), nil
+	}
+
+	return p.ParseNumberN(2)
+}
+
+var dateMonthToInt = map[string]time.Month{
+	"Jan": time.January,
+	"Feb": time.February,
+	"Mar": time.March,
+	"Apr": time.April,
+	"May": time.May,
+	"Jun": time.June,
+	"Jul": time.July,
+	"Aug": time.August,
+	"Sep": time.September,
+	"Oct": time.October,
+	"Nov": time.November,
+	"Dec": time.December,
+}
+
+func ParseDateMonth(p *parser.Parser) (time.Month, error) {
+	month := make([]byte, 3)
+
+	for i := 0; i < 3; i++ {
+		if err := p.Consume(parser.TokenTypeChar, "unexpected character for date month"); err != nil {
+			return 0, err
+		}
+
+		month[i] = p.PreviousToken().Value
+	}
+
+	v, ok := dateMonthToInt[string(month)]
+	if !ok {
+		return 0, p.MakeError(fmt.Sprintf("invalid date month '%v'", string(month)))
+	}
+
+	return v, nil
+}
+
+func ParseDateYear(p *parser.Parser) (int, error) {
+	return p.ParseNumberN(4)
+}
+
+func ParseZone(p *parser.Parser) (*time.Location, error) {
+	multiplier := 1
+
+	if ok, err := p.Matches(parser.TokenTypePlus); err != nil {
+		return nil, err
+	} else if !ok {
+		if ok, err := p.Matches(parser.TokenTypeMinus); err != nil {
+			return nil, err
+		} else if ok {
+			multiplier = -1
+		} else {
+			return nil, p.MakeError("expected either '+' or '-' on time zone start")
+		}
+	}
+
+	zoneHour, err := p.ParseNumberN(2)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneMinute, err := p.ParseNumberN(2)
+	if err != nil {
+		return nil, err
+	}
+
+	zone := (zoneHour*3600 + zoneMinute*60) * multiplier
+
+	return time.FixedZone("zone", zone), nil
+}
+
+func ParseTime(p *parser.Parser) (int, int, int, error) {
+	hour, err := p.ParseNumberN(2)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	if err := p.Consume(parser.TokenTypeColon, "expected colon after hour component"); err != nil {
+		return 0, 0, 0, err
+	}
+
+	min, err := p.ParseNumberN(2)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	if err := p.Consume(parser.TokenTypeColon, "expected colon after minute component"); err != nil {
+		return 0, 0, 0, err
+	}
+
+	sec, err := p.ParseNumberN(2)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return hour, min, sec, nil
+}

--- a/imap/command/date_time_test.go
+++ b/imap/command/date_time_test.go
@@ -1,0 +1,37 @@
+package command
+
+import (
+	"bytes"
+	"github.com/ProtonMail/gluon/imap/parser"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestDateTimeParser(t *testing.T) {
+	input := []byte(`"15-Nov-1984 13:37:01 +0730"`)
+	expected := buildAppendDateTime(1984, time.November, 15, 13, 37, 1, 07, 30, false)
+
+	p := parser.NewParser(parser.NewScanner(bytes.NewReader(input)))
+	// Advance at least once to prepare first token.
+	err := p.Advance()
+	require.NoError(t, err)
+
+	dt, err := ParseDateTime(p)
+	require.NoError(t, err)
+	require.Equal(t, expected, dt)
+}
+
+func TestDateTimeParser_OneDayDigit(t *testing.T) {
+	input := []byte(`" 5-Nov-1984 13:37:01 -0730"`)
+	expected := buildAppendDateTime(1984, time.November, 5, 13, 37, 1, 07, 30, true)
+
+	p := parser.NewParser(parser.NewScanner(bytes.NewReader(input)))
+	// Advance at least once to prepare first token.
+	err := p.Advance()
+	require.NoError(t, err)
+
+	dt, err := ParseDateTime(p)
+	require.NoError(t, err)
+	require.Equal(t, expected, dt)
+}

--- a/imap/command/list.go
+++ b/imap/command/list.go
@@ -1,0 +1,69 @@
+package command
+
+import (
+	"fmt"
+	"github.com/ProtonMail/gluon/imap/parser"
+)
+
+type ListCommand struct {
+	Mailbox     string
+	ListMailbox string
+}
+
+func (l ListCommand) String() string {
+	return fmt.Sprintf("LIST '%v' '%v'", l.Mailbox, l.ListMailbox)
+}
+
+func (l ListCommand) SanitizedString() string {
+	return l.String()
+}
+
+type ListCommandParser struct{}
+
+func (ListCommandParser) FromParser(p *parser.Parser) (Payload, error) {
+	// list            = "LIST" SP mailbox SP list-mailbox
+	mailbox, err := p.ParseMailbox()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.Consume(parser.TokenTypeSP, "expected space after mailbox"); err != nil {
+		return nil, err
+	}
+
+	listMailbox, err := parseListMailbox(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListCommand{
+		Mailbox:     mailbox,
+		ListMailbox: listMailbox,
+	}, nil
+}
+
+func parseListMailbox(p *parser.Parser) (string, error) {
+	/*
+	  list-mailbox    = 1*list-char / string
+
+	  list-char       = ATOM-CHAR / list-wildcards / resp-specials
+
+	  list-wildcards  = "%" / "*"
+	*/
+	isListChar := func(tt parser.TokenType) bool {
+		return parser.IsAtomChar(tt) || parser.IsRespSpecial(tt) || tt == parser.TokenTypePercent || tt == parser.TokenTypeAsterisk
+	}
+
+	if ok, err := p.MatchesWith(isListChar); err != nil {
+		return "", err
+	} else if !ok {
+		return p.ParseString()
+	}
+
+	listMailbox, err := p.CollectBytesWhileMatchesWithPrevWith(isListChar)
+	if err != nil {
+		return "", err
+	}
+
+	return string(listMailbox), nil
+}

--- a/imap/command/list_test.go
+++ b/imap/command/list_test.go
@@ -1,0 +1,102 @@
+package command
+
+import (
+	"bytes"
+	"github.com/ProtonMail/gluon/imap/parser"
+	cppParser "github.com/ProtonMail/gluon/internal/parser"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParser_ListCommandQuoted(t *testing.T) {
+	input := toIMAPLine(`tag LIST "" "*"`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "tag", Payload: &ListCommand{
+		Mailbox:     "",
+		ListMailbox: "*",
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "list", p.LastParsedCommand())
+	require.Equal(t, "tag", p.LastParsedTag())
+}
+
+func TestParser_ListCommandSpecialAsterisk(t *testing.T) {
+	input := toIMAPLine(`tag LIST "foo" *`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "tag", Payload: &ListCommand{
+		Mailbox:     "foo",
+		ListMailbox: "*",
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "list", p.LastParsedCommand())
+	require.Equal(t, "tag", p.LastParsedTag())
+}
+
+func TestParser_ListCommandSpecialPercentage(t *testing.T) {
+	input := toIMAPLine(`tag LIST "bar" %`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	expected := Command{Tag: "tag", Payload: &ListCommand{
+		Mailbox:     "bar",
+		ListMailbox: "%",
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.Equal(t, "list", p.LastParsedCommand())
+	require.Equal(t, "tag", p.LastParsedTag())
+}
+
+func TestParser_ListCommandLiteral(t *testing.T) {
+	input := toIMAPLine(`tag LIST {5}`, `"bar" %`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	continuationCalled := false
+	p := NewParserWithLiteralContinuationCb(s, func() error {
+		continuationCalled = true
+		return nil
+	})
+	expected := Command{Tag: "tag", Payload: &ListCommand{
+		Mailbox:     `"bar"`,
+		ListMailbox: "%",
+	}}
+
+	cmd, err := p.Parse()
+	require.NoError(t, err)
+	require.Equal(t, expected, cmd)
+	require.True(t, continuationCalled)
+	require.Equal(t, "list", p.LastParsedCommand())
+	require.Equal(t, "tag", p.LastParsedTag())
+}
+
+func BenchmarkParser_ListCommand(b *testing.B) {
+	input := toIMAPLine(`tag LIST "bar" %`)
+
+	for i := 0; i < b.N; i++ {
+		s := parser.NewScanner(bytes.NewReader(input))
+		p := NewParser(s)
+
+		_, err := p.Parse()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkParser_ListCommandCPP(b *testing.B) {
+	input := string(toIMAPLine(`tag LIST "bar" %`))
+	literalMap := cppParser.NewStringMap()
+
+	for i := 0; i < b.N; i++ {
+		cppParser.Parse(input, literalMap, "/")
+	}
+}

--- a/imap/command/parser.go
+++ b/imap/command/parser.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"fmt"
+	"github.com/ProtonMail/gluon/imap/parser"
+)
+
+type Builder interface {
+	FromParser(p *parser.Parser) (Payload, error)
+}
+
+// Parser parses IMAP Commands.
+type Parser struct {
+	parser   *parser.Parser
+	commands map[string]Builder
+	lastTag  string
+	lastCmd  string
+}
+
+func NewParser(s *parser.Scanner) *Parser {
+	return NewParserWithLiteralContinuationCb(s, nil)
+}
+
+func NewParserWithLiteralContinuationCb(s *parser.Scanner, cb func() error) *Parser {
+	return &Parser{
+		parser: parser.NewParserWithLiteralContinuationCb(s, cb),
+		commands: map[string]Builder{
+			"list":   &ListCommandParser{},
+			"append": &AppendCommandParser{},
+		},
+	}
+}
+
+func (p *Parser) LastParsedTag() string {
+	return p.lastTag
+}
+
+func (p *Parser) LastParsedCommand() string {
+	return p.lastCmd
+}
+
+func (p *Parser) Parse() (Command, error) {
+	result := Command{}
+
+	p.lastTag = ""
+	p.lastCmd = ""
+	p.parser.ResetOffsetCounter()
+
+	if err := p.parser.Advance(); err != nil {
+		return result, err
+	}
+
+	tag, err := p.parseTag()
+	if err != nil {
+		return result, err
+	}
+
+	result.Tag = tag
+	p.lastTag = tag
+
+	if err := p.parser.Consume(parser.TokenTypeSP, "Expected space after tag"); err != nil {
+		return result, err
+	}
+
+	payload, err := p.parseCommand()
+	if err != nil {
+		return result, err
+	}
+
+	result.Payload = payload
+
+	if err := p.parser.ConsumeNewLine(); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (p *Parser) parseCommand() (Payload, error) {
+	var commandBytes []byte
+
+	for {
+		if ok, err := p.parser.Matches(parser.TokenTypeChar); err != nil {
+			return nil, err
+		} else if ok {
+			commandBytes = append(commandBytes, parser.ByteToLower(p.parser.PreviousToken().Value))
+		} else {
+			break
+		}
+	}
+
+	p.lastCmd = string(commandBytes)
+
+	if err := p.parser.Consume(parser.TokenTypeSP, "expected space after command"); err != nil {
+		return nil, err
+	}
+
+	builder, ok := p.commands[p.lastCmd]
+	if !ok {
+		return nil, fmt.Errorf("unknown command '%v'", p.lastCmd)
+	}
+
+	return builder.FromParser(p.parser)
+}
+
+func (p *Parser) parseTag() (string, error) {
+	// tag             = 1*<any ASTRING-CHAR except "+">
+	isTagChar := func(tt parser.TokenType) bool {
+		return parser.IsAStringChar(tt) && tt != parser.TokenTypePlus
+	}
+
+	if err := p.parser.ConsumeWith(isTagChar, "Invalid tag char detected"); err != nil {
+		return "", err
+	}
+
+	tag, err := p.parser.CollectBytesWhileMatchesWithPrevWith(isTagChar)
+	if err != nil {
+		return "", err
+	}
+
+	return string(tag), err
+}

--- a/imap/command/parser_test.go
+++ b/imap/command/parser_test.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"bytes"
+	"github.com/ProtonMail/gluon/imap/parser"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func toIMAPLine(string ...string) []byte {
+	var result []byte
+
+	for _, v := range string {
+		result = append(result, []byte(v)...)
+		result = append(result, '\r', '\n')
+	}
+
+	return result
+}
+
+func TestParser_InvalidTag(t *testing.T) {
+	input := []byte(`+tag LIST "" "*"`)
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	_, err := p.Parse()
+	require.Error(t, err)
+	require.Empty(t, p.LastParsedCommand())
+	require.Empty(t, p.LastParsedTag())
+}
+
+func TestParser_TestEof(t *testing.T) {
+	var input []byte
+	s := parser.NewScanner(bytes.NewReader(input))
+	p := NewParser(s)
+
+	_, err := p.Parse()
+	require.Error(t, err)
+	require.True(t, parser.IsError(err))
+	parserError, ok := err.(*parser.Error) //nolint:errorlint
+	require.True(t, ok)
+	require.True(t, parserError.IsEOF())
+}

--- a/imap/parser/parser.go
+++ b/imap/parser/parser.go
@@ -1,0 +1,538 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Parser provide facilities to consumes tokens from a given scanner. Advance should be called at least once before
+// any checks in order to initialize the previousToken.
+type Parser struct {
+	scanner               *Scanner
+	literalContinuationCb func() error
+	previousToken         Token
+	currentToken          Token
+}
+
+type Error struct {
+	Token   Token
+	Message string
+}
+
+func (p *Error) Error() string {
+	return fmt.Sprintf("[Error offset=%v]: %v", p.Token.Offset, p.Message)
+}
+
+func (p *Error) IsEOF() bool {
+	return p.Token.TType == TokenTypeEOF
+}
+
+func IsError(err error) bool {
+	var perr *Error
+	return errors.As(err, &perr)
+}
+
+func NewParser(s *Scanner) *Parser {
+	return &Parser{scanner: s}
+}
+
+func NewParserWithLiteralContinuationCb(s *Scanner, f func() error) *Parser {
+	return &Parser{scanner: s, literalContinuationCb: f,
+		previousToken: Token{
+			TType:  TokenTypeEOF,
+			Value:  0,
+			Offset: 0,
+		},
+		currentToken: Token{
+			TType:  TokenTypeEOF,
+			Value:  0,
+			Offset: 0,
+		}}
+}
+
+// ParseAString parses an astring according to RFC3501.
+func (p *Parser) ParseAString() (string, error) {
+	/*
+		astring         = 1*ASTRING-CHAR / string
+	*/
+	if p.Check(TokenTypeDQuote) || p.Check(TokenTypeLCurly) {
+		return p.ParseString()
+	}
+
+	astring, err := p.CollectBytesWhileMatchesWith(IsAStringChar)
+	if err != nil {
+		return "", err
+	}
+
+	return string(astring), nil
+}
+
+// ParseString parses a string according to RFC3501.
+func (p *Parser) ParseString() (string, error) {
+	/*
+		string          = quoted / literal
+	*/
+	if p.Check(TokenTypeDQuote) {
+		return p.ParseQuoted()
+	} else if p.Check(TokenTypeLCurly) {
+		l, err := p.ParseLiteral()
+		if err != nil {
+			return "", err
+		}
+		return string(l), err
+	}
+
+	return "", fmt.Errorf("unexpected character, expected start of quote or literal")
+}
+
+// ParseQuoted parses a quoted string.
+func (p *Parser) ParseQuoted() (string, error) {
+	/*
+		quoted          = DQUOTE *QUOTED-CHAR DQUOTE
+
+		QUOTED-CHAR     = <any TEXT-CHAR except quoted-specials> /
+		                  "\" quoted-specials
+	*/
+	if err := p.Consume(TokenTypeDQuote, `Expected '"' for quoted start`); err != nil {
+		return "", err
+	}
+
+	var quoted []byte
+
+	for {
+		if ok, err := p.MatchesWith(IsQuotedChar); err != nil {
+			return "", err
+		} else if ok {
+			quoted = append(quoted, p.previousToken.Value)
+		} else {
+			if ok, err := p.Matches(TokenTypeBackslash); err != nil {
+				return "", err
+			} else if ok {
+				if err := p.ConsumeWith(IsQuotedSpecial, `Expected '\' or '"' after '\' in quoted`); err != nil {
+					return "", err
+				}
+				quoted = append(quoted, p.previousToken.Value)
+			} else {
+				break
+			}
+		}
+	}
+
+	if err := p.Consume(TokenTypeDQuote, `Expected '"' for quoted end`); err != nil {
+		return "", err
+	}
+
+	return string(quoted), nil
+}
+
+// ParseLiteral parses a literal as defined in RFC3501.
+func (p *Parser) ParseLiteral() ([]byte, error) {
+	/*
+		literal         = "{" number "}" CRLF *CHAR8
+	*/
+	if err := p.Consume(TokenTypeLCurly, "expected '{' for literal start"); err != nil {
+		return nil, err
+	}
+
+	literalSize, err := p.ParseNumber()
+	if err != nil {
+		return nil, err
+	}
+
+	if literalSize <= 0 {
+		return nil, fmt.Errorf("invalid literal size")
+	}
+
+	if literalSize >= 30*1024*1024 {
+		return nil, fmt.Errorf("literal size exceeds maximum size of 30MB")
+	}
+
+	if err := p.Consume(TokenTypeRCurly, "expected '}' for literal end"); err != nil {
+		return nil, err
+	}
+
+	if err := p.ConsumeNewLine(); err != nil {
+		return nil, err
+	}
+
+	if p.literalContinuationCb != nil {
+		if err := p.literalContinuationCb(); err != nil {
+			return nil, fmt.Errorf("error occurred during literal continuation callback:%w", err)
+		}
+	}
+
+	literal := make([]byte, literalSize)
+
+	if err := p.scanner.ConsumeBytes(literal); err != nil {
+		return nil, err
+	}
+
+	// Need to advance parser after scanning literal so that next token is loaded
+	if err := p.Advance(); err != nil {
+		return nil, err
+	}
+
+	return literal, nil
+}
+
+// ParseMailbox parses a mailbox name as defined in RFC 3501.
+func (p *Parser) ParseMailbox() (string, error) {
+	// mailbox = "INBOX" / astring
+	astring, err := p.ParseAString()
+	if err != nil {
+		return "", err
+	}
+
+	if strings.EqualFold(astring, "INBOX") {
+		return "INBOX", nil
+	}
+
+	return astring, nil
+}
+
+// ParseNumber parses a non decimal number without any signs.
+func (p *Parser) ParseNumber() (int, error) {
+	if err := p.Consume(TokenTypeDigit, "expected valid digit for number"); err != nil {
+		return 0, err
+	}
+
+	number := ByteToInt(p.previousToken.Value)
+
+	for {
+		if ok, err := p.Matches(TokenTypeDigit); err != nil {
+			return 0, err
+		} else if ok {
+			number *= 10
+			number += ByteToInt(p.previousToken.Value)
+		} else {
+			break
+		}
+	}
+
+	return number, nil
+}
+
+// ParseNumberN parses a non decimal with N digits.
+func (p *Parser) ParseNumberN(n int) (int, error) {
+	if n == 0 {
+		return 0, p.MakeError("requested ParserNumberN with 0 length number")
+	}
+
+	if err := p.Consume(TokenTypeDigit, "expected valid digit for number"); err != nil {
+		return 0, err
+	}
+
+	number := ByteToInt(p.previousToken.Value)
+
+	for i := 0; i < n-1; i++ {
+		if ok, err := p.Matches(TokenTypeDigit); err != nil {
+			return 0, err
+		} else if ok {
+			number *= 10
+			number += ByteToInt(p.previousToken.Value)
+		} else {
+			break
+		}
+	}
+
+	return number, nil
+}
+
+func (p *Parser) TryParseFlagList() ([]string, bool, error) {
+	if !p.Check(TokenTypeLParen) {
+		return nil, false, nil
+	}
+
+	flags, err := p.ParseFlagList()
+
+	return flags, true, err
+}
+
+func (p *Parser) ParseFlagList() ([]string, error) {
+	// flag-list       = "(" [flag *(SP flag)] ")"
+	var flags []string
+
+	if err := p.Consume(TokenTypeLParen, "Expected '(' at start of flag list"); err != nil {
+		return nil, err
+	}
+
+	{
+		firstFlag, err := p.ParseFlag()
+		if err != nil {
+			return nil, err
+		}
+		flags = append(flags, firstFlag)
+	}
+
+	for {
+		if ok, err := p.Matches(TokenTypeSP); err != nil {
+			return nil, err
+		} else if !ok {
+			break
+		}
+
+		flag, err := p.ParseFlag()
+		if err != nil {
+			return nil, err
+		}
+
+		flags = append(flags, flag)
+	}
+
+	if err := p.Consume(TokenTypeRParen, "Expected ')' at end of flag list"); err != nil {
+		return nil, err
+	}
+
+	return flags, nil
+}
+
+func (p *Parser) ParseFlag() (string, error) {
+	/*
+	 flag            = "\Answered" / "\Flagged" / "\Deleted" /
+	                   "\Seen" / "\Draft" / flag-keyword / flag-extension
+	                     ; Does not include "\Recent"
+
+	 flag-extension  = "\" atom
+	                     ; Future expansion.  Client implementations
+	                     ; MUST accept flag-extension flags.  Server
+	                     ; implementations MUST NOT generate
+	                     ; flag-extension flags except as defined by
+	                     ; future standard or standards-track
+	                     ; revisions of this specification.
+
+	 flag-keyword    = atom
+	*/
+	hasBackslash, err := p.Matches(TokenTypeBackslash)
+	if err != nil {
+		return "", err
+	}
+
+	if hasBackslash {
+		flag, err := p.ParseAtom()
+		if err != nil {
+			return "", err
+		}
+
+		if strings.EqualFold(flag, "recent") {
+			return "", p.MakeError("Recent Flag is not allowed in this context")
+		}
+
+		return fmt.Sprintf("\\%v", flag), nil
+	}
+
+	return p.ParseAtom()
+}
+
+func (p *Parser) ParseAtom() (string, error) {
+	if err := p.ConsumeWith(IsAtomChar, "Invalid character detected in atom"); err != nil {
+		return "", err
+	}
+
+	atom, err := p.CollectBytesWhileMatchesWithPrevWith(IsAtomChar)
+	if err != nil {
+		return "", err
+	}
+
+	return string(atom), nil
+}
+
+// Check if the next token matches the given input.
+func (p *Parser) Check(tokenType TokenType) bool {
+	return p.currentToken.TType == tokenType
+}
+
+// CheckWith checks if the next token matches the given condition.
+func (p *Parser) CheckWith(f func(tokenType TokenType) bool) bool {
+	return f(p.currentToken.TType)
+}
+
+// ConsumeNewLine issues two Consume calls for the `CRLF` token sequence.
+func (p *Parser) ConsumeNewLine() error {
+	if err := p.Consume(TokenTypeCR, "expected CR"); err != nil {
+		return err
+	}
+
+	if err := p.Consume(TokenTypeLF, "expected LF after CR"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Consume will advance the scanner to the next token if the current token matches the given token. If current
+// token does not match, an error with given message will be returned.
+func (p *Parser) Consume(tokenType TokenType, message string) error {
+	return p.ConsumeWith(func(token TokenType) bool {
+		return token == tokenType
+	}, message)
+}
+
+// ConsumeWith will advance the scanner to the next token if the current token matches the given condition. If current
+// token does not match, an error with given message will be returned.
+func (p *Parser) ConsumeWith(f func(token TokenType) bool, message string) error {
+	if f(p.currentToken.TType) {
+		return p.Advance()
+	}
+
+	return p.MakeError(message)
+}
+
+// MatchesWith will advance the scanner to the next token and return true if the current token matches the given
+// condition.
+func (p *Parser) MatchesWith(f func(tokenType TokenType) bool) (bool, error) {
+	if !p.CheckWith(f) {
+		return false, nil
+	}
+
+	err := p.Advance()
+
+	return true, err
+}
+
+// Matches will advance the scanner to the next token and return true if the current token matches the given tokenType.
+func (p *Parser) Matches(tokenType TokenType) (bool, error) {
+	if !p.Check(tokenType) {
+		return false, nil
+	}
+
+	err := p.Advance()
+
+	return true, err
+}
+
+// Advance advances the scanner to the next token.
+func (p *Parser) Advance() error {
+	p.previousToken = p.currentToken
+
+	nextToken, err := p.scanner.ScanToken()
+	if err != nil {
+		return err
+	}
+
+	p.currentToken = nextToken
+
+	return nil
+}
+
+// CollectBytesWhileMatchesWithPrev collects bytes from the token scanner while tokens match the given token type.
+// This function INCLUDES the previous token consumed before this call.
+func (p *Parser) CollectBytesWhileMatchesWithPrev(tokenType TokenType) ([]byte, error) {
+	return p.CollectBytesWhileMatchesWithPrevWith(func(tt TokenType) bool {
+		return tt == tokenType
+	})
+}
+
+// CollectBytesWhileMatchesWithPrevWith collects bytes from the token scanner while tokens match the given condition.
+// This function INCLUDES the previous token consumed before this call.
+func (p *Parser) CollectBytesWhileMatchesWithPrevWith(f func(tokenType TokenType) bool) ([]byte, error) {
+	value := []byte{p.previousToken.Value}
+
+	for {
+		if ok, err := p.MatchesWith(f); err != nil {
+			return nil, err
+		} else if ok {
+			value = append(value, p.previousToken.Value)
+		} else {
+			break
+		}
+	}
+
+	return value, nil
+}
+
+// CollectBytesWhileMatches collects bytes from the token scanner while tokens match the given token type. This function
+// DOES NOT INCLUDE the previous token consumed before this call.
+func (p *Parser) CollectBytesWhileMatches(tokenType TokenType) ([]byte, error) {
+	return p.CollectBytesWhileMatchesWith(func(tt TokenType) bool {
+		return tt == tokenType
+	})
+}
+
+// CollectBytesWhileMatchesWith collects bytes from the token scanner while tokens match the given condition. This
+// function DOES NOT INCLUDE the previous token consumed before this call.
+func (p *Parser) CollectBytesWhileMatchesWith(f func(tokenType TokenType) bool) ([]byte, error) {
+	var value []byte
+
+	for {
+		if ok, err := p.MatchesWith(f); err != nil {
+			return nil, err
+		} else if ok {
+			value = append(value, p.previousToken.Value)
+		} else {
+			break
+		}
+	}
+
+	return value, nil
+}
+
+// ResetOffsetCounter resets the token offset back to 0.
+func (p *Parser) ResetOffsetCounter() {
+	p.scanner.ResetOffsetCounter()
+}
+
+func (p *Parser) PreviousToken() Token {
+	return p.previousToken
+}
+
+func (p *Parser) CurrentToken() Token {
+	return p.currentToken
+}
+
+func (p *Parser) MakeError(err string) error {
+	return &Error{
+		Token:   p.previousToken,
+		Message: err,
+	}
+}
+
+func IsAStringChar(tokenType TokenType) bool {
+	/*
+		ASTRING-CHAR   = ATOM-CHAR / resp-specials
+	*/
+	return IsAtomChar(tokenType) || IsRespSpecial(tokenType)
+}
+
+func IsAtomChar(tokenType TokenType) bool {
+	/*
+		ATOM-CHAR       = <any CHAR except atom-specials>
+
+		atom-specials   = "(" / ")" / "{" / SP / CTL / list-wildcards /
+		                  quoted-specials / resp-specials
+	*/
+	switch tokenType { //nolint:exhaustive
+	case TokenTypeLParen:
+		fallthrough
+	case TokenTypeRParen:
+		fallthrough
+	case TokenTypeLBracket:
+		fallthrough
+	case TokenTypeEOF:
+		fallthrough
+	case TokenTypeSP:
+		return false
+	}
+
+	return !IsQuotedSpecial(tokenType) && !IsRespSpecial(tokenType) && !IsCTL(tokenType)
+}
+
+func IsQuotedSpecial(tokenType TokenType) bool {
+	return tokenType == TokenTypeDQuote || tokenType == TokenTypeBackslash
+}
+
+func IsRespSpecial(tokenType TokenType) bool {
+	return tokenType == TokenTypeRBracket
+}
+
+func IsQuotedChar(tokenType TokenType) bool {
+	return !IsQuotedSpecial(tokenType)
+}
+
+func IsCTL(tokenType TokenType) bool {
+	return tokenType == TokenTypeCTL || tokenType == TokenTypeCR || tokenType == TokenTypeLF
+}
+
+func ByteToInt(b byte) int {
+	return int(b) - int(byte('0'))
+}

--- a/imap/parser/parser_test.go
+++ b/imap/parser/parser_test.go
@@ -1,0 +1,149 @@
+package parser
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func newTestParser(input []byte) *Parser {
+	p := NewParser(NewScanner(bytes.NewReader(input)))
+	if err := p.Advance(); err != nil {
+		panic("Could not advance parser to first token")
+	}
+
+	return p
+}
+
+func TestParser_ParseNumber(t *testing.T) {
+	input := []byte(`1024`)
+	p := newTestParser(input)
+
+	v, err := p.ParseNumber()
+	require.NoError(t, err)
+	require.Equal(t, 1024, v)
+}
+
+func TestParser_ParseNumberInvalid(t *testing.T) {
+	inputs := [][]byte{
+		[]byte(`-1`),
+		[]byte(`.1`),
+		[]byte(`a`),
+		[]byte(`+1`),
+	}
+	for _, i := range inputs {
+		p := newTestParser(i)
+
+		_, err := p.ParseNumber()
+		require.Error(t, err)
+	}
+}
+
+func TestParser_ParseQuoted(t *testing.T) {
+	values := map[string]string{
+		`"hello world 10234"`:  `hello world 10234`,
+		`"h\"b\"c"`:            `h"b"c`,
+		`"\\{}@foo&^*(#$!<>="`: `\{}@foo&^*(#$!<>=`,
+	}
+
+	for input, expected := range values {
+		p := newTestParser([]byte(input))
+		v, err := p.ParseQuoted()
+		require.NoError(t, err)
+		require.Equal(t, expected, v)
+	}
+}
+
+func TestParser_ParseQuotedInvalid(t *testing.T) {
+	inputs := [][]byte{
+		[]byte(`"foo`),
+		[]byte(`"x\f"`),
+		[]byte(`"\/"'`),
+		[]byte(`foo"'`),
+	}
+	for _, i := range inputs {
+		p := newTestParser(i)
+
+		_, err := p.ParseNumber()
+		require.Error(t, err)
+	}
+}
+
+func TestParser_ParseString(t *testing.T) {
+	// Strings are either quoted or literals.
+	values := map[string]string{
+		`"hello world 10234"`: `hello world 10234`,
+		"{5}\r\n01234":        `01234`,
+	}
+
+	for input, expected := range values {
+		p := newTestParser([]byte(input))
+		v, err := p.ParseString()
+		require.NoError(t, err)
+		require.Equal(t, expected, v)
+	}
+}
+
+func TestParser_ParseLiteral(t *testing.T) {
+	// Strings are either quoted or literals.
+	values := map[string]string{
+		"{5}\r\n h123": ` h123`,
+		"{6}\r\n你好":    `你好`,
+	}
+
+	for input, expected := range values {
+		p := newTestParser([]byte(input))
+		v, err := p.ParseLiteral()
+		require.NoError(t, err)
+		require.Equal(t, []byte(expected), v)
+	}
+}
+
+func TestParser_ParseAString(t *testing.T) {
+	values := map[string]string{
+		"{5}\r\n h123":         ` h123`,
+		"{6}\r\n你好":            `你好`,
+		`"hello world 10234"`:  `hello world 10234`,
+		`"h\"b\"c"`:            `h"b"c`,
+		`"\\{}@foo&^*(#$!<>="`: `\{}@foo&^*(#$!<>=`,
+		`hello_world`:          `hello_world`,
+		`hello-1234`:           `hello-1234`,
+	}
+
+	for input, expected := range values {
+		p := newTestParser([]byte(input))
+		v, err := p.ParseAString()
+		require.NoError(t, err)
+		require.Equal(t, expected, v)
+	}
+}
+
+func TestParser_ParseFlagList(t *testing.T) {
+	values := map[string][]string{
+		`(\Answered)`:                {`\Answered`},
+		`(\Answered Foo \Something)`: {`\Answered`, `Foo`, `\Something`},
+	}
+
+	for input, expected := range values {
+		p := newTestParser([]byte(input))
+		v, err := p.ParseFlagList()
+		require.NoError(t, err)
+		require.Equal(t, expected, v)
+	}
+}
+
+func TestParser_ParseFlagListInvalid(t *testing.T) {
+	inputs := [][]byte{
+		[]byte(`()`),
+		[]byte(`(\Foo\Bar)`),
+		[]byte(`"(\Recent)`),
+		[]byte(`(\Foo )`),
+		[]byte(`(\Foo`),
+	}
+	for _, i := range inputs {
+		p := newTestParser(i)
+
+		_, err := p.ParseNumber()
+		require.Error(t, err)
+	}
+}

--- a/imap/parser/scanner.go
+++ b/imap/parser/scanner.go
@@ -1,0 +1,249 @@
+package parser
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+type TokenType int
+
+const (
+	TokenTypeEOF TokenType = iota
+	TokenTypeSP
+	TokenTypeExclamation
+	TokenTypeDQuote
+	TokenTypeHash
+	TokenTypeDollar
+	TokenTypePercent
+	TokenTypeAmpersand
+	TokenTypeSQuote
+	TokenTypeLParen
+	TokenTypeRParen
+	TokenTypeAsterisk
+	TokenTypePlus
+	TokenTypeComma
+	TokenTypeMinus
+	TokenTypePeriod
+	TokenTypeSlash
+	TokenTypeSemicolon
+	TokenTypeColon
+	TokenTypeLess
+	TokenTypeEqual
+	TokenTypeGreater
+	TokenTypeQuestion
+	TokenTypeAt
+	TokenTypeLBracket
+	TokenTypeRBracket
+	TokenTypeCaret
+	TokenTypeUnderscore
+	TokenTyeBacktick
+	TokenTypeLCurly
+	TokenTypePipe
+	TokenTypeRCurly
+	TokenTypeTilde
+	TokenTypeBackslash
+	TokenTypeDigit
+	TokenTypeChar
+	TokenTypeExtendedChar
+	TokenTypeCR
+	TokenTypeLF
+	TokenTypeCTL
+)
+
+type Token struct {
+	TType  TokenType
+	Value  byte
+	Offset int
+}
+
+type Scanner struct {
+	source      *bufio.Reader
+	currentByte byte
+	offset      int
+}
+
+func NewScanner(source io.Reader) *Scanner {
+	return &Scanner{
+		source: bufio.NewReader(source),
+	}
+}
+
+func (s *Scanner) ConsumeBytes(dst []byte) error {
+	// We have already read a byte at this point, so we need to
+	// skip this one.
+	dst[0] = s.currentByte
+
+	if _, err := io.ReadFull(s.source, dst[1:]); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return io.EOF
+		}
+
+		return err
+	}
+
+	s.offset += len(dst) - 1
+
+	return nil
+}
+
+func (s *Scanner) ScanToken() (Token, error) {
+	b, err := s.advance()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return s.makeEOF(), nil
+		}
+
+		return Token{}, nil
+	}
+
+	if isByteDigit(b) {
+		return s.makeToken(TokenTypeDigit), nil
+	}
+
+	if isByteAlpha(b) {
+		return s.makeToken(TokenTypeChar), nil
+	}
+
+	if isByteExtendedChar(b) {
+		return s.makeToken(TokenTypeExtendedChar), nil
+	}
+
+	if isByteCTL(b) {
+		if b == '\r' {
+			return s.makeToken(TokenTypeCR), nil
+		} else if b == '\n' {
+			return s.makeToken(TokenTypeLF), nil
+		}
+
+		return s.makeToken(TokenTypeCTL), nil
+	}
+
+	switch b {
+	case ' ':
+		return s.makeToken(TokenTypeSP), nil
+	case '!':
+		return s.makeToken(TokenTypeExclamation), nil
+	case '"':
+		return s.makeToken(TokenTypeDQuote), nil
+	case '#':
+		return s.makeToken(TokenTypeHash), nil
+	case '$':
+		return s.makeToken(TokenTypeDollar), nil
+	case '%':
+		return s.makeToken(TokenTypePercent), nil
+	case '&':
+		return s.makeToken(TokenTypeAmpersand), nil
+	case '\'':
+		return s.makeToken(TokenTypeSQuote), nil
+	case '\\':
+		return s.makeToken(TokenTypeBackslash), nil
+	case '(':
+		return s.makeToken(TokenTypeLParen), nil
+	case ')':
+		return s.makeToken(TokenTypeRParen), nil
+	case '*':
+		return s.makeToken(TokenTypeAsterisk), nil
+	case '+':
+		return s.makeToken(TokenTypePlus), nil
+	case ',':
+		return s.makeToken(TokenTypeComma), nil
+	case '-':
+		return s.makeToken(TokenTypeMinus), nil
+	case '.':
+		return s.makeToken(TokenTypePeriod), nil
+	case '/':
+		return s.makeToken(TokenTypeSlash), nil
+	case ':':
+		return s.makeToken(TokenTypeColon), nil
+	case ';':
+		return s.makeToken(TokenTypeSemicolon), nil
+	case '<':
+		return s.makeToken(TokenTypeLess), nil
+	case '=':
+		return s.makeToken(TokenTypeEqual), nil
+	case '>':
+		return s.makeToken(TokenTypeGreater), nil
+	case '?':
+		return s.makeToken(TokenTypeQuestion), nil
+	case '@':
+		return s.makeToken(TokenTypeAt), nil
+	case '[':
+		return s.makeToken(TokenTypeLBracket), nil
+	case ']':
+		return s.makeToken(TokenTypeRBracket), nil
+	case '^':
+		return s.makeToken(TokenTypeCaret), nil
+	case '_':
+		return s.makeToken(TokenTypeUnderscore), nil
+	case '`':
+		return s.makeToken(TokenTyeBacktick), nil
+	case '{':
+		return s.makeToken(TokenTypeLCurly), nil
+	case '|':
+		return s.makeToken(TokenTypePipe), nil
+	case '}':
+		return s.makeToken(TokenTypeRCurly), nil
+	case '~':
+		return s.makeToken(TokenTypeTilde), nil
+	}
+
+	return Token{}, fmt.Errorf("unexpected character %v", b)
+}
+
+func (s *Scanner) ResetOffsetCounter() {
+	s.offset = 0
+}
+
+func (s *Scanner) advance() (byte, error) {
+	b, err := s.source.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+
+	s.currentByte = b
+	s.offset += 1
+
+	return b, nil
+}
+
+func (s *Scanner) makeToken(t TokenType) Token {
+	return Token{
+		TType:  t,
+		Value:  s.currentByte,
+		Offset: s.offset,
+	}
+}
+
+func (s *Scanner) makeEOF() Token {
+	return Token{
+		TType:  TokenTypeEOF,
+		Value:  0,
+		Offset: s.offset,
+	}
+}
+
+func isByteAlpha(b byte) bool {
+	return (b >= 65 && b <= 90) || (b >= 97 && b <= 122)
+}
+
+func isByteDigit(b byte) bool {
+	return b >= byte('0') && b <= byte('9')
+}
+
+func isByteExtendedChar(b byte) bool {
+	return b >= 128
+}
+
+func isByteCTL(b byte) bool {
+	return b <= 31
+}
+
+func ByteToLower(b byte) byte {
+	if b >= 65 && b <= 90 {
+		return 97 + (b - byte(65))
+	}
+
+	return b
+}


### PR DESCRIPTION
Lay the foundations for native parsers in Go so we can move away from the C++ libraries.

This patch sets up the foundations to convert the remaining commands to this new format. At the moment the List and Append command have been ported and should serve as an example for the remaining commands.

More commands will follow in future patches.