### PR TITLE
refactor(GODT-2201): Drop Command suffix from all IMAP commands

### DIFF
--- a/imap/command/append.go
+++ b/imap/command/append.go
@@ -6,14 +6,14 @@ import (
 	"time"
 )
 
-type AppendCommand struct {
+type Append struct {
 	Mailbox  string
 	Flags    []string
 	DateTime time.Time
 	Literal  []byte
 }
 
-func (l AppendCommand) String() string {
+func (l Append) String() string {
 	return fmt.Sprintf("APPEND '%v' Flags='%v' DateTime='%v' Literal=%v",
 		l.Mailbox,
 		l.Flags,
@@ -22,7 +22,7 @@ func (l AppendCommand) String() string {
 	)
 }
 
-func (l AppendCommand) SanitizedString() string {
+func (l Append) SanitizedString() string {
 	return fmt.Sprintf("APPEND '%v' Flags='%v' DateTime='%v'",
 		sanitizeString(l.Mailbox),
 		l.Flags,
@@ -30,7 +30,7 @@ func (l AppendCommand) SanitizedString() string {
 	)
 }
 
-func (l AppendCommand) HasDateTime() bool {
+func (l Append) HasDateTime() bool {
 	return l.DateTime != time.Time{}
 }
 
@@ -87,7 +87,7 @@ func (AppendCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &AppendCommand{
+	return &Append{
 		Mailbox:  mailbox.Value,
 		Literal:  literal,
 		Flags:    appendFlags,

--- a/imap/command/append_test.go
+++ b/imap/command/append_test.go
@@ -28,7 +28,7 @@ func TestParser_AppendCommandWithAllFields(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "A003", Payload: &AppendCommand{
+	expected := Command{Tag: "A003", Payload: &Append{
 		Mailbox:  "saved-messages",
 		Flags:    []string{`\Seen`},
 		Literal:  []byte("My message body is here"),
@@ -47,7 +47,7 @@ func TestParser_AppendCommandWithLiteralOnly(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "A003", Payload: &AppendCommand{
+	expected := Command{Tag: "A003", Payload: &Append{
 		Mailbox: "saved-messages",
 		Literal: []byte("My message body is here"),
 	}}
@@ -64,7 +64,7 @@ func TestParser_AppendCommandWithFlagAndLiteral(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "A003", Payload: &AppendCommand{
+	expected := Command{Tag: "A003", Payload: &Append{
 		Mailbox: "saved-messages",
 		Flags:   []string{`\Seen`},
 		Literal: []byte("My message body is here"),
@@ -82,7 +82,7 @@ func TestParser_AppendCommandWithDateTimeAndLiteral(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "A003", Payload: &AppendCommand{
+	expected := Command{Tag: "A003", Payload: &Append{
 		Mailbox:  "saved-messages",
 		Literal:  []byte("My message body is here"),
 		DateTime: buildAppendDateTime(1984, time.November, 15, 13, 37, 1, 07, 30, false),
@@ -102,7 +102,7 @@ func TestParser_AppendWithUTF8Literal(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "A003", Payload: &AppendCommand{
+	expected := Command{Tag: "A003", Payload: &Append{
 		Mailbox: "saved-messages",
 		Flags:   []string{`\Seen`},
 		Literal: []byte(literal),

--- a/imap/command/capability.go
+++ b/imap/command/capability.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type CapabilityCommand struct{}
+type Capability struct{}
 
-func (l CapabilityCommand) String() string {
+func (l Capability) String() string {
 	return fmt.Sprintf("CAPABILITY")
 }
 
-func (l CapabilityCommand) SanitizedString() string {
+func (l Capability) SanitizedString() string {
 	return l.String()
 }
 
 type CapabilityCommandParser struct{}
 
 func (CapabilityCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &CapabilityCommand{}, nil
+	return &Capability{}, nil
 }

--- a/imap/command/capability_test.go
+++ b/imap/command/capability_test.go
@@ -12,7 +12,7 @@ func TestParser_CapabilityCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &CapabilityCommand{}}
+	expected := Command{Tag: "tag", Payload: &Capability{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/check.go
+++ b/imap/command/check.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type CheckCommand struct{}
+type Check struct{}
 
-func (l CheckCommand) String() string {
+func (l Check) String() string {
 	return fmt.Sprintf("CHECK")
 }
 
-func (l CheckCommand) SanitizedString() string {
+func (l Check) SanitizedString() string {
 	return l.String()
 }
 
 type CheckCommandParser struct{}
 
 func (CheckCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &CheckCommand{}, nil
+	return &Check{}, nil
 }

--- a/imap/command/check_test.go
+++ b/imap/command/check_test.go
@@ -12,7 +12,7 @@ func TestParser_CheckCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &CheckCommand{}}
+	expected := Command{Tag: "tag", Payload: &Check{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/close.go
+++ b/imap/command/close.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type CloseCommand struct{}
+type Close struct{}
 
-func (l CloseCommand) String() string {
+func (l Close) String() string {
 	return fmt.Sprintf("CLOSE")
 }
 
-func (l CloseCommand) SanitizedString() string {
+func (l Close) SanitizedString() string {
 	return l.String()
 }
 
 type CloseCommandParser struct{}
 
 func (CloseCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &CloseCommand{}, nil
+	return &Close{}, nil
 }

--- a/imap/command/close_test.go
+++ b/imap/command/close_test.go
@@ -12,7 +12,7 @@ func TestParser_CloseCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &CloseCommand{}}
+	expected := Command{Tag: "tag", Payload: &Close{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/copy.go
+++ b/imap/command/copy.go
@@ -5,16 +5,16 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type CopyCommand struct {
+type Copy struct {
 	SeqSet  []SeqRange
 	Mailbox string
 }
 
-func (l CopyCommand) String() string {
+func (l Copy) String() string {
 	return fmt.Sprintf("COPY %v '%v'", l.SeqSet, l.Mailbox)
 }
 
-func (l CopyCommand) SanitizedString() string {
+func (l Copy) SanitizedString() string {
 	return fmt.Sprintf("COPY %v '%v'", l.SeqSet, sanitizeString(l.Mailbox))
 }
 
@@ -40,7 +40,7 @@ func (CopyCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &CopyCommand{
+	return &Copy{
 		SeqSet:  seqSet,
 		Mailbox: mailbox.Value,
 	}, nil

--- a/imap/command/copy_test.go
+++ b/imap/command/copy_test.go
@@ -12,7 +12,7 @@ func TestParser_CopyCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &CopyCommand{
+	expected := Command{Tag: "tag", Payload: &Copy{
 		Mailbox: "INBOX",
 		SeqSet:  []SeqRange{{Begin: 1, End: SeqNumValueAsterisk}},
 	}}

--- a/imap/command/create.go
+++ b/imap/command/create.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type CreateCommand struct {
+type Create struct {
 	Mailbox string
 }
 
-func (l CreateCommand) String() string {
+func (l Create) String() string {
 	return fmt.Sprintf("CREATE '%v'", l.Mailbox)
 }
 
-func (l CreateCommand) SanitizedString() string {
+func (l Create) SanitizedString() string {
 	return fmt.Sprintf("CREATE '%v'", sanitizeString(l.Mailbox))
 }
 
@@ -30,7 +30,7 @@ func (CreateCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &CreateCommand{
+	return &Create{
 		Mailbox: mailbox.Value,
 	}, nil
 }

--- a/imap/command/create_test.go
+++ b/imap/command/create_test.go
@@ -12,7 +12,7 @@ func TestParser_CreateCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &CreateCommand{
+	expected := Command{Tag: "tag", Payload: &Create{
 		Mailbox: "INBOX",
 	}}
 

--- a/imap/command/delete.go
+++ b/imap/command/delete.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type DeleteCommand struct {
+type Delete struct {
 	Mailbox string
 }
 
-func (l DeleteCommand) String() string {
+func (l Delete) String() string {
 	return fmt.Sprintf("DELETE '%v'", l.Mailbox)
 }
 
-func (l DeleteCommand) SanitizedString() string {
+func (l Delete) SanitizedString() string {
 	return fmt.Sprintf("DELETE '%v'", sanitizeString(l.Mailbox))
 }
 
@@ -30,7 +30,7 @@ func (DeleteCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &DeleteCommand{
+	return &Delete{
 		Mailbox: mailbox.Value,
 	}, nil
 }

--- a/imap/command/delete_test.go
+++ b/imap/command/delete_test.go
@@ -12,7 +12,7 @@ func TestParser_DeleteCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &DeleteCommand{
+	expected := Command{Tag: "tag", Payload: &Delete{
 		Mailbox: "INBOX",
 	}}
 

--- a/imap/command/done.go
+++ b/imap/command/done.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 )
 
-type DoneCommand struct{}
+type Done struct{}
 
-func (l DoneCommand) String() string {
+func (l Done) String() string {
 	return fmt.Sprintf("DONE")
 }
 
-func (l DoneCommand) SanitizedString() string {
+func (l Done) SanitizedString() string {
 	return l.String()
 }

--- a/imap/command/done_test.go
+++ b/imap/command/done_test.go
@@ -12,7 +12,7 @@ func TestParser_DoneCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "", Payload: &DoneCommand{}}
+	expected := Command{Tag: "", Payload: &Done{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/examine.go
+++ b/imap/command/examine.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type ExamineCommand struct {
+type Examine struct {
 	Mailbox string
 }
 
-func (l ExamineCommand) String() string {
+func (l Examine) String() string {
 	return fmt.Sprintf("EXAMINE '%v'", l.Mailbox)
 }
 
-func (l ExamineCommand) SanitizedString() string {
+func (l Examine) SanitizedString() string {
 	return fmt.Sprintf("EXAMINE '%v'", sanitizeString(l.Mailbox))
 }
 
@@ -30,7 +30,7 @@ func (ExamineCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &ExamineCommand{
+	return &Examine{
 		Mailbox: mailbox.Value,
 	}, nil
 }

--- a/imap/command/examine_test.go
+++ b/imap/command/examine_test.go
@@ -12,7 +12,7 @@ func TestParser_ExamineCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &ExamineCommand{
+	expected := Command{Tag: "tag", Payload: &Examine{
 		Mailbox: "INBOX",
 	}}
 

--- a/imap/command/expunge.go
+++ b/imap/command/expunge.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type ExpungeCommand struct{}
+type Expunge struct{}
 
-func (l ExpungeCommand) String() string {
+func (l Expunge) String() string {
 	return fmt.Sprintf("EXPUNGE")
 }
 
-func (l ExpungeCommand) SanitizedString() string {
+func (l Expunge) SanitizedString() string {
 	return l.String()
 }
 
 type ExpungeCommandParser struct{}
 
 func (ExpungeCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &ExpungeCommand{}, nil
+	return &Expunge{}, nil
 }

--- a/imap/command/expunge_test.go
+++ b/imap/command/expunge_test.go
@@ -12,7 +12,7 @@ func TestParser_ExpungeCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &ExpungeCommand{}}
+	expected := Command{Tag: "tag", Payload: &Expunge{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/fetch.go
+++ b/imap/command/fetch.go
@@ -10,16 +10,16 @@ type FetchAttribute interface {
 	String() string
 }
 
-type FetchCommand struct {
+type Fetch struct {
 	SeqSet     []SeqRange
 	Attributes []FetchAttribute
 }
 
-func (f FetchCommand) String() string {
+func (f Fetch) String() string {
 	return fmt.Sprintf("FETCH %v %v", f.SeqSet, f.Attributes)
 }
 
-func (f FetchCommand) SanitizedString() string {
+func (f Fetch) SanitizedString() string {
 	return f.String()
 }
 
@@ -75,7 +75,7 @@ func (FetchCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		}
 	}
 
-	return &FetchCommand{SeqSet: seqSet, Attributes: attributes}, nil
+	return &Fetch{SeqSet: seqSet, Attributes: attributes}, nil
 }
 
 func parseFetchAttributeName(p *rfcparser.Parser) (string, error) {

--- a/imap/command/fetch_test.go
+++ b/imap/command/fetch_test.go
@@ -13,7 +13,7 @@ func TestParser_FetchCommandAll(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeAll{},
@@ -28,7 +28,7 @@ func TestParser_FetchCommandAll(t *testing.T) {
 }
 
 func TestParser_FetchCommandFull(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeFull{},
@@ -41,7 +41,7 @@ func TestParser_FetchCommandFull(t *testing.T) {
 }
 
 func TestParser_FetchCommandFast(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeFast{},
@@ -54,7 +54,7 @@ func TestParser_FetchCommandFast(t *testing.T) {
 }
 
 func TestParser_FetchCommandEnvelope(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeEnvelope{},
@@ -67,7 +67,7 @@ func TestParser_FetchCommandEnvelope(t *testing.T) {
 }
 
 func TestParser_FetchCommandFlags(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeFlags{},
@@ -80,7 +80,7 @@ func TestParser_FetchCommandFlags(t *testing.T) {
 }
 
 func TestParser_FetchCommandInternalDate(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeInternalDate{},
@@ -93,7 +93,7 @@ func TestParser_FetchCommandInternalDate(t *testing.T) {
 }
 
 func TestParser_FetchCommandRFC822Header(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeRFC822Header{},
@@ -106,7 +106,7 @@ func TestParser_FetchCommandRFC822Header(t *testing.T) {
 }
 
 func TestParser_FetchCommandRFC822Size(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeRFC822Size{},
@@ -119,7 +119,7 @@ func TestParser_FetchCommandRFC822Size(t *testing.T) {
 }
 
 func TestParser_FetchCommandRFC822Text(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeRFC822Text{},
@@ -132,7 +132,7 @@ func TestParser_FetchCommandRFC822Text(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodyStructure(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodyStructure{},
@@ -145,7 +145,7 @@ func TestParser_FetchCommandBodyStructure(t *testing.T) {
 }
 
 func TestParser_FetchCommandBody(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBody{},
@@ -158,7 +158,7 @@ func TestParser_FetchCommandBody(t *testing.T) {
 }
 
 func TestParser_FetchCommandUID(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeUID{},
@@ -171,7 +171,7 @@ func TestParser_FetchCommandUID(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_Empty(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -188,7 +188,7 @@ func TestParser_FetchCommandBodySection_Empty(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_Header(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -205,7 +205,7 @@ func TestParser_FetchCommandBodySection_Header(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_Text(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -222,7 +222,7 @@ func TestParser_FetchCommandBodySection_Text(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_HeaderFieldsSingular(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -242,7 +242,7 @@ func TestParser_FetchCommandBodySection_HeaderFieldsSingular(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_HeaderFieldsMultiple(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -262,7 +262,7 @@ func TestParser_FetchCommandBodySection_HeaderFieldsMultiple(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_HeaderFieldsNot(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -287,7 +287,7 @@ func TestParser_FetchCommandBodySection_MIMEIsErrorWithoutPart(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_MIME(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -307,7 +307,7 @@ func TestParser_FetchCommandBodySection_MIME(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_PartWithSectionMsgText(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -327,7 +327,7 @@ func TestParser_FetchCommandBodySection_PartWithSectionMsgText(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_Partial(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -347,7 +347,7 @@ func TestParser_FetchCommandBodySection_Partial(t *testing.T) {
 }
 
 func TestParser_FetchCommandBodySection_Peek(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 1, End: 1}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeBodySection{
@@ -364,7 +364,7 @@ func TestParser_FetchCommandBodySection_Peek(t *testing.T) {
 }
 
 func TestParser_FetchCommandMultiple(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &FetchCommand{
+	expected := Command{Tag: "tag", Payload: &Fetch{
 		SeqSet: []SeqRange{{Begin: 2, End: 4}},
 		Attributes: []FetchAttribute{
 			&FetchAttributeFlags{},

--- a/imap/command/idle.go
+++ b/imap/command/idle.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type IdleCommand struct{}
+type Idle struct{}
 
-func (l IdleCommand) String() string {
+func (l Idle) String() string {
 	return fmt.Sprintf("IDLE")
 }
 
-func (l IdleCommand) SanitizedString() string {
+func (l Idle) SanitizedString() string {
 	return l.String()
 }
 
 type IdleCommandParser struct{}
 
 func (IdleCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &IdleCommand{}, nil
+	return &Idle{}, nil
 }

--- a/imap/command/idle_test.go
+++ b/imap/command/idle_test.go
@@ -12,7 +12,7 @@ func TestParser_IdleCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &IdleCommand{}}
+	expected := Command{Tag: "tag", Payload: &Idle{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/list.go
+++ b/imap/command/list.go
@@ -5,16 +5,16 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type ListCommand struct {
+type List struct {
 	Mailbox     string
 	ListMailbox string
 }
 
-func (l ListCommand) String() string {
+func (l List) String() string {
 	return fmt.Sprintf("LIST '%v' '%v'", l.Mailbox, l.ListMailbox)
 }
 
-func (l ListCommand) SanitizedString() string {
+func (l List) SanitizedString() string {
 	return l.String()
 }
 
@@ -40,7 +40,7 @@ func (ListCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &ListCommand{
+	return &List{
 		Mailbox:     mailbox.Value,
 		ListMailbox: listMailbox.Value,
 	}, nil

--- a/imap/command/list_test.go
+++ b/imap/command/list_test.go
@@ -13,7 +13,7 @@ func TestParser_ListCommandQuoted(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &ListCommand{
+	expected := Command{Tag: "tag", Payload: &List{
 		Mailbox:     "",
 		ListMailbox: "*",
 	}}
@@ -30,7 +30,7 @@ func TestParser_ListCommandSpecialAsterisk(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &ListCommand{
+	expected := Command{Tag: "tag", Payload: &List{
 		Mailbox:     "foo",
 		ListMailbox: "*",
 	}}
@@ -47,7 +47,7 @@ func TestParser_ListCommandSpecialPercentage(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &ListCommand{
+	expected := Command{Tag: "tag", Payload: &List{
 		Mailbox:     "bar",
 		ListMailbox: "%",
 	}}
@@ -67,7 +67,7 @@ func TestParser_ListCommandLiteral(t *testing.T) {
 		continuationCalled = true
 		return nil
 	})
-	expected := Command{Tag: "tag", Payload: &ListCommand{
+	expected := Command{Tag: "tag", Payload: &List{
 		Mailbox:     `"bar"`,
 		ListMailbox: "%",
 	}}

--- a/imap/command/login.go
+++ b/imap/command/login.go
@@ -5,16 +5,16 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type LoginCommand struct {
+type Login struct {
 	UserID   string
 	Password string
 }
 
-func (l LoginCommand) String() string {
+func (l Login) String() string {
 	return fmt.Sprintf("LOGIN '%v' '%v'", l.UserID, l.Password)
 }
 
-func (l LoginCommand) SanitizedString() string {
+func (l Login) SanitizedString() string {
 	return fmt.Sprintf("LOGIN '%v' <PASSWORD>", sanitizeString(l.UserID))
 }
 
@@ -42,7 +42,7 @@ func (LoginCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &LoginCommand{
+	return &Login{
 		UserID:   user.Value,
 		Password: password.Value,
 	}, nil

--- a/imap/command/login_test.go
+++ b/imap/command/login_test.go
@@ -12,7 +12,7 @@ func TestParser_LoginCommandQuoted(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &LoginCommand{
+	expected := Command{Tag: "tag", Payload: &Login{
 		UserID:   "foo",
 		Password: "bar",
 	}}

--- a/imap/command/logout.go
+++ b/imap/command/logout.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type LogoutCommand struct{}
+type Logout struct{}
 
-func (l LogoutCommand) String() string {
+func (l Logout) String() string {
 	return fmt.Sprintf("LOGOUT")
 }
 
-func (l LogoutCommand) SanitizedString() string {
+func (l Logout) SanitizedString() string {
 	return l.String()
 }
 
 type LogoutCommandParser struct{}
 
 func (LogoutCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &LogoutCommand{}, nil
+	return &Logout{}, nil
 }

--- a/imap/command/logout_test.go
+++ b/imap/command/logout_test.go
@@ -12,7 +12,7 @@ func TestParser_LogoutCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &LogoutCommand{}}
+	expected := Command{Tag: "tag", Payload: &Logout{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/lsub.go
+++ b/imap/command/lsub.go
@@ -5,16 +5,16 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type LSubCommand struct {
+type LSub struct {
 	Mailbox     string
 	LSubMailbox string
 }
 
-func (l LSubCommand) String() string {
+func (l LSub) String() string {
 	return fmt.Sprintf("LSUB '%v' '%v'", l.Mailbox, l.LSubMailbox)
 }
 
-func (l LSubCommand) SanitizedString() string {
+func (l LSub) SanitizedString() string {
 	return l.String()
 }
 
@@ -40,7 +40,7 @@ func (LSubCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &LSubCommand{
+	return &LSub{
 		Mailbox:     mailbox.Value,
 		LSubMailbox: listMailbox.Value,
 	}, nil

--- a/imap/command/lsub_test.go
+++ b/imap/command/lsub_test.go
@@ -12,7 +12,7 @@ func TestParser_LSubCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &LSubCommand{
+	expected := Command{Tag: "tag", Payload: &LSub{
 		Mailbox:     "",
 		LSubMailbox: "*",
 	}}
@@ -29,7 +29,7 @@ func TestParser_LSubCommandSpecialAsterisk(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &LSubCommand{
+	expected := Command{Tag: "tag", Payload: &LSub{
 		Mailbox:     "foo",
 		LSubMailbox: "*",
 	}}
@@ -46,7 +46,7 @@ func TestParser_LSubCommandSpecialPercentage(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &LSubCommand{
+	expected := Command{Tag: "tag", Payload: &LSub{
 		Mailbox:     "bar",
 		LSubMailbox: "%",
 	}}

--- a/imap/command/move.go
+++ b/imap/command/move.go
@@ -5,16 +5,16 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type MoveCommand struct {
+type Move struct {
 	SeqSet  []SeqRange
 	Mailbox string
 }
 
-func (l MoveCommand) String() string {
+func (l Move) String() string {
 	return fmt.Sprintf("MOVE %v '%v'", l.SeqSet, l.Mailbox)
 }
 
-func (l MoveCommand) SanitizedString() string {
+func (l Move) SanitizedString() string {
 	return fmt.Sprintf("MOVE %v '%v'", l.SeqSet, sanitizeString(l.Mailbox))
 }
 
@@ -40,7 +40,7 @@ func (MoveCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &MoveCommand{
+	return &Move{
 		SeqSet:  seqSet,
 		Mailbox: mailbox.Value,
 	}, nil

--- a/imap/command/move_test.go
+++ b/imap/command/move_test.go
@@ -12,7 +12,7 @@ func TestParser_MoveCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &MoveCommand{
+	expected := Command{Tag: "tag", Payload: &Move{
 		Mailbox: "INBOX",
 		SeqSet:  []SeqRange{{Begin: 1, End: SeqNumValueAsterisk}},
 	}}

--- a/imap/command/noop.go
+++ b/imap/command/noop.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type NoopCommand struct{}
+type Noop struct{}
 
-func (l NoopCommand) String() string {
+func (l Noop) String() string {
 	return fmt.Sprintf("NOOP")
 }
 
-func (l NoopCommand) SanitizedString() string {
+func (l Noop) SanitizedString() string {
 	return l.String()
 }
 
 type NoopCommandParser struct{}
 
 func (NoopCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &NoopCommand{}, nil
+	return &Noop{}, nil
 }

--- a/imap/command/noop_test.go
+++ b/imap/command/noop_test.go
@@ -12,7 +12,7 @@ func TestParser_NoopCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &NoopCommand{}}
+	expected := Command{Tag: "tag", Payload: &Noop{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/parser.go
+++ b/imap/command/parser.go
@@ -88,7 +88,7 @@ func (p *Parser) Parse() (Command, error) {
 
 		return Command{
 			Tag:     "",
-			Payload: &DoneCommand{},
+			Payload: &Done{},
 		}, nil
 	}
 

--- a/imap/command/rename.go
+++ b/imap/command/rename.go
@@ -5,16 +5,16 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type RenameCommand struct {
+type Rename struct {
 	From string
 	To   string
 }
 
-func (l RenameCommand) String() string {
+func (l Rename) String() string {
 	return fmt.Sprintf("RENAME '%v' '%v'", l.From, l.To)
 }
 
-func (l RenameCommand) SanitizedString() string {
+func (l Rename) SanitizedString() string {
 	return fmt.Sprintf("RENAME '%v' '%v'", sanitizeString(l.From), sanitizeString(l.To))
 }
 
@@ -40,7 +40,7 @@ func (RenameCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &RenameCommand{
+	return &Rename{
 		From: mailboxFrom.Value,
 		To:   mailboxTo.Value,
 	}, nil

--- a/imap/command/rename_test.go
+++ b/imap/command/rename_test.go
@@ -12,7 +12,7 @@ func TestParser_RenameCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &RenameCommand{
+	expected := Command{Tag: "tag", Payload: &Rename{
 		From: "Foo",
 		To:   "Bar",
 	}}

--- a/imap/command/search.go
+++ b/imap/command/search.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-type SearchCommand struct {
+type Search struct {
 	Charset string
 	Keys    []SearchKey
 }
@@ -17,7 +17,7 @@ type SearchKey interface {
 	SanitizedString() string
 }
 
-func (s SearchCommand) String() string {
+func (s Search) String() string {
 	charsetStr := "NONE"
 	if len(s.Charset) != 0 {
 		charsetStr = s.Charset
@@ -26,7 +26,7 @@ func (s SearchCommand) String() string {
 	return fmt.Sprintf("SEARCH CHARSET=%v %v", charsetStr, s.Keys)
 }
 
-func (s SearchCommand) SanitizedString() string {
+func (s Search) SanitizedString() string {
 	charsetStr := "NONE"
 	if len(s.Charset) != 0 {
 		charsetStr = s.Charset
@@ -90,7 +90,7 @@ func (scp *SearchCommandParser) FromParser(p *rfcparser.Parser) (Payload, error)
 		return nil, fmt.Errorf("no search keys specified")
 	}
 
-	return &SearchCommand{
+	return &Search{
 		Charset: charset,
 		Keys:    keys,
 	}, nil

--- a/imap/command/search_test.go
+++ b/imap/command/search_test.go
@@ -15,7 +15,7 @@ func buildSearchTestDate(year int, month time.Month, day int) time.Time {
 }
 
 func TestParser_SearchCommandAll(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyAll{},
@@ -34,7 +34,7 @@ func TestParser_SearchCommandAll(t *testing.T) {
 }
 
 func TestParser_SearchCommandWithCharset(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "UTF-8",
 		Keys: []SearchKey{
 			&SearchKeyAll{},
@@ -52,7 +52,7 @@ func TestParser_SearchCommandWithCharsetInWrongLocation(t *testing.T) {
 }
 
 func TestParser_SearchCommandAnswered(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyAnswered{},
@@ -65,7 +65,7 @@ func TestParser_SearchCommandAnswered(t *testing.T) {
 }
 
 func TestParser_SearchCommandBCC(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyBCC{Value: "foobar"},
@@ -78,7 +78,7 @@ func TestParser_SearchCommandBCC(t *testing.T) {
 }
 
 func TestParser_SearchCommandBefore(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyBefore{Value: buildSearchTestDate(2009, time.January, 01)},
@@ -91,7 +91,7 @@ func TestParser_SearchCommandBefore(t *testing.T) {
 }
 
 func TestParser_SearchCommandBody(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyBody{Value: "foobar"},
@@ -104,7 +104,7 @@ func TestParser_SearchCommandBody(t *testing.T) {
 }
 
 func TestParser_SearchCommandCC(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyCC{Value: "foobar"},
@@ -117,7 +117,7 @@ func TestParser_SearchCommandCC(t *testing.T) {
 }
 
 func TestParser_SearchCommandDeleted(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyDeleted{},
@@ -130,7 +130,7 @@ func TestParser_SearchCommandDeleted(t *testing.T) {
 }
 
 func TestParser_SearchCommandFlagged(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyFlagged{},
@@ -143,7 +143,7 @@ func TestParser_SearchCommandFlagged(t *testing.T) {
 }
 
 func TestParser_SearchCommandFrom(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyFrom{Value: "foobar"},
@@ -156,7 +156,7 @@ func TestParser_SearchCommandFrom(t *testing.T) {
 }
 
 func TestParser_SearchCommandKeyword(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyKeyword{Value: "foobar"},
@@ -169,7 +169,7 @@ func TestParser_SearchCommandKeyword(t *testing.T) {
 }
 
 func TestParser_SearchCommandNew(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyNew{},
@@ -182,7 +182,7 @@ func TestParser_SearchCommandNew(t *testing.T) {
 }
 
 func TestParser_SearchCommandOld(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyOld{},
@@ -195,7 +195,7 @@ func TestParser_SearchCommandOld(t *testing.T) {
 }
 
 func TestParser_SearchCommandRecent(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyRecent{},
@@ -208,7 +208,7 @@ func TestParser_SearchCommandRecent(t *testing.T) {
 }
 
 func TestParser_SearchCommandOn(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyOn{Value: buildSearchTestDate(2009, time.January, 01)},
@@ -221,7 +221,7 @@ func TestParser_SearchCommandOn(t *testing.T) {
 }
 
 func TestParser_SearchCommandSince(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeySince{Value: buildSearchTestDate(2009, time.January, 01)},
@@ -234,7 +234,7 @@ func TestParser_SearchCommandSince(t *testing.T) {
 }
 
 func TestParser_SearchCommandSubject(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeySubject{Value: "foobar"},
@@ -247,7 +247,7 @@ func TestParser_SearchCommandSubject(t *testing.T) {
 }
 
 func TestParser_SearchCommandText(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyText{Value: "foobar"},
@@ -260,7 +260,7 @@ func TestParser_SearchCommandText(t *testing.T) {
 }
 
 func TestParser_SearchCommandTo(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyTo{Value: "foobar"},
@@ -273,7 +273,7 @@ func TestParser_SearchCommandTo(t *testing.T) {
 }
 
 func TestParser_SearchCommandUnanswered(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUnanswered{},
@@ -286,7 +286,7 @@ func TestParser_SearchCommandUnanswered(t *testing.T) {
 }
 
 func TestParser_SearchCommandUndeleted(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUndeleted{},
@@ -299,7 +299,7 @@ func TestParser_SearchCommandUndeleted(t *testing.T) {
 }
 
 func TestParser_SearchCommandUnflagged(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUnflagged{},
@@ -312,7 +312,7 @@ func TestParser_SearchCommandUnflagged(t *testing.T) {
 }
 
 func TestParser_SearchCommandUnseen(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUnseen{},
@@ -325,7 +325,7 @@ func TestParser_SearchCommandUnseen(t *testing.T) {
 }
 
 func TestParser_SearchCommandUnkeyword(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUnkeyword{Value: "foobar"},
@@ -338,7 +338,7 @@ func TestParser_SearchCommandUnkeyword(t *testing.T) {
 }
 
 func TestParser_SearchCommandDraft(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyDraft{},
@@ -351,7 +351,7 @@ func TestParser_SearchCommandDraft(t *testing.T) {
 }
 
 func TestParser_SearchCommandHeader(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyHeader{Field: "field", Value: "foobar"},
@@ -364,7 +364,7 @@ func TestParser_SearchCommandHeader(t *testing.T) {
 }
 
 func TestParser_SearchLarger(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyLarger{Value: 1024},
@@ -377,7 +377,7 @@ func TestParser_SearchLarger(t *testing.T) {
 }
 
 func TestParser_SearchNot(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyNot{
@@ -392,7 +392,7 @@ func TestParser_SearchNot(t *testing.T) {
 }
 
 func TestParser_SearchOr(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyOr{
@@ -408,7 +408,7 @@ func TestParser_SearchOr(t *testing.T) {
 }
 
 func TestParser_SearchSentBefore(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeySentBefore{Value: buildSearchTestDate(2009, time.January, 1)},
@@ -421,7 +421,7 @@ func TestParser_SearchSentBefore(t *testing.T) {
 }
 
 func TestParser_SearchSentOn(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeySentOn{Value: buildSearchTestDate(2009, time.January, 1)},
@@ -434,7 +434,7 @@ func TestParser_SearchSentOn(t *testing.T) {
 }
 
 func TestParser_SearchSentSince(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeySentSince{Value: buildSearchTestDate(2009, time.January, 1)},
@@ -447,7 +447,7 @@ func TestParser_SearchSentSince(t *testing.T) {
 }
 
 func TestParser_SearchSmaller(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeySmaller{Value: 512},
@@ -460,7 +460,7 @@ func TestParser_SearchSmaller(t *testing.T) {
 }
 
 func TestParser_SearchUID(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUID{Value: 512},
@@ -473,7 +473,7 @@ func TestParser_SearchUID(t *testing.T) {
 }
 
 func TestParser_SearchUndraft(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUndraft{},
@@ -486,7 +486,7 @@ func TestParser_SearchUndraft(t *testing.T) {
 }
 
 func TestParser_SearchMultipleKeys(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "",
 		Keys: []SearchKey{
 			&SearchKeyUndraft{},
@@ -501,7 +501,7 @@ func TestParser_SearchMultipleKeys(t *testing.T) {
 }
 
 func TestParser_SearchUtf8String(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "UTF-8",
 		Keys: []SearchKey{
 			&SearchKeySubject{Value: "割ゃちとた紀別チノホコ隠面ノ"},
@@ -522,7 +522,7 @@ func TestParser_Search_ISO_8859_1_String(t *testing.T) {
 	require.False(t, utf8.Valid(text))
 	require.False(t, utf8.Valid(textWithQuotes))
 
-	expected := Command{Tag: "tag", Payload: &SearchCommand{
+	expected := Command{Tag: "tag", Payload: &Search{
 		Charset: "ISO-8859-1",
 		Keys: []SearchKey{
 			&SearchKeySubject{Value: string(text)},

--- a/imap/command/select.go
+++ b/imap/command/select.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type SelectCommand struct {
+type Select struct {
 	Mailbox string
 }
 
-func (l SelectCommand) String() string {
+func (l Select) String() string {
 	return fmt.Sprintf("SELECT '%v'", l.Mailbox)
 }
 
-func (l SelectCommand) SanitizedString() string {
+func (l Select) SanitizedString() string {
 	return fmt.Sprintf("SELECT '%v'", sanitizeString(l.Mailbox))
 }
 
@@ -30,7 +30,7 @@ func (SelectCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &SelectCommand{
+	return &Select{
 		Mailbox: mailbox.Value,
 	}, nil
 }

--- a/imap/command/select_test.go
+++ b/imap/command/select_test.go
@@ -12,7 +12,7 @@ func TestParser_SelectCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &SelectCommand{
+	expected := Command{Tag: "tag", Payload: &Select{
 		Mailbox: "INBOX",
 	}}
 

--- a/imap/command/starttls.go
+++ b/imap/command/starttls.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type StartTLSCommand struct{}
+type StartTLS struct{}
 
-func (l StartTLSCommand) String() string {
+func (l StartTLS) String() string {
 	return fmt.Sprintf("STARTTLS")
 }
 
-func (l StartTLSCommand) SanitizedString() string {
+func (l StartTLS) SanitizedString() string {
 	return l.String()
 }
 
 type StartTLSCommandParser struct{}
 
 func (StartTLSCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &StartTLSCommand{}, nil
+	return &StartTLS{}, nil
 }

--- a/imap/command/starttls_test.go
+++ b/imap/command/starttls_test.go
@@ -12,7 +12,7 @@ func TestParser_StartTLSCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &StartTLSCommand{}}
+	expected := Command{Tag: "tag", Payload: &StartTLS{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/status.go
+++ b/imap/command/status.go
@@ -33,18 +33,18 @@ func (s StatusAttribute) String() string {
 	}
 }
 
-type StatusCommand struct {
+type Status struct {
 	Mailbox    string
 	Attributes []StatusAttribute
 }
 
-func (s StatusCommand) String() string {
+func (s Status) String() string {
 	return fmt.Sprintf("Status '%v' '%v'", s.Mailbox, xslices.Map(s.Attributes, func(s StatusAttribute) string {
 		return s.String()
 	}))
 }
 
-func (s StatusCommand) SanitizedString() string {
+func (s Status) SanitizedString() string {
 	return s.String()
 }
 
@@ -102,7 +102,7 @@ func (StatusCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &StatusCommand{
+	return &Status{
 		Mailbox:    mailbox.Value,
 		Attributes: attributes,
 	}, nil

--- a/imap/command/status_test.go
+++ b/imap/command/status_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParser_StatusCommandRecent(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StatusCommand{
+	expected := Command{Tag: "tag", Payload: &Status{
 		Mailbox:    "INBOX",
 		Attributes: []StatusAttribute{StatusAttributeRecent},
 	}}
@@ -25,7 +25,7 @@ func TestParser_StatusCommandRecent(t *testing.T) {
 }
 
 func TestParser_StatusCommandMessages(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StatusCommand{
+	expected := Command{Tag: "tag", Payload: &Status{
 		Mailbox:    "Foo",
 		Attributes: []StatusAttribute{StatusAttributeRecent},
 	}}
@@ -36,7 +36,7 @@ func TestParser_StatusCommandMessages(t *testing.T) {
 }
 
 func TestParser_StatusCommandUIDNext(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StatusCommand{
+	expected := Command{Tag: "tag", Payload: &Status{
 		Mailbox:    "Foo",
 		Attributes: []StatusAttribute{StatusAttributeUIDNext},
 	}}
@@ -47,7 +47,7 @@ func TestParser_StatusCommandUIDNext(t *testing.T) {
 }
 
 func TestParser_StatusCommandUIDValidity(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StatusCommand{
+	expected := Command{Tag: "tag", Payload: &Status{
 		Mailbox:    "Foo",
 		Attributes: []StatusAttribute{StatusAttributeUIDValidity},
 	}}
@@ -58,7 +58,7 @@ func TestParser_StatusCommandUIDValidity(t *testing.T) {
 }
 
 func TestParser_StatusCommandUnseen(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StatusCommand{
+	expected := Command{Tag: "tag", Payload: &Status{
 		Mailbox:    "Foo",
 		Attributes: []StatusAttribute{StatusAttributeUnseen},
 	}}
@@ -69,7 +69,7 @@ func TestParser_StatusCommandUnseen(t *testing.T) {
 }
 
 func TestParser_StatusCommandMultiple(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StatusCommand{
+	expected := Command{Tag: "tag", Payload: &Status{
 		Mailbox:    "Foo",
 		Attributes: []StatusAttribute{StatusAttributeUnseen, StatusAttributeRecent},
 	}}

--- a/imap/command/store.go
+++ b/imap/command/store.go
@@ -26,14 +26,14 @@ func (s StoreAction) String() string {
 	}
 }
 
-type StoreCommand struct {
+type Store struct {
 	SeqSet []SeqRange
 	Action StoreAction
 	Flags  []string
 	Silent bool
 }
 
-func (s StoreCommand) String() string {
+func (s Store) String() string {
 	silentStr := ""
 	if s.Silent {
 		silentStr = ".SILENT"
@@ -42,7 +42,7 @@ func (s StoreCommand) String() string {
 	return fmt.Sprintf("STORE %v%v %v", s.Action.String(), silentStr, s.Flags)
 }
 
-func (s StoreCommand) SanitizedString() string {
+func (s Store) SanitizedString() string {
 	return s.String()
 }
 
@@ -107,7 +107,7 @@ func (StoreCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &StoreCommand{
+	return &Store{
 		SeqSet: seqSet,
 		Action: action,
 		Flags:  flags,

--- a/imap/command/store_test.go
+++ b/imap/command/store_test.go
@@ -12,7 +12,7 @@ func TestParser_StoreCommandSetFlags(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &StoreCommand{
+	expected := Command{Tag: "tag", Payload: &Store{
 		SeqSet: []SeqRange{{
 			Begin: 1,
 			End:   1,
@@ -30,7 +30,7 @@ func TestParser_StoreCommandSetFlags(t *testing.T) {
 }
 
 func TestParser_StoreCommandAddFlags(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StoreCommand{
+	expected := Command{Tag: "tag", Payload: &Store{
 		SeqSet: []SeqRange{{
 			Begin: 1,
 			End:   1,
@@ -46,7 +46,7 @@ func TestParser_StoreCommandAddFlags(t *testing.T) {
 }
 
 func TestParser_StoreCommandRemoveFlags(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StoreCommand{
+	expected := Command{Tag: "tag", Payload: &Store{
 		SeqSet: []SeqRange{{
 			Begin: 1,
 			End:   1,
@@ -62,7 +62,7 @@ func TestParser_StoreCommandRemoveFlags(t *testing.T) {
 }
 
 func TestParser_StoreCommandSilent(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StoreCommand{
+	expected := Command{Tag: "tag", Payload: &Store{
 		SeqSet: []SeqRange{{
 			Begin: 1,
 			End:   1,
@@ -78,7 +78,7 @@ func TestParser_StoreCommandSilent(t *testing.T) {
 }
 
 func TestParser_StoreCommandMultipleFlags(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StoreCommand{
+	expected := Command{Tag: "tag", Payload: &Store{
 		SeqSet: []SeqRange{{
 			Begin: 1,
 			End:   1,
@@ -94,7 +94,7 @@ func TestParser_StoreCommandMultipleFlags(t *testing.T) {
 }
 
 func TestParser_StoreCommandMultipleFlagsWithParen(t *testing.T) {
-	expected := Command{Tag: "tag", Payload: &StoreCommand{
+	expected := Command{Tag: "tag", Payload: &Store{
 		SeqSet: []SeqRange{{
 			Begin: 1,
 			End:   1,

--- a/imap/command/subscribe.go
+++ b/imap/command/subscribe.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type SubscribeCommand struct {
+type Subscribe struct {
 	Mailbox string
 }
 
-func (l SubscribeCommand) String() string {
+func (l Subscribe) String() string {
 	return fmt.Sprintf("SUBSCRIBE '%v'", l.Mailbox)
 }
 
-func (l SubscribeCommand) SanitizedString() string {
+func (l Subscribe) SanitizedString() string {
 	return fmt.Sprintf("SUBSCRIBE '%v'", sanitizeString(l.Mailbox))
 }
 
@@ -30,7 +30,7 @@ func (SubscribeCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &SubscribeCommand{
+	return &Subscribe{
 		Mailbox: mailbox.Value,
 	}, nil
 }

--- a/imap/command/subscribte_test.go
+++ b/imap/command/subscribte_test.go
@@ -12,7 +12,7 @@ func TestParser_SubscribeCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &SubscribeCommand{
+	expected := Command{Tag: "tag", Payload: &Subscribe{
 		Mailbox: "INBOX",
 	}}
 

--- a/imap/command/uid.go
+++ b/imap/command/uid.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type UIDCommand struct {
+type UID struct {
 	Command Payload
 }
 
-func (l UIDCommand) String() string {
+func (l UID) String() string {
 	return fmt.Sprintf("UID %v", l.Command.String())
 }
 
-func (l UIDCommand) SanitizedString() string {
+func (l UID) SanitizedString() string {
 	return fmt.Sprintf("UID %v", l.Command.SanitizedString())
 }
 
@@ -68,7 +68,7 @@ func (u *UIDCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
 		return nil, err
 	}
 
-	return &UIDCommand{
+	return &UID{
 		Command: payload,
 	}, nil
 }

--- a/imap/command/uid_test.go
+++ b/imap/command/uid_test.go
@@ -14,8 +14,8 @@ func TestParser_UIDCommandCopy(t *testing.T) {
 
 	expected := Command{
 		Tag: "tag",
-		Payload: &UIDCommand{
-			Command: &CopyCommand{
+		Payload: &UID{
+			Command: &Copy{
 				Mailbox: "INBOX",
 				SeqSet:  []SeqRange{{Begin: 1, End: SeqNumValueAsterisk}},
 			},
@@ -32,8 +32,8 @@ func TestParser_UIDCommandCopy(t *testing.T) {
 func TestParser_UIDCommandMove(t *testing.T) {
 	expected := Command{
 		Tag: "tag",
-		Payload: &UIDCommand{
-			Command: &MoveCommand{
+		Payload: &UID{
+			Command: &Move{
 				Mailbox: "INBOX",
 				SeqSet:  []SeqRange{{Begin: 1, End: SeqNumValueAsterisk}},
 			},
@@ -48,8 +48,8 @@ func TestParser_UIDCommandMove(t *testing.T) {
 func TestParser_UIDCommandStore(t *testing.T) {
 	expected := Command{
 		Tag: "tag",
-		Payload: &UIDCommand{
-			Command: &StoreCommand{
+		Payload: &UID{
+			Command: &Store{
 				SeqSet: []SeqRange{{
 					Begin: 1,
 					End:   1,
@@ -82,8 +82,8 @@ func TestParser_UIDCommandExpunge(t *testing.T) {
 func TestParser_UIDCommandFetch(t *testing.T) {
 	expected := Command{
 		Tag: "tag",
-		Payload: &UIDCommand{
-			Command: &FetchCommand{
+		Payload: &UID{
+			Command: &Fetch{
 				SeqSet: []SeqRange{{Begin: 1, End: 1}},
 				Attributes: []FetchAttribute{
 					&FetchAttributeFast{},
@@ -100,8 +100,8 @@ func TestParser_UIDCommandFetch(t *testing.T) {
 func TestParser_UIDCommandSearch(t *testing.T) {
 	expected := Command{
 		Tag: "tag",
-		Payload: &UIDCommand{
-			Command: &SearchCommand{
+		Payload: &UID{
+			Command: &Search{
 				Charset: "",
 				Keys: []SearchKey{
 					&SearchKeyAnswered{},

--- a/imap/command/unselect.go
+++ b/imap/command/unselect.go
@@ -5,18 +5,18 @@ import (
 	"github.com/ProtonMail/gluon/rfcparser"
 )
 
-type UnselectCommand struct{}
+type Unselect struct{}
 
-func (l UnselectCommand) String() string {
+func (l Unselect) String() string {
 	return fmt.Sprintf("UNSELECT")
 }
 
-func (l UnselectCommand) SanitizedString() string {
+func (l Unselect) SanitizedString() string {
 	return l.String()
 }
 
 type UnselectCommandParser struct{}
 
 func (UnselectCommandParser) FromParser(p *rfcparser.Parser) (Payload, error) {
-	return &UnselectCommand{}, nil
+	return &Unselect{}, nil
 }

--- a/imap/command/unselect_test.go
+++ b/imap/command/unselect_test.go
@@ -12,7 +12,7 @@ func TestParser_UnselectCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &UnselectCommand{}}
+	expected := Command{Tag: "tag", Payload: &Unselect{}}
 
 	cmd, err := p.Parse()
 	require.NoError(t, err)

--- a/imap/command/unsubscribe.go
+++ b/imap/command/unsubscribe.go
@@ -5,15 +5,15 @@ import (
 	rfcparser "github.com/ProtonMail/gluon/rfcparser"
 )
 
-type UnsubscribeCommand struct {
+type Unsubscribe struct {
 	Mailbox string
 }
 
-func (l UnsubscribeCommand) String() string {
+func (l Unsubscribe) String() string {
 	return fmt.Sprintf("UNSUBSCRIBE '%v'", l.Mailbox)
 }
 
-func (l UnsubscribeCommand) SanitizedString() string {
+func (l Unsubscribe) SanitizedString() string {
 	return fmt.Sprintf("UNSUBSCRIBE '%v'", sanitizeString(l.Mailbox))
 }
 
@@ -30,7 +30,7 @@ func (UnsubscribeCommandParser) FromParser(p *rfcparser.Parser) (Payload, error)
 		return nil, err
 	}
 
-	return &UnsubscribeCommand{
+	return &Unsubscribe{
 		Mailbox: mailbox.Value,
 	}, nil
 }

--- a/imap/command/unsubscribe_test.go
+++ b/imap/command/unsubscribe_test.go
@@ -12,7 +12,7 @@ func TestParser_UnsubscribeCommand(t *testing.T) {
 	s := rfcparser.NewScanner(bytes.NewReader(input))
 	p := NewParser(s)
 
-	expected := Command{Tag: "tag", Payload: &UnsubscribeCommand{
+	expected := Command{Tag: "tag", Payload: &Unsubscribe{
 		Mailbox: "INBOX",
 	}}
 


### PR DESCRIPTION
When inegration with the rest of Gluon, can lead to a lot of noise. Before this patch `command.FetchCommand`, after `command.Fetch`.