### PR TITLE
fix(GODT-2399): Defer updated message deletion

### DIFF
--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -677,7 +677,9 @@ func (user *user) applyMessageUpdated(ctx context.Context, update *imap.MessageU
 					stateUpdates = append(stateUpdates, updates...)
 				}
 
-				if err := db.DeleteMessages(ctx, tx, internalMessageID); err != nil {
+				// We need change the old remote id as it will break our table constraint otherwise and everything
+				// will silently fail.
+				if err := db.MarkMessageAsDeletedAndAssignRandomRemoteID(ctx, tx, internalMessageID); err != nil {
 					return err
 				}
 			}
@@ -699,8 +701,10 @@ func (user *user) applyMessageUpdated(ctx context.Context, update *imap.MessageU
 					InternalID:  newInternalID,
 				}
 
-				if _, err := db.CreateMessages(ctx, tx, request); err != nil {
+				if m, err := db.CreateMessages(ctx, tx, request); err != nil {
 					return err
+				} else if len(m) == 0 {
+					return fmt.Errorf("no messages were inserted")
 				}
 
 				if err := user.store.Set(newInternalID, literalReader); err != nil {

--- a/internal/db/message.go
+++ b/internal/db/message.go
@@ -560,6 +560,15 @@ func MarkMessageAsDeleted(ctx context.Context, tx *ent.Tx, messageID imap.Intern
 	return nil
 }
 
+func MarkMessageAsDeletedAndAssignRandomRemoteID(ctx context.Context, tx *ent.Tx, messageID imap.InternalMessageID) error {
+	randomID := imap.MessageID(fmt.Sprintf("DELETED-%v", imap.NewInternalMessageID()))
+	if _, err := tx.Message.Update().Where(message.ID(messageID)).SetDeleted(true).SetRemoteID(randomID).Save(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func MarkMessageAsDeletedWithRemoteID(ctx context.Context, tx *ent.Tx, messageID imap.MessageID) error {
 	if _, err := tx.Message.Update().Where(message.RemoteID(messageID)).SetDeleted(true).Save(ctx); err != nil {
 		return err

--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -334,3 +334,96 @@ func TestMessageCreatedWithIgnoreMissingMailbox(t *testing.T) {
 		}
 	})
 }
+
+func TestInvalidIMAPCommandDoesNotBlockStateUpdates(t *testing.T) {
+	// Test that a sequence of delete followed by create with the same message ID  results in an updated message.
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		messageID := s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"), time.Now())
+
+		s.flush("user")
+		c.C(`A002 SELECT mbox1`).OK(`A002`)
+
+		// Check that the message exists.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm FLAGS (\\Recent \\Seen))")
+		c.OK("A005")
+
+		// Update to the message is applied.
+		s.messageDeleted("user", messageID)
+		s.flush("user")
+
+		// First fetch should read the old message data due to deferred deletion.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm)")
+		c.OK("A005")
+
+		c.C("A006 NOOP").OK("")
+
+		// Second fetch fail with
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("A005 BAD no such message")
+
+		// new message gets create
+		s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"), time.Now())
+		s.flush("user")
+
+		// Third fetch will still fail, but now we get updates to the state.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S(`* 1 EXISTS`)
+		c.S(`* 1 RECENT`)
+		c.S("A005 BAD no such message")
+
+		// Forth fetch succeeds.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm FLAGS (\\Recent \\Seen))")
+		c.OK("A005")
+	})
+}
+
+func TestUpdatedMessageFetchSucceedsOnSecondTry(t *testing.T) {
+	// Test that a sequence of delete followed by create with the same message ID  results in an updated message.
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		messageID := s.messageCreated("user", mailboxID, []byte("To: 3@3.pm"), time.Now())
+
+		s.flush("user")
+		c.C(`A002 SELECT mbox1`).OK(`A002`)
+
+		// Check that the message exists.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm FLAGS (\\Recent \\Seen))")
+		c.OK("A005")
+
+		// Update to the message is applied.
+		s.messageUpdatedWithID("user", messageID, mailboxID, []byte("To: 4@4.pm"), time.Now())
+		s.flush("user")
+
+		// First fetch should read the old message data due to deferred deletion and get the updates
+		// that the message has been removed and replaced with new version.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm)")
+		c.S("* 2 EXISTS")
+		c.S("* 2 RECENT")
+		c.OK("A005", "EXPUNGEISSUED")
+
+		// Original message remains active until Noop/Status/Select.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 3@3.pm)")
+		c.OK(`A005`)
+
+		// New message is now available.
+		c.C(`A005 FETCH 2 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 2 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm FLAGS (\\Recent \\Seen))")
+		c.OK("A005")
+
+		// Noop finally allows expunges.
+		c.C("A006 NOOP")
+		c.OK("A006")
+
+		// Old message is now gone.
+		c.C(`A005 FETCH 1 (BODY[HEADER.FIELDS (TO)])`)
+		c.S("* 1 FETCH (BODY[HEADER.FIELDS (TO)] {10}\r\nTo: 4@4.pm)")
+		c.OK("A005")
+	})
+}


### PR DESCRIPTION
Ensure that when a message gets update, we defer deletion of the message so that it remains accessible until all snapshots that have this message have been released.