### PR TITLE
fix(GODT-2417): Do no attempt to re-download recovered messages

### DIFF
--- a/internal/ids/ids.go
+++ b/internal/ids/ids.go
@@ -2,6 +2,7 @@ package ids
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/db/ent"
@@ -77,3 +78,12 @@ func SplitMailboxIDPairSlice(s []MailboxIDPair) ([]imap.InternalMailboxID, []ima
 const GluonRecoveryMailboxName = "Recovered Messages"
 const GluonRecoveryMailboxNameLowerCase = "recovered messages"
 const GluonInternalRecoveryMailboxRemoteID = imap.MailboxID("GLUON-INTERNAL-RECOVERY-MBOX")
+const gluonInternalRecoveredMessageRemoteIDPrefix = "GLUON-RECOVERED-MESSAGE"
+
+func NewRecoveredRemoteMessageID(internalID imap.InternalMessageID) imap.MessageID {
+	return imap.MessageID(fmt.Sprintf("%v-%v", gluonInternalRecoveredMessageRemoteIDPrefix, internalID))
+}
+
+func IsRecoveredRemoteMessageID(id imap.MessageID) bool {
+	return strings.HasPrefix(gluonInternalRecoveredMessageRemoteIDPrefix, string(id))
+}

--- a/internal/state/actions.go
+++ b/internal/state/actions.go
@@ -181,7 +181,7 @@ func (state *State) actionCreateRecoveredMessage(
 	date time.Time,
 ) error {
 	internalID := imap.NewInternalMessageID()
-	remoteID := imap.MessageID(fmt.Sprintf("GLUON-RECOVERED-MESSAGE-%v", internalID))
+	remoteID := ids.NewRecoveredRemoteMessageID(internalID)
 
 	parsedMessage, err := imap.NewParsedMessage(literal)
 	if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -661,6 +661,12 @@ func (state *State) getLiteral(ctx context.Context, messageID ids.MessageIDPair)
 
 	storeLiteral, firstErr := state.user.GetStore().Get(messageID.InternalID)
 	if firstErr != nil {
+		// Do not attempt to recovered messages from the connector.
+		if ids.IsRecoveredRemoteMessageID(messageID.RemoteID) {
+			logrus.Debugf("Failed load %v from store, but it is a recovered message.", messageID.InternalID)
+			return nil, firstErr
+		}
+
 		logrus.Debugf("Failed load %v from store, attempting to download from connector", messageID.InternalID.ShortID())
 
 		connectorLiteral, err := state.user.GetRemote().GetMessageLiteral(ctx, messageID.RemoteID)


### PR DESCRIPTION
They don't exist on the connector.