### PR TITLE
fix(2425): Ensure message flag updates are only issued if changed

### DIFF
--- a/internal/response/item_uid.go
+++ b/internal/response/item_uid.go
@@ -17,3 +17,12 @@ func ItemUID(n imap.UID) *itemUID {
 func (c *itemUID) String() string {
 	return fmt.Sprintf("UID %v", c.uid)
 }
+
+func (c *itemUID) mergeWith(other Item) Item {
+	_, ok := other.(*itemUID)
+	if !ok {
+		return nil
+	}
+
+	return ItemUID(c.uid)
+}


### PR DESCRIPTION
When adding or removing flags, we should only notify the messages that have been modified in the process.