### PR TITLE
fix(GODT-2442): Use rename instead of remove for db files

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -2,6 +2,8 @@ package gluon
 
 import (
 	"crypto/tls"
+	"github.com/ProtonMail/gluon/internal/db"
+	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"time"
@@ -81,6 +83,12 @@ func (builder *serverBuilder) build() (*Server, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// Defer delete all the previous databases from removed user accounts. This is required since we can't
+	// close ent databases on demand.
+	if err := db.DeleteDeferredDBFiles(builder.databaseDir); err != nil {
+		logrus.WithError(err).Error("Failed to remove old database files")
 	}
 
 	return &Server{


### PR DESCRIPTION
Unfortunately, closing the Ent database clients doesn't guarantee that all the SQLite db files are closed. This causes issues on Windows where the files are locked, making it impossible to remove and re-add the same user.