### PR TITLE
fix(GODT-2418): Do not issue connector renames for inferiors

### DIFF
--- a/tests/rename_test.go
+++ b/tests/rename_test.go
@@ -38,6 +38,18 @@ func TestRenameHierarchy(t *testing.T) {
 	})
 }
 
+func TestRenameHierarchyRoot(t *testing.T) {
+	runOneToOneTestClientWithAuth(t, defaultServerOptions(t), func(client *client.Client, _ *testSession) {
+		require.NoError(t, client.Create("foo/bar/zap"))
+
+		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "foo", "foo/bar", "foo/bar/zap"})
+
+		require.NoError(t, client.Rename("foo", "baz"))
+
+		matchMailboxNamesClient(t, client, "", "*", []string{"INBOX", "baz", "baz/bar", "baz/bar/zap"})
+	})
+}
+
 func TestRenameAddHierarchy(t *testing.T) {
 	type renameTC struct {
 		src       string


### PR DESCRIPTION
When renaming a mailbox with inferiors, do not issue rename requests to the connector for the inferiors. The connector should internally handle this. We should only rename the mailboxes locally to avoid waiting on the connector event.