### PR TITLE
fix(GODT-2513): Fix crash in scanner

### DIFF
--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -161,3 +161,10 @@ This is the epilogue.  It is also to be ignored.
 	require.NoError(t, err)
 	require.NotNil(t, parsed)
 }
+
+func TestParseMessage_GODT_2513(t *testing.T) {
+	// This sequence could cause a crash.
+	parsed, err := NewParsedMessage([]byte("Content-tYpe: multipArt/0;BoundArY=\"simple boundary\"\n\n--simple boundary\r"))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+}

--- a/rfc822/scanner.go
+++ b/rfc822/scanner.go
@@ -60,7 +60,7 @@ func indexOfNewLineAfterBoundary(data []byte) int {
 	for ; index < dataLen && data[index] == '\r'; index++ {
 	}
 
-	if data[index] == '\n' {
+	if index < dataLen && data[index] == '\n' {
 		return index
 	}
 


### PR DESCRIPTION
Fix a crash that can occur when scanning for '\n' after '\r' and we reached the end of the input.