### PR TITLE
fix(GODT-2573): Remove Prelude header parsing support

### DIFF
--- a/rfc822/header.go
+++ b/rfc822/header.go
@@ -455,6 +455,7 @@ func EraseHeaderValue(literal []byte, key string) ([]byte, error) {
 var (
 	ErrNonASCIIHeaderKey = fmt.Errorf("header key contains invalid characters")
 	ErrKeyNotFound       = fmt.Errorf("invalid header key")
+	ErrParseHeader       = fmt.Errorf("failed to parse header")
 )
 
 func mergeMultiline(line []byte) string {

--- a/rfc822/header_parser.go
+++ b/rfc822/header_parser.go
@@ -35,14 +35,47 @@ func (hp *headerParser) next() (parsedHeaderEntry, error) {
 			if hp.header[hp.offset] == ':' {
 				prevOffset := hp.offset
 				hp.offset++
-				if hp.offset < headerLen && (hp.header[hp.offset] == ' ' || hp.header[hp.offset] == '\r' || hp.header[hp.offset] == '\n') {
+				if hp.offset < headerLen {
 					result.keyEnd = prevOffset
 
-					// Validate the header key.
-					for i := result.keyStart; i < result.keyEnd; i++ {
-						if v := hp.header[i]; v < 33 || v > 126 {
-							return parsedHeaderEntry{}, ErrNonASCIIHeaderKey
+					validateHeaderField := func(h parsedHeaderEntry) error {
+						for i := h.keyStart; i < h.keyEnd; i++ {
+							if v := hp.header[i]; v < 33 || v > 126 {
+								return ErrNonASCIIHeaderKey
+							}
 						}
+
+						return nil
+					}
+
+					switch {
+					case hp.header[hp.offset] == ' ':
+						if err := validateHeaderField(result); err != nil {
+							return parsedHeaderEntry{}, err
+						}
+
+					case hp.header[hp.offset] == '\r':
+						// ensure next char is '\n'
+						hp.offset++
+						if hp.offset < headerLen && hp.header[hp.offset] != '\n' {
+							return parsedHeaderEntry{}, fmt.Errorf("expected \\n after \\r: %w", ErrParseHeader)
+						}
+						fallthrough
+					case hp.header[hp.offset] == '\n':
+						hp.offset++
+
+						if err := validateHeaderField(result); err != nil {
+							return parsedHeaderEntry{}, err
+						}
+
+						// If the next char it's not a space, it's an empty header field.
+						if hp.offset < headerLen && !isWSP(hp.header[hp.offset]) {
+							result.valueStart = result.keyEnd
+							result.valueEnd = result.keyEnd
+							return result, nil
+						}
+					default:
+						return parsedHeaderEntry{}, fmt.Errorf("unexpected char '%v', for header field value: %w", string(hp.header[hp.offset]), ErrParseHeader)
 					}
 
 					break
@@ -66,7 +99,12 @@ func (hp *headerParser) next() (parsedHeaderEntry, error) {
 	}
 
 	// collect value.
-	searchOffset := result.keyEnd + 2
+	searchOffset := hp.offset
+
+	for searchOffset < headerLen && isWSP(hp.header[searchOffset]) {
+		searchOffset++
+	}
+
 	result.valueStart = searchOffset
 
 	for searchOffset < headerLen {

--- a/tests/fetch_body_test.go
+++ b/tests/fetch_body_test.go
@@ -704,8 +704,7 @@ func TestFetchBodyPeekInvalidSectionNumber(t *testing.T) {
 func TestFetchBody_Dovecot_InvalidMessageHeader(t *testing.T) {
 	// This tests fails when requesting when fetch BODY.PEEK[HEADER.FIELDS (In-Reply-To In-Reply-To Cc)].
 	// Instead of only returning In-Reply-To and Cc, it was also returning the References header.
-	const message = `From tss@iki.fi  Mon Apr  7 01:27:38 2003
-Received: with ECARTIS (v1.0.0; list dovecot); Mon, 07 Apr 2003 01:27:38 +0300 (EEST)
+	const message = `Received: with ECARTIS (v1.0.0; list dovecot); Mon, 07 Apr 2003 01:27:38 +0300 (EEST)
 Return-Path: <tss@iki.fi>
 X-Original-To: dovecot@procontrol.fi
 Delivered-To: dovecot@procontrol.fi

--- a/tests/fetch_test.go
+++ b/tests/fetch_test.go
@@ -463,8 +463,7 @@ func TestFetchFromDataUids(t *testing.T) {
 }
 
 func TestFetchInReplyTo(t *testing.T) {
-	const message = `From cras@irccrew.org  Tue Jul 23 19:39:23 2002
-Received: with ECARTIS (v1.0.0; list dovecot); Tue, 23 Jul 2002 19:39:23 +0300 (EEST)
+	const message = `Received: with ECARTIS (v1.0.0; list dovecot); Tue, 23 Jul 2002 19:39:23 +0300 (EEST)
 Return-Path: <cras@irccrew.org>
 Delivered-To: dovecot@procontrol.fi
 Date: Tue, 23 Jul 2002 19:39:23 +0300


### PR DESCRIPTION
The handling of Preludes in the headers stem from the MBox format. According to the IMAP spec, the literal submitted to APPEND should be a valid RFC822 formatted message.

The handling of the prelude was also causing issues where an MBox formatted entry would slip through and then cause issues later.