### PR TITLE
fix(GODT-2582): Improve message hashing for recovery dedup

### DIFF
--- a/internal/utils/message_hashmap.go
+++ b/internal/utils/message_hashmap.go
@@ -1,9 +1,8 @@
 package utils
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"github.com/ProtonMail/gluon/imap"
+	"github.com/ProtonMail/gluon/rfc822"
 	"sync"
 )
 
@@ -24,14 +23,10 @@ func NewMessageHashesMap() *MessageHashesMap {
 // Insert inserts the hash of the current message literal into the map and return true if an existing value was already
 // present.
 func (m *MessageHashesMap) Insert(id imap.InternalMessageID, literal []byte) (bool, error) {
-	hash := sha256.New()
-
-	if _, err := hash.Write(literal); err != nil {
+	literalHashStr, err := rfc822.GetMessageHash(literal)
+	if err != nil {
 		return false, err
 	}
-
-	literalHash := hash.Sum(nil)
-	literalHashStr := hex.EncodeToString(literalHash)
 
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/rfc822/hash.go
+++ b/rfc822/hash.go
@@ -1,0 +1,84 @@
+package rfc822
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// GetMessageHash returns the hash of the given message.
+// This takes into account:
+// - the Subject header,
+// - the From/To/Cc headers,
+// - the Content-Type header of each (leaf) part,
+// - the Content-Disposition header of each (leaf) part,
+// - the (decoded) body of each part.
+func GetMessageHash(b []byte) (string, error) {
+	section := Parse(b)
+
+	header, err := section.ParseHeader()
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+
+	if _, err := h.Write([]byte(header.Get("Subject"))); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write([]byte(header.Get("From"))); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write([]byte(header.Get("To"))); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write([]byte(header.Get("Cc"))); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write([]byte(header.Get("Reply-To"))); err != nil {
+		return "", err
+	}
+
+	if _, err := h.Write([]byte(header.Get("In-Reply-To"))); err != nil {
+		return "", err
+	}
+
+	if err := section.Walk(func(section *Section) error {
+		children, err := section.Children()
+		if err != nil {
+			return err
+		} else if len(children) > 0 {
+			return nil
+		}
+
+		header, err := section.ParseHeader()
+		if err != nil {
+			return err
+		}
+
+		if _, err := h.Write([]byte(header.Get("Content-Type"))); err != nil {
+			return err
+		}
+
+		if _, err := h.Write([]byte(header.Get("Content-Disposition"))); err != nil {
+			return err
+		}
+
+		body := section.Body()
+		body = bytes.ReplaceAll(body, []byte{'\r'}, nil)
+		body = bytes.TrimSpace(body)
+		if _, err := h.Write(body); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}

--- a/tests/recovery_mailbox_test.go
+++ b/tests/recovery_mailbox_test.go
@@ -249,8 +249,8 @@ func TestRecoveryMailboxOnlyReportsOnFirstDedupedMessage(t *testing.T) {
 		status, err := client.Select("INBOX", false)
 		require.NoError(t, err)
 		require.Equal(t, uint32(0), status.Messages)
-		require.Error(t, doAppendWithClient(client, "INBOX", "To: Foo@bar.com", time.Now()))
-		require.Error(t, doAppendWithClient(client, "INBOX", "To: Foo@bar.com", time.Now()))
+		require.Error(t, doAppendWithClientFromFile(t, client, "INBOX", "testdata/multipart-mixed.eml", time.Now()))
+		require.Error(t, doAppendWithClientFromFile(t, client, "INBOX", "testdata/multipart-mixed2.eml", time.Now()))
 
 		{
 			status, err := client.Status(ids.GluonRecoveryMailboxName, []goimap.StatusItem{goimap.StatusMessages})

--- a/tests/testdata/multipart-mixed2.eml
+++ b/tests/testdata/multipart-mixed2.eml
@@ -1,0 +1,57 @@
+Return-Path: <somebody@gmail.com>
+Received: from [10.1.1.121] ([185.159.157.131])
+        by smtp.gmail.com with ESMTPSA id t8sm14889112wrr.10.2021.03.26.12.01.23
+        for <somebody@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_128_GCM_SHA256 bits=128/128);
+        Fri, 26 Mar 2021 12:01:24 -0700 (PDT)
+To: somebody@gmail.com
+From: BQA <somebody@gmail.com>
+Subject: Simple test mail
+Message-ID: <d3b6e735-8fb4-9bde-1063-049b97f8f3ca@gmail.com>
+Date: Fri, 26 Mar 2021 20:01:23 +0100
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0)
+ Gecko/20100101 Thunderbird/78.8.1
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------9DC5F36D876D5EED478B5FF9"
+Content-Language: en-US
+
+This is a multi-part message in MIME format.
+--------------9DC5F36D876D5EED478B5FF9
+Content-Type: multipart/alternative;
+ boundary="------------00FYF50B21CF279F489F0184"
+
+
+--------------00FYF50B21CF279F489F0184
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+*this */is**/_html_
+**
+
+--------------00FYF50B21CF279F489F0184
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    <b>this </b><i>is<b> </b></i><u>html</u><br>
+    <b></b>
+  </body>
+</html>
+
+--------------00FYF50B21CF279F489F0184--
+
+--------------9DC5F36D876D5EED478B5FF9
+Content-Type: text/plain; charset=UTF-8; x-mac-type="0"; x-mac-creator="0";
+ name="thing.txt"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="thing.txt"
+
+dGhpcyBpcyBteSBhdHRhY2htZW50Cg==
+--------------9DC5F36D876D5EED478B5FF9--


### PR DESCRIPTION
Improve the message hashing by ensuring we hash the body of each part of the message rather than just the entire blob. This will ensure we can handle cases where the only thing that changes between messages is the part identifiers.