### PR TITLE
[Fuzzing] OSS-Fuzz Support for Fuzzing

### DIFF
--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -168,3 +168,17 @@ func TestParseMessage_GODT_2513(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, parsed)
 }
+
+func Fuzz_NewParsedMessage(f *testing.F) {
+
+	in_seed1, _ := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
+	in_seed2, _ := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
+
+	f.Add(in_seed1)
+	f.Add(in_seed2)
+
+	f.Fuzz(func(t *testing.T, inputData []byte) {
+
+		NewParsedMessage(inputData)
+	})
+}

--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -169,16 +169,15 @@ func TestParseMessage_GODT_2513(t *testing.T) {
 	require.NotNil(t, parsed)
 }
 
-func Fuzz_NewParsedMessage(f *testing.F) {
-	in_seed1, err_1 := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
-	in_seed2, err_2 := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
+func FuzzNewParsedMessage(f *testing.F) {
+	inSeed1, err1 := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
+	inSeed2, err2 := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
 
-	if err_1 != nil || err_2 != nil {
-		return
-	}
+	require.NoError(f, err1)
+	require.NoError(f, err2)
 
-	f.Add(in_seed1)
-	f.Add(in_seed2)
+	f.Add(inSeed1)
+	f.Add(inSeed2)
 
 	f.Fuzz(func(t *testing.T, inputData []byte) {
 

--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -170,7 +170,6 @@ func TestParseMessage_GODT_2513(t *testing.T) {
 }
 
 func Fuzz_NewParsedMessage(f *testing.F) {
-
 	in_seed1, _ := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
 	in_seed2, _ := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
 
@@ -179,6 +178,6 @@ func Fuzz_NewParsedMessage(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, inputData []byte) {
 
-		NewParsedMessage(inputData)
+		_, _ = NewParsedMessage(inputData)
 	})
 }

--- a/imap/structure_test.go
+++ b/imap/structure_test.go
@@ -170,8 +170,12 @@ func TestParseMessage_GODT_2513(t *testing.T) {
 }
 
 func Fuzz_NewParsedMessage(f *testing.F) {
-	in_seed1, _ := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
-	in_seed2, _ := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
+	in_seed1, err_1 := os.ReadFile(filepath.Join("testdata", "rfc822.eml"))
+	in_seed2, err_2 := os.ReadFile(filepath.Join("testdata", "bounds.eml"))
+
+	if err_1 != nil || err_2 != nil {
+		return
+	}
 
 	f.Add(in_seed1)
 	f.Add(in_seed2)

--- a/rfc5322/parser_test.go
+++ b/rfc5322/parser_test.go
@@ -2,9 +2,9 @@ package rfc5322
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
+    "github.com/stretchr/testify/require"
     "net/mail"
-	"testing"
+    "testing"
 
 	"github.com/ProtonMail/gluon/rfcparser"
 	"github.com/stretchr/testify/assert"
@@ -858,7 +858,7 @@ func TestParse_GODT_2587_infinite_loop(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Fuzz_ParseAddress(f *testing.F) {
+func FuzzParseAddress(f *testing.F) {
 	f.Add("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org")
 	f.Add("!#$%&`*+/=?^`{|}~@iana.org")
 
@@ -869,7 +869,7 @@ func Fuzz_ParseAddress(f *testing.F) {
 	})
 }
 
-func Fuzz_RFC5322(f *testing.F) {
+func FuzzRFC5322(f *testing.F) {
 	f.Add(`pete(his account)@silly.test(his host)`)
 	f.Add(` " foo bar derer " `)
 	f.Add("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org")

--- a/rfc5322/parser_test.go
+++ b/rfc5322/parser_test.go
@@ -857,3 +857,28 @@ func TestParse_GODT_2587_infinite_loop(t *testing.T) {
 	_, err := ParseAddressList("00@[000000000000000")
 	assert.Error(t, err)
 }
+
+func Fuzz_ParseAddress(f *testing.F) {
+
+	f.Add("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org")
+	f.Add("!#$%&`*+/=?^`{|}~@iana.org")
+
+	f.Fuzz(func(t *testing.T, inputData string) {
+
+		ParseAddress(inputData)
+		ParseAddressList(inputData)
+	})
+}
+
+func Fuzz_RFC5322(f *testing.F) {
+
+	f.Add(`pete(his account)@silly.test(his host)`)
+	f.Add(` " foo bar derer " `)
+	f.Add("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org")
+
+	f.Fuzz(func(t *testing.T, inputData string) {
+
+		p := newTestRFCParser(inputData)
+		parseNameAddr(p)
+	})
+}

--- a/rfc5322/parser_test.go
+++ b/rfc5322/parser_test.go
@@ -3,7 +3,7 @@ package rfc5322
 import (
 	"bytes"
 	"github.com/stretchr/testify/require"
-	"net/mail"
+    "net/mail"
 	"testing"
 
 	"github.com/ProtonMail/gluon/rfcparser"
@@ -859,19 +859,17 @@ func TestParse_GODT_2587_infinite_loop(t *testing.T) {
 }
 
 func Fuzz_ParseAddress(f *testing.F) {
-
 	f.Add("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org")
 	f.Add("!#$%&`*+/=?^`{|}~@iana.org")
 
 	f.Fuzz(func(t *testing.T, inputData string) {
 
-		ParseAddress(inputData)
-		ParseAddressList(inputData)
+		_, _ = ParseAddress(inputData)
+		_, _ = ParseAddressList(inputData)
 	})
 }
 
 func Fuzz_RFC5322(f *testing.F) {
-
 	f.Add(`pete(his account)@silly.test(his host)`)
 	f.Add(` " foo bar derer " `)
 	f.Add("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org")
@@ -879,6 +877,6 @@ func Fuzz_RFC5322(f *testing.F) {
 	f.Fuzz(func(t *testing.T, inputData string) {
 
 		p := newTestRFCParser(inputData)
-		parseNameAddr(p)
+		_, _ = parseNameAddr(p)
 	})
 }

--- a/rfc5322/parser_test.go
+++ b/rfc5322/parser_test.go
@@ -2,9 +2,9 @@ package rfc5322
 
 import (
 	"bytes"
-    "github.com/stretchr/testify/require"
-    "net/mail"
-    "testing"
+	"github.com/stretchr/testify/require"
+	"net/mail"
+	"testing"
 
 	"github.com/ProtonMail/gluon/rfcparser"
 	"github.com/stretchr/testify/assert"

--- a/rfc822/parser_test.go
+++ b/rfc822/parser_test.go
@@ -324,7 +324,6 @@ Ym9keQ==
 }
 
 func Fuzz_ParseDec(f *testing.F) {
-
 	f.Add([]byte(`From: Sender <sender@pm.me>
 	To: Receiver <receiver@pm.me>
 	Content-Transfer-Encoding: base64
@@ -339,6 +338,6 @@ func Fuzz_ParseDec(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, inputData []byte) {
 
-		Parse(inputData).DecodedBody()
+		_, _ = Parse(inputData).DecodedBody()
 	})
 }

--- a/rfc822/parser_test.go
+++ b/rfc822/parser_test.go
@@ -322,3 +322,23 @@ Ym9keQ==
 
 	assert.Equal(t, []byte("body"), body)
 }
+
+func Fuzz_ParseDec(f *testing.F) {
+
+	f.Add([]byte(`From: Sender <sender@pm.me>
+	To: Receiver <receiver@pm.me>
+	Content-Transfer-Encoding: base64
+	
+	Ym9keQ==
+	`))
+
+	f.Add([]byte("Content-Type: multipart/alternative; boundary=\"------------62DCF50B21CF279F489F0184\"\r\n\r\n\r\n" +
+		"--------------62DCF50B21CF279F489F0184\r\nContent-Type: text/plain; charset=utf-8; format=flowed\r\n" +
+		"Content-Transfer-Encoding: 7bit\r\n\r\n*this */is**/_html_\r\n**\r\n\r\n--------------62DCF50B21CF279F489F0184\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n<foo></foo>\r\n--------------62DCF50B21CF279F489F0184--\r\n"))
+
+	f.Fuzz(func(t *testing.T, inputData []byte) {
+
+		Parse(inputData).DecodedBody()
+	})
+}

--- a/rfc822/parser_test.go
+++ b/rfc822/parser_test.go
@@ -323,7 +323,7 @@ Ym9keQ==
 	assert.Equal(t, []byte("body"), body)
 }
 
-func Fuzz_ParseDec(f *testing.F) {
+func FuzzParseDec(f *testing.F) {
 	f.Add([]byte(`From: Sender <sender@pm.me>
 	To: Receiver <receiver@pm.me>
 	Content-Transfer-Encoding: base64


### PR DESCRIPTION
Adding [Go Fuzzing](https://go.dev/security/fuzz/) support to identify bugs.
These files can be used in Go-lang [OSS-Fuzz](https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/) integration.

Edit:
Bug found by PR:  https://github.com/ProtonMail/gluon/commit/8ec759b512f149ed6fd34428cfb5f0fd0fa94e8a https://github.com/ProtonMail/gluon/commit/dfde413d521f01b00bcd9c03038b7f82b7aaf16d
