### PR TITLE
fix: Defer wg.Done() in Group.Once() 

### DIFF
--- a/async/group.go
+++ b/async/group.go
@@ -46,8 +46,9 @@ func (g *Group) Once(f func(ctx context.Context)) {
 	go func() {
 		defer HandlePanic(g.panicHandler)
 
+		defer g.wg.Done()
+
 		f(g.ctx)
-		g.wg.Done()
 	}()
 }
 


### PR DESCRIPTION
Always defer wait group done on the goroutine to avoid stalls in case of panics.
