### PR TITLE
fix(GODT-2619): Ensure mailbox deletions from connector unsubscribe

### DIFF
--- a/tests/updates_test.go
+++ b/tests/updates_test.go
@@ -427,3 +427,18 @@ func TestUpdatedMessageFetchSucceedsOnSecondTry(t *testing.T) {
 		c.OK("A005")
 	})
 }
+
+func TestDeleteMailboxFromConnectorAlsoRemoveSubscriptionStatus(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		s.flush("user")
+		s.mailboxDeleted("user", mailboxID)
+		s.flush("user")
+
+		c.C(`S001 LSUB "" "*"`)
+		c.S(
+			`* LSUB (\Unmarked) "/" "INBOX"`,
+		)
+		c.S("S001 OK LSUB")
+	})
+}


### PR DESCRIPTION
When a mailbox is deleted from the connector, make sure it is also removed from the subscription list.