### PR TITLE
fix(GODT-2637): Fix rfc5322 address list parsing with trailing sep.

### DIFF
--- a/rfc5322/address.go
+++ b/rfc5322/address.go
@@ -57,11 +57,16 @@ func parseAddressList(p *Parser) ([]*mail.Address, error) {
 		if ok, err := tryParseCFWS(p.parser); err != nil {
 			return nil, err
 		} else if ok {
-			// Only continue if the next input is EOF or comma or we can run into issues with parsring
+			// Only continue if the next input is EOF or comma or we can run into issues with parsing
 			// the `',' address` rules.
 			if p.parser.Check(rfcparser.TokenTypeEOF) || p.parser.CheckWith(isSep) {
 				continue
 			}
+		}
+
+		// Check there is still input to be processed before continuing.
+		if p.parser.Check(rfcparser.TokenTypeEOF) {
+			break
 		}
 
 		// address

--- a/rfc5322/parser_test.go
+++ b/rfc5322/parser_test.go
@@ -880,3 +880,10 @@ func FuzzRFC5322(f *testing.F) {
 		_, _ = parseNameAddr(p)
 	})
 }
+
+func TestParse_AddressAngleAddrOnlyWithSeparator(t *testing.T) {
+	// EOF was not properly handled after separator.
+	addrList, err := ParseAddressList("<test@user.com>,")
+	assert.NoError(t, err)
+	require.Equal(t, addrList[0].Address, "test@user.com")
+}


### PR DESCRIPTION
Fix parsing of addresses if there is no more input after the separator.