### PR TITLE
fix(GODT-2454): Only apply state updates if db transactions succeed

### DIFF
--- a/internal/state/mailbox_search.go
+++ b/internal/state/mailbox_search.go
@@ -88,7 +88,7 @@ func buildSearchData(ctx context.Context, m *Mailbox, op *buildSearchOpResult, m
 	data := searchData{message: message}
 
 	if op.needsMessage {
-		dbm, err := db.ReadResult(ctx, m.state.db(), func(ctx context.Context, client *ent.Client) (*ent.Message, error) {
+		dbm, err := stateDBReadResult(ctx, m.state, func(ctx context.Context, client *ent.Client) (*ent.Message, error) {
 			return db.GetMessageDateAndSize(ctx, client, message.ID.InternalID)
 		})
 		if err != nil {

--- a/internal/state/updates_remote.go
+++ b/internal/state/updates_remote.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ProtonMail/gluon/imap"
 	"github.com/ProtonMail/gluon/internal/contexts"
 	"github.com/ProtonMail/gluon/internal/db/ent"
-	"github.com/ProtonMail/gluon/internal/ids"
 )
 
 type RemoteAddMessageFlagsStateUpdate struct {
@@ -53,22 +52,4 @@ func (u *RemoteRemoveMessageFlagsStateUpdate) String() string {
 type RemoteMessageDeletedStateUpdate struct {
 	MessageIDStateFilter
 	remoteID imap.MessageID
-}
-
-func NewRemoteMessageDeletedStateUpdate(messageID imap.InternalMessageID, remoteID imap.MessageID) Update {
-	return &RemoteMessageDeletedStateUpdate{
-		MessageIDStateFilter: MessageIDStateFilter{MessageID: messageID},
-		remoteID:             remoteID,
-	}
-}
-
-func (u *RemoteMessageDeletedStateUpdate) Apply(ctx context.Context, tx *ent.Tx, s *State) error {
-	return s.actionRemoveMessagesFromMailbox(ctx, tx, []ids.MessageIDPair{{
-		InternalID: u.MessageID,
-		RemoteID:   u.remoteID,
-	}}, s.snap.mboxID)
-}
-
-func (u *RemoteMessageDeletedStateUpdate) String() string {
-	return fmt.Sprintf("RemoteMessageDeletedStateUpdate %v remote ID = %v", u.MessageIDStateFilter.String(), u.remoteID)
 }


### PR DESCRIPTION
Ensure that all changes to the DB are made before publishing state updates for connected sessions. This improves stability of the connected clients.

The states still require another transaction to be applied. However, this is currently only related to the handling of the recent flag. This will be handled in GODT-2522 instead.