### PR TITLE
fix(GODT-2522): Handle invalid message flag migration

### DIFF
--- a/internal/db_impl/sqlite3/migration_test.go
+++ b/internal/db_impl/sqlite3/migration_test.go
@@ -362,6 +362,16 @@ func prepareV0Database(t *testing.T, dir, user string, testData *testData, uidGe
 				}
 
 				require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query, args...))
+
+				// Insert some flags that reference no mailbox.
+				{
+					query := fmt.Sprintf("INSERT INTO %v (`%v`) VALUES ('\\Unrer2'), ('\\Unref1')",
+						v0.MailboxFlagsTableName,
+						v0.MailboxFlagsFieldValue,
+					)
+
+					require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query))
+				}
 			}
 			// Perm flags.
 			for _, m := range testData.mailboxes {
@@ -383,6 +393,16 @@ func prepareV0Database(t *testing.T, dir, user string, testData *testData, uidGe
 				}
 
 				require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query, args...))
+
+				// Insert some permanent flags that reference no mailbox.
+				{
+					query := fmt.Sprintf("INSERT INTO %v (`%v`) VALUES ('\\Unrer2'), ('\\Unref1')",
+						v0.MailboxPermFlagsTableName,
+						v0.MailboxPermFlagsFieldValue,
+					)
+
+					require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query))
+				}
 			}
 			// Attributes
 			for _, m := range testData.mailboxes {
@@ -404,6 +424,16 @@ func prepareV0Database(t *testing.T, dir, user string, testData *testData, uidGe
 				}
 
 				require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query, args...))
+
+				// Insert some attributes that reference no mailbox.
+				{
+					query := fmt.Sprintf("INSERT INTO %v (`%v`) VALUES ('\\Unref2'), ('\\Unref1')",
+						v0.MailboxAttrsTableName,
+						v0.MailboxAttrsFieldValue,
+					)
+
+					require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query))
+				}
 			}
 		}
 
@@ -453,6 +483,16 @@ func prepareV0Database(t *testing.T, dir, user string, testData *testData, uidGe
 				require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query, args...))
 			}
 
+			// Insert some flags that reference no message.
+			{
+
+				query := fmt.Sprintf("INSERT INTO %v (`%v`) VALUES ('\\Seen'), ('\\Foo')",
+					v0.MessageFlagsTableName,
+					v0.MessageFlagsFieldValue,
+				)
+
+				require.NoError(t, utils.ExecQueryAndCheckUpdatedNotZero(ctx, qw, query))
+			}
 		}
 
 		// UIDs

--- a/internal/db_impl/sqlite3/v1/mailbox.go
+++ b/internal/db_impl/sqlite3/v1/mailbox.go
@@ -79,7 +79,13 @@ func copyMailboxFlags(ctx context.Context,
 	toFieldID string,
 	toFieldValue string,
 ) error {
-	loadQuery := fmt.Sprintf("SELECT `%v`, `%v` FROM %v", fromFieldID, fromFieldValue, fromTableName)
+	loadQuery := fmt.Sprintf(
+		"SELECT `%v`, `%v` FROM %v WHERE `%v` IS NOT NULL",
+		fromFieldID,
+		fromFieldValue,
+		fromTableName,
+		fromFieldID,
+	)
 
 	flags, err := utils.MapQueryRowsFn(ctx, tx, loadQuery, scanMailboxFlag)
 	if err != nil {


### PR DESCRIPTION
The first db schema could end up with unresolved references that were never corrected. These can cause migration to fail. Adjust migration code to ignore these.