### PR TITLE
fix(GODT-2578): Apply flag changes on message update event

### DIFF
--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -636,6 +636,10 @@ func (user *user) applyMessageUpdated(ctx context.Context, update *imap.MessageU
 				targetMailboxes = append(targetMailboxes, internalMBoxID)
 			}
 
+			if err := user.setMessageFlags(ctx, tx, internalMessageID, update.Message.Flags); err != nil {
+				return err
+			}
+
 			return user.setMessageMailboxes(ctx, tx, db.MessageIDPair{
 				InternalID: internalMessageID,
 				RemoteID:   update.Message.ID,


### PR DESCRIPTION
If there are no changes to the literal, besides applying mailbox changes we also need to apply flag changes.