### PR TITLE
fix(GODT-2758): Fix panic in SetFlagsOnMessages

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,12 +30,6 @@ jobs:
       - name: Run tests
         run: go test -timeout 15m -v ./...
 
-      - name: Run tests (Ent)
-        if: runner.os == 'Linux'
-        run: go test -timeout 15m -v ./...
-        env:
-          GLUON_TEST_FORCE_ENT_DB: true
-
       - name: Run tests with race check
         if: runner.os != 'Windows'
         run: go test -race -v ./tests

--- a/internal/state/updates.go
+++ b/internal/state/updates.go
@@ -397,8 +397,11 @@ func (state *State) applyMessageFlagsSet(ctx context.Context,
 		return nil, err
 	}
 
-	if err := tx.SetFlagsOnMessages(ctx, messageIDs, setFlags.Remove(imap.FlagDeleted)); err != nil {
-		return nil, err
+	remainingFlags := setFlags.Remove(imap.FlagDeleted)
+	if remainingFlags.Len() != 0 {
+		if err := tx.SetFlagsOnMessages(ctx, messageIDs, remainingFlags); err != nil {
+			return nil, err
+		}
 	}
 
 	return []Update{NewMessageFlagsSetStateUpdate(setFlags, state.snap.mboxID, messageIDs, state.StateID)}, nil

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -58,6 +58,22 @@ func TestStore(t *testing.T) {
 	})
 }
 
+func TestSetStoreDeletedDoesNotCrash(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, _ *testSession) {
+		c.C("b001 CREATE saved-messages")
+		c.S("b001 OK CREATE")
+
+		c.doAppend(`saved-messages`, buildRFC5322TestLiteral(`To: 1@pm.me`)).expect("OK")
+
+		c.C(`A002 SELECT saved-messages`)
+		c.Se(`A002 OK [READ-WRITE] SELECT`)
+
+		c.C(`A002 STORE 1 FLAGS (\Deleted)`)
+		c.S(`* 1 FETCH (FLAGS (\Deleted \Recent))`)
+		c.OK(`A002`)
+	})
+}
+
 func TestStoreSilent(t *testing.T) {
 	runManyToOneTestWithAuth(t, defaultServerOptions(t), []int{1, 2}, func(c map[int]*testConnection, s *testSession) {
 		// one message in INBOX


### PR DESCRIPTION
Check that the flagset is not empty before proceeding with the database modifications.