### PR TITLE
fix(GODT-2759): Fix command behaviors when examining mailbox

### DIFF
--- a/internal/session/handle_copy.go
+++ b/internal/session/handle_copy.go
@@ -21,6 +21,12 @@ func (s *Session) handleCopy(ctx context.Context, tag string, cmd *command.Copy,
 		defer profiling.Stop(ctx, profiling.CmdTypeCopy)
 	}
 
+	// Due to how copies are handled, when the mailbox is read only we can't perform a copy as the message
+	// will get moved.
+	if mailbox.ReadOnly() {
+		return nil, ErrReadOnly
+	}
+
 	nameUTF8, err := s.decodeMailboxName(cmd.Mailbox)
 	if err != nil {
 		return nil, err

--- a/internal/session/handle_move.go
+++ b/internal/session/handle_move.go
@@ -26,6 +26,10 @@ func (s *Session) handleMove(ctx context.Context, tag string, cmd *command.Move,
 		return nil, err
 	}
 
+	if mailbox.ReadOnly() {
+		return nil, ErrReadOnly
+	}
+
 	item, err := mailbox.Move(ctx, cmd.SeqSet, nameUTF8)
 	if errors.Is(err, state.ErrNoSuchMessage) {
 		return response.Bad(tag).WithError(err), nil

--- a/internal/session/handle_store.go
+++ b/internal/session/handle_store.go
@@ -25,6 +25,10 @@ func (s *Session) handleStore(ctx context.Context, tag string, cmd *command.Stor
 		ctx = contexts.AsSilent(ctx)
 	}
 
+	if mailbox.ReadOnly() {
+		return nil, ErrReadOnly
+	}
+
 	flags, err := validateStoreFlags(cmd.Flags)
 	if err != nil {
 		return response.Bad(tag).WithError(err), nil

--- a/internal/state/mailbox_fetch.go
+++ b/internal/state/mailbox_fetch.go
@@ -150,7 +150,7 @@ func (m *Mailbox) Fetch(ctx context.Context, cmd *command.Fetch, ch chan respons
 			items = append(items, response.ItemUID(msg.UID))
 		}
 
-		if setSeen {
+		if setSeen && !m.ReadOnly() {
 			if !msg.flags.ContainsUnchecked(imap.FlagSeenLowerCase) {
 				msg.flags.AddToSelf(imap.FlagSeen)
 


### PR DESCRIPTION
Copy, Fetch, Move and Store did not respect read only state when we are examining a mailbox rather then selecting it.