### PR TITLE
fix(GODT-2857): Do not check for changed values in clear recent flag …

### DIFF
--- a/internal/db_impl/sqlite3/utils/query_utils.go
+++ b/internal/db_impl/sqlite3/utils/query_utils.go
@@ -110,19 +110,6 @@ func ExecQueryAndCheckUpdatedNotZero(ctx context.Context, wrapper QueryWrapper, 
 	return nil
 }
 
-func ExecStmtAndCheckUpdatedNotZero(ctx context.Context, wrapper StmtWrapper, args ...any) error {
-	updated, err := ExecStmt(ctx, wrapper, args...)
-	if err != nil {
-		return err
-	}
-
-	if updated == 0 {
-		return fmt.Errorf("no values changed")
-	}
-
-	return nil
-}
-
 func ExecQuery(ctx context.Context, wrapper QueryWrapper, query string, args ...any) (int, error) {
 	r, err := wrapper.ExecContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db_impl/sqlite3/write_ops.go
+++ b/internal/db_impl/sqlite3/write_ops.go
@@ -269,7 +269,9 @@ func (w writeOps) ClearRecentFlagInMailboxOnMessage(ctx context.Context, mboxID 
 		v1.MailboxMessagesFieldMessageID,
 	)
 
-	return utils.ExecQueryAndCheckUpdatedNotZero(ctx, w.qw, query, messageID)
+	_, err := utils.ExecQuery(ctx, w.qw, query, messageID)
+
+	return err
 }
 
 func (w writeOps) ClearRecentFlagsInMailbox(ctx context.Context, mboxID imap.InternalMailboxID) error {


### PR DESCRIPTION
…on message

Depending on when this executes, it may have already been cleared.