### PR TITLE
feat(GODT-2803): Allow access to IMAP state from connector

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -13,11 +13,14 @@ var ErrMessageSizeExceedsLimits = errors.New("message size exceeds limits")
 
 // Connector connects the gluon server to a remote mail store.
 type Connector interface {
+	// Init the connector. The cache pointer provide here should not be used with any of the other methods.
+	Init(ctx context.Context, cache IMAPState) error
+
 	// Authorize returns whether the given username/password combination are valid for this connector.
 	Authorize(ctx context.Context, username string, password []byte) bool
 
 	// CreateMailbox creates a mailbox with the given name.
-	CreateMailbox(ctx context.Context, name []string) (imap.Mailbox, error)
+	CreateMailbox(ctx context.Context, cache IMAPStateWrite, name []string) (imap.Mailbox, error)
 
 	// GetMessageLiteral is intended to be used by Gluon when, for some reason, the local cached data no longer exists.
 	// Note: this can get called from different go routines.
@@ -27,29 +30,29 @@ type Connector interface {
 	GetMailboxVisibility(ctx context.Context, mboxID imap.MailboxID) imap.MailboxVisibility
 
 	// UpdateMailboxName sets the name of the mailbox with the given ID.
-	UpdateMailboxName(ctx context.Context, mboxID imap.MailboxID, newName []string) error
+	UpdateMailboxName(ctx context.Context, cache IMAPStateWrite, mboxID imap.MailboxID, newName []string) error
 
 	// DeleteMailbox deletes the mailbox with the given ID.
-	DeleteMailbox(ctx context.Context, mboxID imap.MailboxID) error
+	DeleteMailbox(ctx context.Context, cache IMAPStateWrite, mboxID imap.MailboxID) error
 
 	// CreateMessage creates a new message on the remote.
-	CreateMessage(ctx context.Context, mboxID imap.MailboxID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error)
+	CreateMessage(ctx context.Context, cache IMAPStateWrite, mboxID imap.MailboxID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error)
 
 	// AddMessagesToMailbox adds the given messages to the given mailbox.
-	AddMessagesToMailbox(ctx context.Context, messageIDs []imap.MessageID, mboxID imap.MailboxID) error
+	AddMessagesToMailbox(ctx context.Context, cache IMAPStateWrite, messageIDs []imap.MessageID, mboxID imap.MailboxID) error
 
 	// RemoveMessagesFromMailbox removes the given messages from the given mailbox.
-	RemoveMessagesFromMailbox(ctx context.Context, messageIDs []imap.MessageID, mboxID imap.MailboxID) error
+	RemoveMessagesFromMailbox(ctx context.Context, cache IMAPStateWrite, messageIDs []imap.MessageID, mboxID imap.MailboxID) error
 
 	// MoveMessages removes the given messages from one mailbox and adds them to the another mailbox.
 	// Returns true if the original messages should be removed from mboxFromID (e.g: Distinguishing between labels and folders).
-	MoveMessages(ctx context.Context, messageIDs []imap.MessageID, mboxFromID, mboxToID imap.MailboxID) (bool, error)
+	MoveMessages(ctx context.Context, cache IMAPStateWrite, messageIDs []imap.MessageID, mboxFromID, mboxToID imap.MailboxID) (bool, error)
 
 	// MarkMessagesSeen sets the seen value of the given messages.
-	MarkMessagesSeen(ctx context.Context, messageIDs []imap.MessageID, seen bool) error
+	MarkMessagesSeen(ctx context.Context, cache IMAPStateWrite, messageIDs []imap.MessageID, seen bool) error
 
 	// MarkMessagesFlagged sets the flagged value of the given messages.
-	MarkMessagesFlagged(ctx context.Context, messageIDs []imap.MessageID, flagged bool) error
+	MarkMessagesFlagged(ctx context.Context, cache IMAPStateWrite, messageIDs []imap.MessageID, flagged bool) error
 
 	// GetUpdates returns a stream of updates that the gluon server should apply.
 	GetUpdates() <-chan imap.Update

--- a/connector/state.go
+++ b/connector/state.go
@@ -1,0 +1,49 @@
+package connector
+
+import (
+	"context"
+	"github.com/ProtonMail/gluon/imap"
+)
+
+type IMAPState interface {
+	Read(ctx context.Context, f func(context.Context, IMAPStateRead) error) error
+	Write(ctx context.Context, f func(context.Context, IMAPStateWrite) error) error
+}
+
+func IMAPStateReadType[T any](ctx context.Context, state IMAPState, f func(context.Context, IMAPStateRead) (T, error)) (T, error) {
+	var result T
+
+	err := state.Read(ctx, func(ctx context.Context, r IMAPStateRead) error {
+		t, err := f(ctx, r)
+		result = t
+
+		return err
+	})
+
+	return result, err
+}
+
+func IMAPStateWriteType[T any](ctx context.Context, state IMAPState, f func(context.Context, IMAPStateWrite) (T, error)) (T, error) {
+	var result T
+
+	err := state.Write(ctx, func(ctx context.Context, w IMAPStateWrite) error {
+		t, err := f(ctx, w)
+		result = t
+
+		return err
+	})
+
+	return result, err
+}
+
+type IMAPStateRead interface {
+	GetMailboxCount(ctx context.Context) (int, error)
+}
+
+type IMAPStateWrite interface {
+	IMAPStateRead
+
+	CreateMailbox(ctx context.Context, mailbox imap.Mailbox) error
+
+	UpdateMessageFlags(ctx context.Context, id imap.MessageID, flags imap.FlagSet) error
+}

--- a/internal/backend/connector_state.go
+++ b/internal/backend/connector_state.go
@@ -1,0 +1,45 @@
+package backend
+
+import (
+	"context"
+	"github.com/ProtonMail/gluon/connector"
+	"github.com/ProtonMail/gluon/db"
+	"github.com/ProtonMail/gluon/internal/state"
+)
+
+type DBIMAPState struct {
+	user   *user
+	client db.Client
+}
+
+func NewDBIMAPState(client db.Client) *DBIMAPState {
+	return &DBIMAPState{client: client}
+}
+
+func (d *DBIMAPState) Read(ctx context.Context, f func(context.Context, connector.IMAPStateRead) error) error {
+	return d.client.Read(ctx, func(ctx context.Context, only db.ReadOnly) error {
+		rd := DBIMAPStateRead{rd: only}
+
+		return f(ctx, &rd)
+	})
+}
+
+func (d *DBIMAPState) Write(ctx context.Context, f func(context.Context, connector.IMAPStateWrite) error) error {
+	var stateUpdates []state.Update
+
+	err := d.client.Write(ctx, func(ctx context.Context, tx db.Transaction) error {
+		wr := DBIMAPStateWrite{DBIMAPStateRead: DBIMAPStateRead{rd: tx}, tx: tx, user: d.user}
+
+		err := f(ctx, &wr)
+
+		stateUpdates = wr.stateUpdates
+
+		return err
+	})
+
+	if err == nil {
+		d.user.queueStateUpdate(stateUpdates...)
+	}
+
+	return err
+}

--- a/internal/backend/connector_state_read.go
+++ b/internal/backend/connector_state_read.go
@@ -1,0 +1,14 @@
+package backend
+
+import (
+	"context"
+	"github.com/ProtonMail/gluon/db"
+)
+
+type DBIMAPStateRead struct {
+	rd db.ReadOnly
+}
+
+func (d *DBIMAPStateRead) GetMailboxCount(ctx context.Context) (int, error) {
+	return d.rd.GetMailboxCount(ctx)
+}

--- a/internal/backend/connector_state_write.go
+++ b/internal/backend/connector_state_write.go
@@ -1,0 +1,89 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"github.com/ProtonMail/gluon/db"
+	"github.com/ProtonMail/gluon/imap"
+	"github.com/ProtonMail/gluon/internal/ids"
+	"github.com/ProtonMail/gluon/internal/state"
+	"strings"
+)
+
+type DBIMAPStateWrite struct {
+	DBIMAPStateRead
+	tx           db.Transaction
+	user         *user
+	stateUpdates []state.Update
+}
+
+func (d *DBIMAPStateWrite) CreateMailbox(ctx context.Context, mailbox imap.Mailbox) error {
+	if mailbox.ID == ids.GluonInternalRecoveryMailboxRemoteID {
+		return fmt.Errorf("attempting to create protected mailbox (recovery)")
+	}
+
+	if exists, err := d.tx.MailboxExistsWithRemoteID(ctx, mailbox.ID); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+
+	uidValidity, err := d.user.uidValidityGenerator.Generate()
+	if err != nil {
+		return err
+	}
+
+	if err := d.user.imapLimits.CheckUIDValidity(uidValidity); err != nil {
+		return err
+	}
+
+	if mailboxCount, err := d.tx.GetMailboxCount(ctx); err != nil {
+		return err
+	} else if err := d.user.imapLimits.CheckMailBoxCount(mailboxCount); err != nil {
+		return err
+	}
+
+	if _, err := d.tx.CreateMailbox(
+		ctx,
+		mailbox.ID,
+		strings.Join(mailbox.Name, d.user.delimiter),
+		mailbox.Flags,
+		mailbox.PermanentFlags,
+		mailbox.Attributes,
+		uidValidity,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DBIMAPStateWrite) UpdateMessageFlags(ctx context.Context, id imap.MessageID, flags imap.FlagSet) error {
+	if exists, err := d.tx.MessageExistsWithRemoteID(ctx, id); err != nil {
+		return err
+	} else if !exists {
+		return state.ErrNoSuchMessage
+	}
+
+	return d.wrapStateUpdates(ctx, func(ctx context.Context, tx db.Transaction) ([]state.Update, error) {
+		internalMsgID, err := tx.GetMessageIDFromRemoteID(ctx, id)
+
+		if err != nil {
+			if db.IsErrNotFound(err) {
+				return nil, state.ErrNoSuchMessage
+			}
+			return nil, err
+		}
+
+		return d.user.setMessageFlags(ctx, tx, internalMsgID, flags)
+	})
+}
+
+func (d *DBIMAPStateWrite) wrapStateUpdates(ctx context.Context, f func(ctx context.Context, tx db.Transaction) ([]state.Update, error)) error {
+	updates, err := f(ctx, d.tx)
+	if err == nil {
+		d.stateUpdates = append(d.stateUpdates, updates...)
+	}
+
+	return err
+}

--- a/internal/backend/user.go
+++ b/internal/backend/user.go
@@ -62,6 +62,8 @@ func newUser(
 ) (*user, error) {
 	recoveredMessageHashes := utils.NewMessageHashesMap()
 
+	cacheProvider := NewDBIMAPState(database)
+
 	// Create recovery mailbox if it does not exist
 	recoveryMBox, err := db.ClientWriteType(ctx, database, func(ctx context.Context, tx db.Transaction) (*db.Mailbox, error) {
 		uidValidity, err := uidValidityGenerator.Generate()
@@ -104,6 +106,11 @@ func newUser(
 		return recoveryMBox, nil
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	if err := conn.Init(ctx, cacheProvider); err != nil {
+		logrus.WithError(err).Errorf("Failed to init connector")
 		return nil, err
 	}
 

--- a/internal/state/connector.go
+++ b/internal/state/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ProtonMail/gluon/db"
 	"github.com/ProtonMail/gluon/imap"
 )
 
@@ -24,22 +25,23 @@ type Connector interface {
 	ClearAllConnMetadata()
 
 	// CreateMailbox creates a new mailbox with the given name.
-	CreateMailbox(ctx context.Context, name []string) (imap.Mailbox, error)
+	CreateMailbox(ctx context.Context, tx db.Transaction, name []string) ([]Update, imap.Mailbox, error)
 
 	// UpdateMailbox sets the name of the mailbox with the given ID to the given new name.
-	UpdateMailbox(ctx context.Context, mboxID imap.MailboxID, newName []string) error
+	UpdateMailbox(ctx context.Context, tx db.Transaction, mboxID imap.MailboxID, newName []string) ([]Update, error)
 
 	// DeleteMailbox deletes the mailbox with the given ID and name.
-	DeleteMailbox(ctx context.Context, mboxID imap.MailboxID) error
+	DeleteMailbox(ctx context.Context, tx db.Transaction, mboxID imap.MailboxID) ([]Update, error)
 
 	// CreateMessage appends a message literal to the mailbox with the given ID.
 	CreateMessage(
 		ctx context.Context,
+		tx db.Transaction,
 		mboxID imap.MailboxID,
 		literal []byte,
 		flags imap.FlagSet,
 		date time.Time,
-	) (imap.InternalMessageID, imap.Message, []byte, error)
+	) ([]Update, imap.InternalMessageID, imap.Message, []byte, error)
 
 	// GetMessageLiteral retrieves the message literal from the connector.
 	// Note: this can get called from different go routines.
@@ -48,30 +50,33 @@ type Connector interface {
 	// AddMessagesToMailbox adds the message with the given ID to the mailbox with the given ID.
 	AddMessagesToMailbox(
 		ctx context.Context,
+		tx db.Transaction,
 		messageIDs []imap.MessageID,
 		mboxID imap.MailboxID,
-	) error
+	) ([]Update, error)
 
 	// RemoveMessagesFromMailbox removes the message with the given ID from the mailbox with the given ID.
 	RemoveMessagesFromMailbox(
 		ctx context.Context,
+		tx db.Transaction,
 		messageIDs []imap.MessageID,
 		mboxID imap.MailboxID,
-	) error
+	) ([]Update, error)
 
 	// MoveMessagesFromMailbox removes the message with the given ID from the mailbox with the given ID.
 	MoveMessagesFromMailbox(
 		ctx context.Context,
+		tx db.Transaction,
 		messageIDs []imap.MessageID,
 		mboxFromID imap.MailboxID,
 		mboxToID imap.MailboxID,
-	) (bool, error)
+	) ([]Update, bool, error)
 
 	// SetMessagesSeen marks the message with the given ID as seen or unseen.
-	SetMessagesSeen(ctx context.Context, messageIDs []imap.MessageID, seen bool) error
+	SetMessagesSeen(ctx context.Context, tx db.Transaction, messageIDs []imap.MessageID, seen bool) ([]Update, error)
 
 	// SetMessagesFlagged marks the message with the given ID as seen or unseen.
-	SetMessagesFlagged(ctx context.Context, messageIDs []imap.MessageID, flagged bool) error
+	SetMessagesFlagged(ctx context.Context, tx db.Transaction, messageIDs []imap.MessageID, flagged bool) ([]Update, error)
 
 	// GetMailboxVisibility retrieves the visibility status of a mailbox for a client.
 	GetMailboxVisibility(ctx context.Context, id imap.MailboxID) imap.MailboxVisibility

--- a/tests/append_test.go
+++ b/tests/append_test.go
@@ -194,12 +194,12 @@ type returnSameRemoteIDConnector struct {
 	messageLiteral []byte
 }
 
-func (r *returnSameRemoteIDConnector) CreateMessage(ctx context.Context, mboxID imap.MailboxID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error) {
+func (r *returnSameRemoteIDConnector) CreateMessage(ctx context.Context, cache connector.IMAPStateWrite, mboxID imap.MailboxID, literal []byte, flags imap.FlagSet, date time.Time) (imap.Message, []byte, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	if !r.messageCreated {
-		msg, l, err := r.Dummy.CreateMessage(ctx, mboxID, literal, flags, date)
+		msg, l, err := r.Dummy.CreateMessage(ctx, cache, mboxID, literal, flags, date)
 		if err != nil {
 			return imap.Message{}, nil, err
 		}

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -228,8 +228,8 @@ type simulateLabelConnector struct {
 	mboxID imap.MailboxID
 }
 
-func (r *simulateLabelConnector) CreateMailbox(ctx context.Context, name []string) (imap.Mailbox, error) {
-	mbox, err := r.Dummy.CreateMailbox(ctx, name)
+func (r *simulateLabelConnector) CreateMailbox(ctx context.Context, cache connector.IMAPStateWrite, name []string) (imap.Mailbox, error) {
+	mbox, err := r.Dummy.CreateMailbox(ctx, cache, name)
 	if err != nil {
 		return mbox, err
 	}
@@ -243,11 +243,12 @@ func (r *simulateLabelConnector) CreateMailbox(ctx context.Context, name []strin
 
 func (r *simulateLabelConnector) MoveMessages(
 	ctx context.Context,
+	cache connector.IMAPStateWrite,
 	ids []imap.MessageID,
 	from imap.MailboxID,
 	to imap.MailboxID,
 ) (bool, error) {
-	if _, err := r.Dummy.MoveMessages(ctx, ids, from, to); err != nil {
+	if _, err := r.Dummy.MoveMessages(ctx, cache, ids, from, to); err != nil {
 		return false, err
 	}
 

--- a/tests/recovery_mailbox_test.go
+++ b/tests/recovery_mailbox_test.go
@@ -410,6 +410,7 @@ type disableRemoveFromMailboxConnector struct {
 
 func (r *disableRemoveFromMailboxConnector) CreateMessage(
 	ctx context.Context,
+	cache connector.IMAPStateWrite,
 	mboxID imap.MailboxID,
 	literal []byte,
 	flags imap.FlagSet,
@@ -419,11 +420,12 @@ func (r *disableRemoveFromMailboxConnector) CreateMessage(
 		return imap.Message{}, nil, fmt.Errorf("failed")
 	}
 
-	return r.Dummy.CreateMessage(ctx, mboxID, literal, flags, date)
+	return r.Dummy.CreateMessage(ctx, cache, mboxID, literal, flags, date)
 }
 
 func (r *disableRemoveFromMailboxConnector) RemoveMessagesFromMailbox(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ []imap.MessageID,
 	_ imap.MailboxID,
 ) error {
@@ -432,6 +434,7 @@ func (r *disableRemoveFromMailboxConnector) RemoveMessagesFromMailbox(
 
 func (r *disableRemoveFromMailboxConnector) MoveMessages(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ []imap.MessageID,
 	_ imap.MailboxID,
 	_ imap.MailboxID,
@@ -460,6 +463,7 @@ type recoveryDedupConnector struct {
 
 func (r *recoveryDedupConnector) CreateMessage(
 	ctx context.Context,
+	cache connector.IMAPStateWrite,
 	mboxID imap.MailboxID,
 	literal []byte,
 	flags imap.FlagSet,
@@ -470,7 +474,7 @@ func (r *recoveryDedupConnector) CreateMessage(
 	}
 
 	if !r.messageCreated {
-		msg, l, err := r.Dummy.CreateMessage(ctx, mboxID, literal, flags, date)
+		msg, l, err := r.Dummy.CreateMessage(ctx, cache, mboxID, literal, flags, date)
 		if err != nil {
 			return imap.Message{}, nil, err
 		}
@@ -485,6 +489,7 @@ func (r *recoveryDedupConnector) CreateMessage(
 
 func (r *recoveryDedupConnector) AddMessagesToMailbox(
 	ctx context.Context,
+	cache connector.IMAPStateWrite,
 	ids []imap.MessageID,
 	mboxID imap.MailboxID,
 ) error {
@@ -492,7 +497,7 @@ func (r *recoveryDedupConnector) AddMessagesToMailbox(
 		return fmt.Errorf("failed")
 	}
 
-	return r.Dummy.AddMessagesToMailbox(ctx, ids, mboxID)
+	return r.Dummy.AddMessagesToMailbox(ctx, cache, ids, mboxID)
 }
 
 func (r *recoveryDedupConnector) MoveMessagesFromMailbox(
@@ -520,6 +525,7 @@ type failAppendLabelConnector struct {
 
 func (r *failAppendLabelConnector) CreateMessage(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ imap.MailboxID,
 	_ []byte,
 	_ imap.FlagSet,
@@ -529,6 +535,7 @@ func (r *failAppendLabelConnector) CreateMessage(
 
 func (r *failAppendLabelConnector) AddMessagesToMailbox(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ []imap.MessageID,
 	_ imap.MailboxID,
 ) error {
@@ -537,6 +544,7 @@ func (r *failAppendLabelConnector) AddMessagesToMailbox(
 
 func (r *failAppendLabelConnector) MoveMessagesFromMailbox(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ []imap.MessageID,
 	_ imap.MailboxID,
 	_ imap.MailboxID,
@@ -559,6 +567,7 @@ type sizeExceededAppendConnector struct {
 
 func (r *sizeExceededAppendConnector) CreateMessage(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ imap.MailboxID,
 	_ []byte,
 	_ imap.FlagSet,
@@ -568,6 +577,7 @@ func (r *sizeExceededAppendConnector) CreateMessage(
 
 func (r *sizeExceededAppendConnector) AddMessagesToMailbox(
 	_ context.Context,
+	_ connector.IMAPStateWrite,
 	_ []imap.MessageID,
 	_ imap.MailboxID,
 ) error {


### PR DESCRIPTION
Update connector interface so that it has access to the internal IMAP state of Gluon.

Similar to the DB design, there are modifiers for writing and reading from this state. This is required so that it remains compatible with how we are currently handling the database access code.

Finally, The `StateConnectorInterface` has been updated to return state updates for all actions, since it is now possible for connectors to apply IMAP state changes with each operation. Similar to previous changes, those state updates need to be kept around until the transaction has successfully committed.

This patch includes 3 example functions which cover the cases of reading, writing without updates and writing with updates. More should be added in the future as needed.