### PR TITLE
fix(GODT-2873): Add `Wait` to `QueuedChannel`

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -44,4 +44,5 @@ func (w *Watcher[T]) Send(event T) bool {
 
 func (w *Watcher[T]) Close() {
 	w.eventCh.CloseAndDiscardQueued()
+	w.eventCh.Wait()
 }


### PR DESCRIPTION
Required so that we can wait until the queued channel go-routine finishes during the Gluon Watcher closing.