### PR TITLE
fix(GODT-2929): Fix message hash when text transfer encoding differs

### DIFF
--- a/rfc822/hash_test.go
+++ b/rfc822/hash_test.go
@@ -1,0 +1,23 @@
+package rfc822
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestGetMessageHashSameBodyDifferentTextEncodings(t *testing.T) {
+	data1, err := os.ReadFile("testdata/hash_quoted.eml")
+	require.NoError(t, err)
+
+	data2, err := os.ReadFile("testdata/hash_utf8.eml")
+	require.NoError(t, err)
+
+	h1, err := GetMessageHash(data1)
+	require.NoError(t, err)
+
+	h2, err := GetMessageHash(data2)
+	require.NoError(t, err)
+
+	require.Equal(t, h1, h2)
+}

--- a/rfc822/testdata/hash_quoted.eml
+++ b/rfc822/testdata/hash_quoted.eml
@@ -1,0 +1,63 @@
+From: bar@foo.com
+To: foo@bar.com
+Subject: =?utf-8?q?HTML_to_c=C3=B6nt=C3=A4ct_Subj=CE=B5=CE=AD=CF=82=CF=84_?=
+ =?utf-8?q?=F0=9F=91=80_=F0=9F=8F=87_=E2=9A=BD_=F0=9F=91=8C=C2=B6_=C3=84_?=
+ =?utf-8?q?=C3=88?=
+Date: Mon, 11 Sep 2023 11:56:33 +0200
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_000_0023_01D9E4A7.028DF770"
+X-Mailer: Microsoft Outlook 16.0
+Content-Language: en-us
+
+------=_NextPart_000_0023_01D9E4A7.028DF770
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+HTML to c=C3=B6nt=C3=A4ct Subj=CE=B5=CE=AD=CF=82=CF=84 =F0=9F=91=80 =
+=F0=9F=8F=87 =E2=9A=BD =F0=9F=91=8C=C2=B6 =C3=84 =C3=88
+
+Asdojasodjasodjasodja
+
+*	Bullet 1
+
+*	Bullet 1.1
+
+*	Bullet 2
+
+*	Bullet 2.1
+*	Bullet 2.2
+
+*	Bullet 2.2.1
+
+*	Bullet 2.3
+
+*	Bullet 3
+
+=C2=B6 =C3=84 =C3=88 =C2=B6 =C3=84 =C3=88 =C2=B6 =C3=84 =C3=88 =C2=B6 =
+=C3=84 =C3=88 =C2=B6 =C3=84 =C3=88 =C2=B6 =C3=84 =C3=88 =C2=B6 =C3=84 =
+=C3=88 =C2=B6 =C3=84 =C3=88
+
+
+
+1.	Number 1
+
+1.	Number 1.1
+
+2.	Number 2
+
+1.	Number 2.1
+2.	Number 2.2
+
+1.	Number 2.2.1
+
+3.	Number 2.3
+
+3.	Number 3
+
+
+
+<https://protonmail.com/bridge/> HTML HYPERLINK
+
+------=_NextPart_000_0023_01D9E4A7.028DF770--

--- a/rfc822/testdata/hash_utf8.eml
+++ b/rfc822/testdata/hash_utf8.eml
@@ -1,0 +1,60 @@
+Content-Language: en-us
+X-Mailer: Microsoft Outlook 16.0
+Content-Type: multipart/alternative;
+ boundary="----=_NextPart_000_00DF_01D9E49A.A45FAB50"
+To: foo@bar.com
+From: bar@foo.com
+Subject: =?utf-8?q?HTML_to_c=C3=B6nt=C3=A4ct_Subj=CE=B5=CE=AD=CF=82=CF=84_?=
+ =?utf-8?q?=F0=9F=91=80_=F0=9F=8F=87_=E2=9A=BD_=F0=9F=91=8C=C2=B6_=C3=84_?=
+ =?utf-8?q?=C3=88?=
+Mime-Version: 1.0
+Date: Mon, 11 Sep 2023 08:27:43 +0000
+
+------=_NextPart_000_00DF_01D9E49A.A45FAB50
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+HTML to cöntäct Subjεέςτ 👀 🏇 ⚽ 👌¶ Ä È
+
+Asdojasodjasodjasodja
+
+*	Bullet 1
+
+*	Bullet 1.1
+
+*	Bullet 2
+
+*	Bullet 2.1
+*	Bullet 2.2
+
+*	Bullet 2.2.1
+
+*	Bullet 2.3
+
+*	Bullet 3
+
+¶ Ä È ¶ Ä È ¶ Ä È ¶ Ä È ¶ Ä È ¶ Ä È ¶ Ä È ¶ Ä È
+
+
+
+1.	Number 1
+
+1.	Number 1.1
+
+2.	Number 2
+
+1.	Number 2.1
+2.	Number 2.2
+
+1.	Number 2.2.1
+
+3.	Number 2.3
+
+3.	Number 3
+
+
+
+<https://protonmail.com/bridge/> HTML HYPERLINK
+
+------=_NextPart_000_00DF_01D9E49A.A45FAB50--


### PR DESCRIPTION
It's possible for an IMAP client to send UTF8 encoded text with different transfer encodings to SMTP and IMAP. Since this hashing function is used to detect duplicates, we need to decode the text before hashing.