### PR TITLE
fix(GODT-2934): Also record original error in case of rollback error

### DIFF
--- a/internal/db_impl/sqlite3/client.go
+++ b/internal/db_impl/sqlite3/client.go
@@ -185,7 +185,7 @@ func (c *Client) wrapTx(ctx context.Context, op func(context.Context, *sql.Tx, *
 		}
 
 		if rerr := tx.Rollback(); rerr != nil {
-			return fmt.Errorf("rolling back transaction: %w", rerr)
+			return fmt.Errorf("rolling back transaction: %v, original err=%w", rerr, err)
 		}
 
 		return err


### PR DESCRIPTION
When db rollback fails, also record original error that triggered the rollback so that it is is not lost.