### PR TITLE
feat(BRIDGE-288): handle previously existing message in create events…

### DIFF
--- a/connector/dummy_simulate.go
+++ b/connector/dummy_simulate.go
@@ -163,7 +163,7 @@ func (conn *Dummy) MessageUpdated(message imap.Message, literal []byte, mboxIDs 
 		mboxIDs: mboxIDMap,
 	}
 
-	conn.pushUpdate(imap.NewMessageUpdated(message, literal, mboxIDs, parsedMessage, false))
+	conn.pushUpdate(imap.NewMessageUpdated(message, literal, mboxIDs, parsedMessage, false, false))
 
 	return nil
 }

--- a/imap/update_message_updated.go
+++ b/imap/update_message_updated.go
@@ -14,11 +14,12 @@ type MessageUpdated struct {
 	updateBase
 	*updateWaiter
 
-	Message       Message
-	Literal       []byte
-	MailboxIDs    []MailboxID
-	ParsedMessage *ParsedMessage
-	AllowCreate   bool
+	Message                 Message
+	Literal                 []byte
+	MailboxIDs              []MailboxID
+	ParsedMessage           *ParsedMessage
+	AllowCreate             bool
+	IgnoreUnknownMailboxIDs bool
 }
 
 func NewMessageUpdated(
@@ -26,25 +27,27 @@ func NewMessageUpdated(
 	literal []byte,
 	mailboxIDs []MailboxID,
 	parsedMessage *ParsedMessage,
-	allowCreate bool,
+	allowCreate, ignoreUnkownMailboxIDs bool,
 ) *MessageUpdated {
 	return &MessageUpdated{
-		updateWaiter:  newUpdateWaiter(),
-		Message:       message,
-		Literal:       literal,
-		MailboxIDs:    mailboxIDs,
-		ParsedMessage: parsedMessage,
-		AllowCreate:   allowCreate,
+		updateWaiter:            newUpdateWaiter(),
+		Message:                 message,
+		Literal:                 literal,
+		MailboxIDs:              mailboxIDs,
+		ParsedMessage:           parsedMessage,
+		AllowCreate:             allowCreate,
+		IgnoreUnknownMailboxIDs: ignoreUnkownMailboxIDs,
 	}
 }
 
 func (u *MessageUpdated) String() string {
-	return fmt.Sprintf("MessageUpdated: ID:%v Mailboxes:%v Flags:%s AllowCreate:%v",
+	return fmt.Sprintf("MessageUpdated: ID:%v Mailboxes:%v Flags:%s AllowCreate:%v IgnoreUnkownMailboxIDs:%v",
 		u.Message.ID.ShortID(),
 		xslices.Map(u.MailboxIDs, func(mboxID MailboxID) string {
 			return mboxID.ShortID()
 		}),
 		u.Message.Flags.ToSlice(),
 		u.AllowCreate,
+		u.IgnoreUnknownMailboxIDs,
 	)
 }


### PR DESCRIPTION
Changed the message creation handler logic. If a previously existing message is encountered in a create event, instead of simply appending new mailboxes to the message we now fully update it. 

This includes comparing the message literal, as well the actual difference in assigned mailboxes. 