### PR TITLE
fix(BRIDGE-362): Necessary changes for detecting label name conflicts

### DIFF
--- a/imap/mailbox.go
+++ b/imap/mailbox.go
@@ -23,3 +23,10 @@ const (
 	Visible
 	HiddenIfEmpty
 )
+
+type MailboxData struct {
+	InternalID string
+	RemoteID   string
+	GluonName  string
+	BridgeName []string
+}

--- a/imap/update_mailbox_created_or_updated.go
+++ b/imap/update_mailbox_created_or_updated.go
@@ -1,0 +1,28 @@
+package imap
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MailboxUpdatedOrCreated struct {
+	updateBase
+
+	*updateWaiter
+
+	Mailbox Mailbox
+}
+
+func NewMailboxUpdatedOrCreated(mailbox Mailbox) *MailboxUpdatedOrCreated {
+	return &MailboxUpdatedOrCreated{
+		updateWaiter: newUpdateWaiter(),
+		Mailbox:      mailbox,
+	}
+}
+
+func (u *MailboxUpdatedOrCreated) String() string {
+	return fmt.Sprintf("MailboxUpdatedOrCreated: Mailbox.ID = %v, Mailbox.Name = %v",
+		u.Mailbox.ID.ShortID(),
+		ShortID(strings.Join(u.Mailbox.Name, "/")),
+	)
+}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -343,4 +344,17 @@ func (b *Backend) getStoreDir() string {
 
 func (b *Backend) getDBDir() string {
 	return b.databaseDir
+}
+
+func (b *Backend) GetUserMailboxByName(ctx context.Context, addrID string, mailboxName []string) (imap.MailboxData, error) {
+	b.usersLock.Lock()
+	defer b.usersLock.Unlock()
+
+	user, ok := b.users[addrID]
+	if !ok {
+		return imap.MailboxData{}, ErrNoSuchUser
+	}
+
+	internalName := strings.Join(mailboxName, b.delim)
+	return user.getUserMailboxByName(ctx, mailboxName, internalName)
 }

--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -38,6 +38,9 @@ func (user *user) apply(ctx context.Context, update imap.Update) error {
 		case *imap.MailboxIDChanged:
 			return user.applyMailboxIDChanged(ctx, update)
 
+		case *imap.MailboxUpdatedOrCreated:
+			return user.applyMailboxUpdatedOrCreated(ctx, update)
+
 		case *imap.MessagesCreated:
 			return user.applyMessagesCreated(ctx, update)
 
@@ -203,6 +206,16 @@ func (user *user) applyMailboxIDChanged(ctx context.Context, update *imap.Mailbo
 
 		return []state.Update{state.NewMailboxRemoteIDUpdateStateUpdate(update.InternalID, update.RemoteID)}, nil
 	})
+}
+
+func (user *user) applyMailboxUpdatedOrCreated(ctx context.Context, update *imap.MailboxUpdatedOrCreated) error {
+	if err := user.applyMailboxCreated(ctx, imap.NewMailboxCreated(update.Mailbox)); err != nil {
+		return err
+	}
+	if err := user.applyMailboxUpdated(ctx, imap.NewMailboxUpdated(update.Mailbox.ID, update.Mailbox.Name)); err != nil {
+		return err
+	}
+	return nil
 }
 
 // applyMessagesCreated applies a MessagesCreated update.

--- a/internal/backend/user.go
+++ b/internal/backend/user.go
@@ -380,3 +380,24 @@ func (user *user) cleanupStaleStoreData(ctx context.Context) error {
 
 	return user.store.Delete(idsToDelete...)
 }
+
+func (user *user) getUserMailboxByName(ctx context.Context, bridgeName []string, mailboxName string) (imap.MailboxData, error) {
+	var mboxData imap.MailboxData
+	err := user.db.Read(ctx, func(ctx context.Context, internalDB db.ReadOnly) error {
+		mailbox, err := internalDB.GetMailboxByName(ctx, mailboxName)
+		if err != nil {
+			return err
+		}
+
+		mboxData = imap.MailboxData{
+			InternalID: mailbox.ID.String(),
+			RemoteID:   string(mailbox.RemoteID),
+			GluonName:  mailboxName,
+			BridgeName: bridgeName,
+		}
+
+		return nil
+	})
+
+	return mboxData, err
+}

--- a/server.go
+++ b/server.go
@@ -414,6 +414,10 @@ func newConnCh(l net.Listener, panicHandler async.PanicHandler) <-chan net.Conn 
 	return connCh
 }
 
+func (s *Server) GetUserMailboxByName(ctx context.Context, addrID string, mailboxName []string) (imap.MailboxData, error) {
+	return s.backend.GetUserMailboxByName(ctx, addrID, mailboxName)
+}
+
 // GetOpenSessionCount - Returns the number of currently open IMAP sessions.
 func (s *Server) GetOpenSessionCount() int {
 	s.sessionsLock.Lock()


### PR DESCRIPTION
This MR is in essence the same with #432, but rebased with `dev` changes and conflicts resolved. #432 Will be kept open until Bridge 3.20.1 rolls out, to get Bridge 3.21.0 out, we should merge this one to dev. 