### PR TITLE
fix(BRIDGE-382): properly close context if Start gets called multiple times

### DIFF
--- a/imap/connectioncounter/connectioncounter.go
+++ b/imap/connectioncounter/connectioncounter.go
@@ -91,6 +91,9 @@ func (rc *RollingCounter) run() {
 }
 
 func (rc *RollingCounter) Stop() {
+	if rc.cancel == nil {
+		return
+	}
 	rc.bucketRotationTicker.Stop()
 	rc.cancel()
 	rc.wg.Wait()

--- a/server.go
+++ b/server.go
@@ -199,6 +199,7 @@ func (s *Server) Serve(ctx context.Context, l net.Listener) error {
 	})
 
 	if s.connectionRollingCounter != nil {
+		s.connectionRollingCounter.Stop() //stop previous instance if its running
 		s.connectionRollingCounter.Start(ctx, s.observabilitySender, s)
 	}
 


### PR DESCRIPTION
If gluon `Serve` is called twice on the same server instance RollingCounter overrides the context and context cancel, and since we use a RollingCounter in Bridge this causes a deadlock which can indefinitely block. 