### PR TITLE
fix: UID SEARCH on an empty mailbox must match nothing, not answer NO

### DIFF
--- a/internal/state/snapshot_messages.go
+++ b/internal/state/snapshot_messages.go
@@ -322,6 +322,14 @@ func (list *snapMsgList) resolveSeqInterval(seqSet []command.SeqRange) ([]SeqInt
 }
 
 func (list *snapMsgList) resolveUIDInterval(seqSet []command.SeqRange) ([]UIDInterval, error) {
+	// An empty mailbox contains no UIDs, so any UID set matches nothing.
+	// Resolving against the empty snapshot would report ErrNoSuchMessage
+	// instead, turning e.g. a UID SEARCH on an empty mailbox into a NO reply;
+	// RFC 3501 requires non-existent UIDs to be ignored without error.
+	if list.len() == 0 {
+		return nil, nil
+	}
+
 	res := make([]UIDInterval, 0, len(seqSet))
 
 	for _, uidRange := range seqSet {

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -564,6 +564,28 @@ func TestSearchUID(t *testing.T) {
 	})
 }
 
+func TestSearchUIDEmptyMailbox(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		c.C(`A001 select inbox`).OK("A001")
+
+		// RFC 3501 section 6.4.8: "A non-existent unique identifier is
+		// ignored without any error message generated." In an empty mailbox
+		// every UID is non-existent, so a UID key matches nothing; it must
+		// not turn the SEARCH into a NO reply.
+		c.C(`A002 uid search uid 1`)
+		c.S("* SEARCH")
+		c.OK("A002")
+
+		c.C(`A003 search uid 1,3:5`)
+		c.S("* SEARCH")
+		c.OK("A003")
+
+		c.C(`A004 uid search uid 1:*`)
+		c.S("* SEARCH")
+		c.OK("A004")
+	})
+}
+
 func TestSearchUIDAfterDelete(t *testing.T) {
 	runOneToOneTestWithData(t, defaultServerOptions(t), func(c *testConnection, s *testSession, mbox string, mboxID imap.MailboxID) {
 		// Remove some messages to ensure sequence doesn't match uid


### PR DESCRIPTION
## Problem

A SEARCH whose criteria reference UIDs answers `NO no such message` when the selected mailbox is empty:

```
A001 select inbox        (empty mailbox)
A001 OK [READ-WRITE]
A002 uid search uid 1
A002 NO no such message
```

RFC 3501 §6.4.8 requires the opposite:

> A non-existent unique identifier is ignored without any error message generated.

In an empty mailbox every UID is non-existent, so a `UID <sequence set>` search key matches nothing — the correct answer is an empty untagged `* SEARCH` plus tagged `OK`. Gluon already behaves this way for non-existent UIDs in a **non-empty** mailbox (they resolve and simply match nothing), so the empty-mailbox `NO` is also internally inconsistent.

## Root cause

`buildSearchOpUID` calls `snap.resolveUIDInterval`, whose `resolveUID` errors with `ErrNoSuchMessage` whenever the snapshot holds zero messages. The equivalent FETCH/STORE/COPY range path got an empty-mailbox guard back in b04fb94 (GODT-2218) — "If there are no messages in the mailbox, we still resolve without error" — but the SEARCH path calls `resolveUIDInterval` directly and was missed.

## Impact

Any client that verifies its own mutations trips over this precisely when the mutation fully succeeds: after a MOVE that drains a mailbox, a verification `UID SEARCH UID <moved set>` against the now-empty source fails, reading as "move not applied" when the empty mailbox is exactly the expected outcome. Observed in practice through Proton Mail Bridge 3.25.0.

## Fix

`resolveUIDInterval` returns no intervals for an empty snapshot (mirroring the GODT-2218 guard), so UID search keys match nothing instead of erroring. This also covers `UID SEARCH UID 1:*` on an empty mailbox. Sequence-number resolution is unchanged.

Added `TestSearchUIDEmptyMailbox` covering `uid search uid 1`, `search uid 1,3:5`, and `uid search uid 1:*` against an empty INBOX; it fails with `NO no such message` before the fix. `go test ./tests ./internal/state` passes.