### PR TITLE
fix(BRIDGE-610): structurally compare literals if byte-for-byte comparison fails

### DIFF
--- a/internal/backend/connector_updates.go
+++ b/internal/backend/connector_updates.go
@@ -711,12 +711,79 @@ func (user *user) applyMessageUpdated(ctx context.Context, update *imap.MessageU
 			log.Debug("Failed to get header value from literal, using update literal")
 		}
 
+		// We first check for a byte for byte match to avoid expensive structural comparison.
+		// If the literals are different, we then check for a structural match.
+		// If the literals are structurally equivalent - including headers, we treat it as unchanged and avoid churning the internal ID/UID.
+		// If the literals are not structurally equivalent, we treat it as a new literal and apply the update.
+		unchanged := bytes.Equal(onDiskLiteral, updateLiteral)
+		if !unchanged && len(onDiskLiteral) > 0 {
+			if eq, err := rfc822.CompareLiterals(onDiskLiteral, updateLiteral); err != nil {
+				log.WithError(err).Debug("Failed to compare literals, treating as new literal")
+			} else if eq {
+				unchanged = true
+			}
+		}
+
+		if unchanged {
+			log.Debug("Message literal has no meaningful changes, assigning mailboxes only")
+
+			return user.applyMessageMailboxesOnlyUpdate(ctx, tx, internalMessageID, update)
+		}
+
 		var stateUpdates []state.Update
 
-		if bytes.Equal(onDiskLiteral, updateLiteral) {
-			log.Debug("Message not updated as there are no changes to literals, assigning mailboxes only")
+		log.Debug("Message has new literal, applying update")
 
-			targetMailboxes := make([]imap.InternalMailboxID, 0, len(update.MailboxIDs))
+		{
+			// delete the message and remove from the mailboxes.
+			mailboxes, err := tx.GetMessageMailboxIDs(ctx, internalMessageID)
+			if err != nil {
+				return nil, err
+			}
+
+			messageIDs := []imap.InternalMessageID{internalMessageID}
+
+			for _, mailbox := range mailboxes {
+				updates, err := state.RemoveMessagesFromMailbox(ctx, tx, mailbox, messageIDs)
+				if err != nil {
+					return nil, err
+				}
+
+				stateUpdates = append(stateUpdates, updates...)
+			}
+
+			// We need change the old remote id as it will break our table constraint otherwise and everything
+			// will silently fail.
+			if err := tx.MarkMessageAsDeletedAndAssignRandomRemoteID(ctx, internalMessageID); err != nil {
+				return nil, err
+			}
+		}
+
+		// create new entry
+		{
+			newInternalID := imap.NewInternalMessageID()
+
+			literalReader, literalSize, err := rfc822.SetHeaderValueNoMemCopy(update.Literal, ids.InternalIDKey, newInternalID.String())
+			if err != nil {
+				return nil, fmt.Errorf("failed to set internal ID: %w", err)
+			}
+
+			request := &db.CreateMessageReq{
+				Message:     update.Message,
+				LiteralSize: literalSize,
+				Body:        update.ParsedMessage.Body,
+				Structure:   update.ParsedMessage.Structure,
+				Envelope:    update.ParsedMessage.Envelope,
+				InternalID:  newInternalID,
+			}
+
+			if err := tx.CreateMessages(ctx, request); err != nil {
+				return nil, err
+			}
+
+			if err := user.store.Set(newInternalID, literalReader); err != nil {
+				return nil, err
+			}
 
 			for _, mbox := range update.MailboxIDs {
 				internalMBoxID, err := tx.GetMailboxIDFromRemoteID(ctx, mbox)
@@ -730,109 +797,60 @@ func (user *user) applyMessageUpdated(ctx context.Context, update *imap.MessageU
 					return nil, err
 				}
 
-				targetMailboxes = append(targetMailboxes, internalMBoxID)
-			}
-
-			flagUpdates, err := user.setMessageFlags(ctx, tx, internalMessageID, update.Message.Flags)
-			if err != nil {
-				return nil, err
-			}
-
-			stateUpdates = append(stateUpdates, flagUpdates...)
-
-			mboxUpdates, err := user.setMessageMailboxes(ctx, tx, db.MessageIDPair{
-				InternalID: internalMessageID,
-				RemoteID:   update.Message.ID,
-			}, targetMailboxes)
-			if err != nil {
-				return nil, err
-			}
-
-			return append(stateUpdates, mboxUpdates...), nil
-		} else {
-			log.Debug("Message has new literal, applying update")
-
-			{
-				// delete the message and remove from the mailboxes.
-				mailboxes, err := tx.GetMessageMailboxIDs(ctx, internalMessageID)
+				_, update, err := state.AddMessagesToMailbox(
+					ctx,
+					tx,
+					internalMBoxID,
+					[]db.MessageIDPair{{InternalID: newInternalID, RemoteID: update.Message.ID}},
+					nil,
+					user.imapLimits,
+				)
 				if err != nil {
 					return nil, err
 				}
 
-				messageIDs := []imap.InternalMessageID{internalMessageID}
-
-				for _, mailbox := range mailboxes {
-					updates, err := state.RemoveMessagesFromMailbox(ctx, tx, mailbox, messageIDs)
-					if err != nil {
-						return nil, err
-					}
-
-					stateUpdates = append(stateUpdates, updates...)
-				}
-
-				// We need change the old remote id as it will break our table constraint otherwise and everything
-				// will silently fail.
-				if err := tx.MarkMessageAsDeletedAndAssignRandomRemoteID(ctx, internalMessageID); err != nil {
-					return nil, err
-				}
-			}
-			// create new entry
-			{
-				newInternalID := imap.NewInternalMessageID()
-
-				literalReader, literalSize, err := rfc822.SetHeaderValueNoMemCopy(update.Literal, ids.InternalIDKey, newInternalID.String())
-				if err != nil {
-					return nil, fmt.Errorf("failed to set internal ID: %w", err)
-				}
-
-				request := &db.CreateMessageReq{
-					Message:     update.Message,
-					LiteralSize: literalSize,
-					Body:        update.ParsedMessage.Body,
-					Structure:   update.ParsedMessage.Structure,
-					Envelope:    update.ParsedMessage.Envelope,
-					InternalID:  newInternalID,
-				}
-
-				if err := tx.CreateMessages(ctx, request); err != nil {
-					return nil, err
-				}
-
-				if err := user.store.Set(newInternalID, literalReader); err != nil {
-					return nil, err
-				}
-
-				for _, mbox := range update.MailboxIDs {
-					internalMBoxID, err := tx.GetMailboxIDFromRemoteID(ctx, mbox)
-					if err != nil {
-						if update.IgnoreUnknownMailboxIDs {
-							user.log.WithField("MailboxID", mbox.ShortID()).
-								WithField("MessageID", update.Message.ID.ShortID()).
-								Warn("Unknown Mailbox ID during message update, skipping add to mailbox")
-							continue
-						}
-						return nil, err
-					}
-
-					_, update, err := state.AddMessagesToMailbox(
-						ctx,
-						tx,
-						internalMBoxID,
-						[]db.MessageIDPair{{InternalID: newInternalID, RemoteID: update.Message.ID}},
-						nil,
-						user.imapLimits,
-					)
-					if err != nil {
-						return nil, err
-					}
-
-					stateUpdates = append(stateUpdates, update)
-				}
+				stateUpdates = append(stateUpdates, update)
 			}
 		}
 
 		return stateUpdates, nil
 	})
+}
+
+// applyMessageMailboxesOnlyUpdate applies flag and mailbox membership changes for an updated message
+// The literal passed in is assumed to be structurally equivalent to the on-disk literal.
+func (user *user) applyMessageMailboxesOnlyUpdate(ctx context.Context, tx db.Transaction, internalMessageID imap.InternalMessageID, update *imap.MessageUpdated) ([]state.Update, error) {
+	targetMailboxes := make([]imap.InternalMailboxID, 0, len(update.MailboxIDs))
+
+	for _, mbox := range update.MailboxIDs {
+		internalMBoxID, err := tx.GetMailboxIDFromRemoteID(ctx, mbox)
+		if err != nil {
+			if update.IgnoreUnknownMailboxIDs {
+				user.log.WithField("MailboxID", mbox.ShortID()).
+					WithField("MessageID", update.Message.ID.ShortID()).
+					Warn("Unknown Mailbox ID during message update, skipping add to mailbox")
+				continue
+			}
+			return nil, err
+		}
+
+		targetMailboxes = append(targetMailboxes, internalMBoxID)
+	}
+
+	flagUpdates, err := user.setMessageFlags(ctx, tx, internalMessageID, update.Message.Flags)
+	if err != nil {
+		return nil, err
+	}
+
+	mboxUpdates, err := user.setMessageMailboxes(ctx, tx, db.MessageIDPair{
+		InternalID: internalMessageID,
+		RemoteID:   update.Message.ID,
+	}, targetMailboxes)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(flagUpdates, mboxUpdates...), nil
 }
 
 // applyUIDValidityBumped applies a UIDValidityBumped event to the user.

--- a/rfc822/hash.go
+++ b/rfc822/hash.go
@@ -7,12 +7,16 @@ import (
 	"io"
 	"mime/quotedprintable"
 	"slices"
+	"strconv"
 	"strings"
 
 	pkgutils "github.com/ProtonMail/gluon/pkg/utils"
 	"github.com/ProtonMail/gluon/rfc5322"
 	"github.com/sirupsen/logrus"
 )
+
+// gluonInternalHeaderKey mirrors internal/ids.InternalIDKey.
+const gluonInternalHeaderKey = "X-Pm-Gluon-Id"
 
 // GetMessageHash returns the hash of the given message.
 // This takes into account:
@@ -72,27 +76,8 @@ func GetMessageHash(b []byte) (string, error) {
 		mimeType, values, err := ParseMIMEType(contentType)
 		if err != nil {
 			logrus.Warnf("Message contains invalid mime type: %v", contentType)
-		} else {
-			if _, err := h.Write([]byte(mimeType)); err != nil {
-				return err
-			}
-
-			keys := pkgutils.Keys(values)
-			slices.Sort(keys)
-
-			for _, k := range keys {
-				if strings.EqualFold(k, "boundary") {
-					continue
-				}
-
-				if _, err := h.Write([]byte(k)); err != nil {
-					return err
-				}
-
-				if _, err := h.Write([]byte(values[k])); err != nil {
-					return err
-				}
-			}
+		} else if err := writeContentTypeParams(h, mimeType, values); err != nil {
+			return err
 		}
 
 		if _, err := h.Write([]byte(header.Get("Content-Disposition"))); err != nil {
@@ -110,6 +95,183 @@ func GetMessageHash(b []byte) (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+// LiteralsStructurallyEqual returns whether two messages literals are structurally equivalent.
+// It's based on `GetMessageHash` which skips the Content-Type boundary parameter.
+func LiteralsStructurallyEqual(a, b []byte) (bool, error) {
+	ha, err := GetMessageHash(a)
+	if err != nil {
+		return false, err
+	}
+
+	hb, err := GetMessageHash(b)
+	if err != nil {
+		return false, err
+	}
+
+	return ha == hb, nil
+}
+
+// writeContentTypeParams writes the MIME type and its parameters (excluding the boundary parameter) to the writer.
+// It is shared by the content hash and the header fingerprint so both ignore MIME boundary drift identically.
+func writeContentTypeParams(w io.Writer, mimeType MIMEType, values map[string]string) error {
+	if _, err := io.WriteString(w, string(mimeType)); err != nil {
+		return err
+	}
+
+	keys := pkgutils.Keys(values)
+	slices.Sort(keys)
+
+	for _, k := range keys {
+		if strings.EqualFold(k, "boundary") {
+			continue
+		}
+
+		if _, err := io.WriteString(w, k); err != nil {
+			return err
+		}
+
+		if _, err := io.WriteString(w, values[k]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetMessageHeaderFingerprint returns a hash of the message's headers across the entire
+// MIME tree. Unlike GetMessageHash, this captures every header - including Date, Message-Id and
+// X-Pm-*.
+//
+// It is boundary-neutral: the Content-Type boundary parameter is excluded so pure MIME
+// boundary drift does not change the fingerprint. The Gluon-internal X-Pm-Gluon-Id
+// header is skipped because it is injected by the mailserver. Known address headers are
+// normalized the same way as the content hash so display/folding differences do not
+// cause false mismatches. Header ordering is ignored and bodies are not included.
+//
+// Note: Content-Transfer-Encoding is included per part, so a CTE-only rebuild (same
+// decoded body, different encoding) will differ here even though GetMessageHash ignores
+// it. This is intentional for wire-metadata comparison.
+func GetMessageHeaderFingerprint(b []byte) (string, error) {
+	section := Parse(b)
+
+	h := sha256.New()
+
+	if err := section.Walk(func(section *Section) error {
+		header, err := section.ParseHeader()
+		if err != nil {
+			return err
+		}
+
+		// Section separator + MIME path so identical headers on different parts do not merge.
+		if _, err := io.WriteString(h, "\x01"+sectionPath(section)+"\x02"); err != nil {
+			return err
+		}
+
+		var entries []string
+
+		header.Entries(func(key, val string) {
+			if strings.EqualFold(key, gluonInternalHeaderKey) {
+				return
+			}
+
+			entries = append(entries, canonicalHeaderEntry(key, val))
+		})
+
+		// Sort so header ordering does not affect the fingerprint.
+		slices.Sort(entries)
+
+		for _, e := range entries {
+			if _, err := io.WriteString(h, e); err != nil {
+				return err
+			}
+
+			if _, err := h.Write([]byte{0}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+// canonicalHeaderEntry renders a single header entry into a deterministic, comparable
+// form: Content-Type has its boundary parameter stripped, address headers are normalized
+// to their addresses only, and all other headers keep their merged value verbatim.
+func canonicalHeaderEntry(key, val string) string {
+	lkey := strings.ToLower(key)
+
+	switch lkey {
+	case "content-type":
+		if mimeType, values, err := ParseMIMEType(val); err == nil {
+			var sb strings.Builder
+
+			sb.WriteString(lkey)
+			sb.WriteByte(':')
+
+			// writeContentTypeParams only errors on writer failure; strings.Builder never fails.
+			_ = writeContentTypeParams(&sb, mimeType, values)
+
+			return sb.String()
+		}
+
+		return lkey + ":" + val
+
+	case "from", "to", "cc", "reply-to", "in-reply-to":
+		return lkey + ":" + getAddresses(val)
+
+	default:
+		return lkey + ":" + val
+	}
+}
+
+// sectionPath returns the dotted MIME path of a section; the root section
+// has an empty identifier and returns "".
+func sectionPath(section *Section) string {
+	identifier := section.Identifier()
+
+	parts := make([]string, len(identifier))
+	for i, id := range identifier {
+		parts[i] = strconv.Itoa(id)
+	}
+
+	return strings.Join(parts, ".")
+}
+
+// LiteralsHeadersEqual reports whether two message literals have equivalent headers
+// across the MIME tree, ignoring MIME boundary drift and the Gluon-internal header.
+// See GetMessageHeaderFingerprint.
+func LiteralsHeadersEqual(a, b []byte) (bool, error) {
+	fa, err := GetMessageHeaderFingerprint(a)
+	if err != nil {
+		return false, err
+	}
+
+	fb, err := GetMessageHeaderFingerprint(b)
+	if err != nil {
+		return false, err
+	}
+
+	return fa == fb, nil
+}
+
+// CompareLiterals compares two message literals and returns true if they are structurally and header-wise equivalent.
+func CompareLiterals(a, b []byte) (bool, error) {
+	structEq, err := LiteralsStructurallyEqual(a, b)
+	if err != nil {
+		return false, err
+	}
+
+	if !structEq {
+		return false, nil
+	}
+
+	return LiteralsHeadersEqual(a, b)
 }
 
 func hashBody(writer io.Writer, body []byte, mimeType MIMEType, encoding string) error {

--- a/rfc822/hash_test.go
+++ b/rfc822/hash_test.go
@@ -1,6 +1,7 @@
 package rfc822
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
@@ -21,4 +22,131 @@ func TestGetMessageHashSameBodyDifferentTextEncodings(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, h1, h2)
+}
+
+func TestLiteralsStructurallyEquivalentBoundaryDrift(t *testing.T) {
+	// multipart/mixed > multipart/related(text/plain + inline image) + attachment
+	litA := buildStructuralTestLiteral("outerA", "innerA", "attachment")
+	litB := buildStructuralTestLiteral("outerB", "innerB", "attachment")
+
+	require.False(t, bytes.Equal(litA, litB), "raw literals should differ due to boundary tokens")
+
+	eq, err := LiteralsStructurallyEqual(litA, litB)
+	require.NoError(t, err)
+	require.True(t, eq, "boundary-only drift should be structurally equivalent")
+
+	// Both literals must expose the same MIME tree regardless of boundary values.
+	for _, lit := range [][]byte{litA, litB} {
+		expectPart(t, lit, MultipartRelated, "", 1)
+		expectPart(t, lit, TextPlain, "body", 1, 1)
+		expectPart(t, lit, "image/png", "inline", 1, 2)
+		expectPart(t, lit, "image/png", "attachment", 2)
+	}
+
+	// A real content change (different attachment body) must not be equivalent.
+	litC := buildStructuralTestLiteral("outerA", "innerA", "different-attachment")
+
+	eq, err = LiteralsStructurallyEqual(litA, litC)
+	require.NoError(t, err)
+	require.False(t, eq, "different leaf body should not be structurally equivalent")
+}
+
+func TestLiteralsHeadersEqualBoundaryDrift(t *testing.T) {
+	litA := buildStructuralTestLiteral("outerA", "innerA", "attachment")
+	litB := buildStructuralTestLiteral("outerB", "innerB", "attachment")
+
+	require.False(t, bytes.Equal(litA, litB))
+
+	eq, err := LiteralsHeadersEqual(litA, litB)
+	require.NoError(t, err)
+	require.True(t, eq, "boundary-only drift should keep the same header fingerprint")
+}
+
+func TestLiteralsHeadersEqualHeaderEnrichment(t *testing.T) {
+	litA := buildStructuralTestLiteral("outerA", "innerA", "attachment")
+	// Header order is irrelevant to the fingerprint, so prepending is fine.
+	litEnriched := append([]byte("Message-Id: <id@pm.me>\r\nX-Pm-Internal-Id: abc123\r\n"), litA...)
+
+	structEq, err := LiteralsStructurallyEqual(litA, litEnriched)
+	require.NoError(t, err)
+	require.True(t, structEq, "content is unchanged, so structure must match")
+
+	headersEq, err := LiteralsHeadersEqual(litA, litEnriched)
+	require.NoError(t, err)
+	require.False(t, headersEq, "added Message-Id / X-Pm-* headers must change the fingerprint")
+
+	cosmeticEq, err := CompareLiterals(litA, litEnriched)
+	require.NoError(t, err)
+	require.False(t, cosmeticEq, "header enrichment must not be treated as cosmetically equal")
+}
+
+func TestLiteralsHeadersEqualIgnoresGluonID(t *testing.T) {
+	litA := buildStructuralTestLiteral("outerA", "innerA", "attachment")
+
+	withGluonID, err := SetHeaderValue(litA, gluonInternalHeaderKey, "some-internal-id")
+	require.NoError(t, err)
+
+	require.False(t, bytes.Equal(litA, withGluonID))
+
+	eq, err := LiteralsHeadersEqual(litA, withGluonID)
+	require.NoError(t, err)
+	require.True(t, eq, "X-Pm-Gluon-Id must be ignored by the header fingerprint")
+}
+
+func TestCompareLiterals(t *testing.T) {
+	litA := buildStructuralTestLiteral("outerA", "innerA", "attachment")
+	litB := buildStructuralTestLiteral("outerB", "innerB", "attachment")
+	litC := buildStructuralTestLiteral("outerA", "innerA", "different-attachment")
+
+	eq, err := CompareLiterals(litA, litB)
+	require.NoError(t, err)
+	require.True(t, eq, "boundary-only drift is cosmetically equal")
+
+	eq, err = CompareLiterals(litA, litC)
+	require.NoError(t, err)
+	require.False(t, eq, "different content is not cosmetically equal")
+}
+
+func buildStructuralTestLiteral(outerBoundary, innerBoundary, attachmentBody string) []byte {
+	return []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Subject: structural test\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart/mixed; boundary=\"" + outerBoundary + "\"\r\n" +
+		"\r\n" +
+		"--" + outerBoundary + "\r\n" +
+		"Content-Type: multipart/related; boundary=\"" + innerBoundary + "\"\r\n" +
+		"\r\n" +
+		"--" + innerBoundary + "\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"body\r\n" +
+		"--" + innerBoundary + "\r\n" +
+		"Content-Type: image/png\r\n" +
+		"Content-Disposition: inline\r\n" +
+		"\r\n" +
+		"inline\r\n" +
+		"--" + innerBoundary + "--\r\n" +
+		"--" + outerBoundary + "\r\n" +
+		"Content-Type: image/png\r\n" +
+		"Content-Disposition: attachment\r\n" +
+		"\r\n" +
+		attachmentBody + "\r\n" +
+		"--" + outerBoundary + "--\r\n")
+}
+
+// expectPart asserts the Content-Type (and, for leaf parts, the trimmed body) of the MIME part at the given 1-based path.
+func expectPart(t *testing.T, literal []byte, wantType MIMEType, wantBody string, path ...int) {
+	t.Helper()
+
+	part, err := Parse(literal).Part(path...)
+	require.NoError(t, err, "part %v should exist", path)
+
+	mimeType, _, err := part.ContentType()
+	require.NoError(t, err)
+	require.Equal(t, wantType, mimeType, "content type of part %v", path)
+
+	if wantBody != "" {
+		require.Equal(t, wantBody, string(bytes.TrimSpace(part.Body())), "body of part %v", path)
+	}
 }

--- a/tests/message_update_structural_test.go
+++ b/tests/message_update_structural_test.go
@@ -1,0 +1,158 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func buildStructuralTestLiteral(outerBoundary, innerBoundary, attachmentBody string) []byte {
+	return []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Subject: structural test\r\n" +
+		"Date: " + DefaultTestDateStr + "\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart/mixed; boundary=\"" + outerBoundary + "\"\r\n" +
+		"\r\n" +
+		"--" + outerBoundary + "\r\n" +
+		"Content-Type: multipart/related; boundary=\"" + innerBoundary + "\"\r\n" +
+		"\r\n" +
+		"--" + innerBoundary + "\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"body\r\n" +
+		"--" + innerBoundary + "\r\n" +
+		"Content-Type: image/png\r\n" +
+		"Content-Disposition: inline\r\n" +
+		"\r\n" +
+		"inline\r\n" +
+		"--" + innerBoundary + "--\r\n" +
+		"--" + outerBoundary + "\r\n" +
+		"Content-Type: image/png\r\n" +
+		"Content-Disposition: attachment\r\n" +
+		"\r\n" +
+		attachmentBody + "\r\n" +
+		"--" + outerBoundary + "--\r\n")
+}
+
+// TestRemoteMessageUpdateStructurallyEquivalentKeepsMessage verifies that an update whose literal differs only in
+// MIME boundary tokens is treated as unchanged.
+// No new UID is assigned so UIDNEXT does not advance.
+func TestRemoteMessageUpdateStructurallyEquivalentKeepsMessage(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		messageID := s.messageCreated("user", mailboxID, buildStructuralTestLiteral("outerA", "innerA", "attachment"), time.Now())
+		s.flush("user")
+
+		c.C(`A001 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 2 MESSAGES 1)`)
+		c.OK(`A001`)
+
+		// Same structure and content, only the boundary tokens differ.
+		s.messageUpdatedWithID("user", messageID, mailboxID, buildStructuralTestLiteral("outerB", "innerB", "attachment"), time.Now())
+		s.flush("user")
+
+		// No new UID: the message stays in place (UIDNEXT unchanged, still 1 message).
+		c.C(`A002 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 2 MESSAGES 1)`)
+		c.OK(`A002`)
+
+		// The original message (UID 1) is still present and fetchable.
+		c.C(`A003 SELECT mbox1`).OK(`A003`)
+		c.C(`A004 FETCH 1 (UID)`)
+		c.Sx(`\* 1 FETCH \(UID 1[ )]`)
+		c.OK(`A004`)
+	})
+}
+
+// TestRemoteMessageUpdateStructurallyDifferentAppliesNewLiteral verifies that a
+// real content change still takes the new-literal path.
+// A new UID is assigned so UIDNEXT advances.
+func TestRemoteMessageUpdateStructurallyDifferentAppliesNewLiteral(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		messageID := s.messageCreated("user", mailboxID, buildStructuralTestLiteral("outerA", "innerA", "attachment"), time.Now())
+		s.flush("user")
+
+		c.C(`A001 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 2 MESSAGES 1)`)
+		c.OK(`A001`)
+
+		// Real content change: the attachment body differs.
+		s.messageUpdatedWithID("user", messageID, mailboxID, buildStructuralTestLiteral("outerA", "innerA", "different-attachment"), time.Now())
+		s.flush("user")
+
+		// A new UID was assigned (UIDNEXT advanced) while the message count stays 1.
+		c.C(`A002 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 3 MESSAGES 1)`)
+		c.OK(`A002`)
+
+		c.C(`A003 SELECT mbox1`).OK(`A003`)
+		c.C(`A004 FETCH 1 (UID)`)
+		c.Sx(`\* 1 FETCH \(UID 2[ )]`)
+		c.OK(`A004`)
+	})
+}
+
+// TestRemoteMessageUpdateHeaderEnrichmentAppliesNewLiteral verifies that an update whose content is unchanged but
+// whose headers were updated takes the new-literal path so clients
+// see the updated headers. A new UID is assigned so UIDNEXT advances.
+func TestRemoteMessageUpdateHeaderEnrichmentAppliesNewLiteral(t *testing.T) {
+	runOneToOneTestWithAuth(t, defaultServerOptions(t), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		base := buildStructuralTestLiteral("outerA", "innerA", "attachment")
+		messageID := s.messageCreated("user", mailboxID, base, time.Now())
+		s.flush("user")
+
+		c.C(`A001 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 2 MESSAGES 1)`)
+		c.OK(`A001`)
+
+		// Same content and boundaries, but the API added Message-Id / X-Pm-* headers.
+		enriched := append([]byte("Message-Id: <id@pm.me>\r\nX-Pm-Internal-Id: abc123\r\n"), base...)
+		s.messageUpdatedWithID("user", messageID, mailboxID, enriched, time.Now())
+		s.flush("user")
+
+		// The added headers are a real change: a new UID was assigned (UIDNEXT advanced).
+		c.C(`A002 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 3 MESSAGES 1)`)
+		c.OK(`A002`)
+
+		// The updated message (UID 2) exposes the newly added Message-Id.
+		c.C(`A003 SELECT mbox1`).OK(`A003`)
+		c.C(`A004 FETCH 1 (UID BODY.PEEK[HEADER.FIELDS (Message-Id)])`)
+		c.Sx(`\* 1 FETCH \(UID 2 BODY\[HEADER.FIELDS \(MESSAGE-ID\)\] \{.*`)
+		c.OK(`A004`)
+	})
+}
+
+// TestRemoteMessageUpdateStructurallyEquivalentWithMissingLiteral verifies that when the on-disk literal is missing,
+// even a structurally-equivalent update falls back to the new-literal path rather than the mailboxes-only path.
+// A new UID is assigned so UIDNEXT advances.
+func TestRemoteMessageUpdateStructurallyEquivalentWithMissingLiteral(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "test_store")
+
+	runOneToOneTestWithAuth(t, defaultServerOptions(t, withDataDir(dataDir)), func(c *testConnection, s *testSession) {
+		mailboxID := s.mailboxCreated("user", []string{"mbox1"})
+		messageID := s.messageCreated("user", mailboxID, buildStructuralTestLiteral("outerA", "innerA", "attachment"), time.Now())
+		s.flush("user")
+
+		c.C(`A001 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 2 MESSAGES 1)`)
+		c.OK(`A001`)
+
+		// Remove the on-disk literals so the structural comparison has nothing to compare against.
+		require.NoError(t, os.RemoveAll(dataDir))
+
+		// Boundary-only drift, but the literal is missing: must take the new-literal path.
+		s.messageUpdatedWithID("user", messageID, mailboxID, buildStructuralTestLiteral("outerB", "innerB", "attachment"), time.Now())
+		s.flush("user")
+
+		c.C(`A002 STATUS mbox1 (UIDNEXT MESSAGES)`)
+		c.S(`* STATUS "mbox1" (UIDNEXT 3 MESSAGES 1)`)
+		c.OK(`A002`)
+	})
+}


### PR DESCRIPTION
Add a structural equivalence check before deciding on whether to update or create a new literal. 